### PR TITLE
Clean memory in function `Reset_SOILWAT2_after_UnitTest`

### DIFF
--- a/test/sw_testhelpers.cc
+++ b/test/sw_testhelpers.cc
@@ -41,6 +41,8 @@ extern char _firstfile[];
 /** Initialize SOILWAT2 variables and read values from example input file
  */
 void Reset_SOILWAT2_after_UnitTest(void) {
+  SW_CTL_clear_model(swFALSE);
+
   SW_CTL_init_model(_firstfile);
   SW_CTL_obtain_inputs();
 


### PR DESCRIPTION
- addressing issue #205, but not completely resolving it

- added call to `SW_CTL_clear_model` before re-initializing SOILWAT2
- this is similar behavior to updated functions `start` of `rSOILWAT2` and `SXW_Reset` of `STEPWAT2`