### PR TITLE
Better compilation and use in rSOILWAT2

### DIFF
--- a/.LSAN_suppr.txt
+++ b/.LSAN_suppr.txt
@@ -1,0 +1,7 @@
+# Suppression of memory leaks
+# https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer#suppressions
+
+# These are known leaks that await fixing
+
+# https://github.com/DrylandEcology/SOILWAT2/issues/205
+leak:SW_VPD_construct

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,21 @@
 language: cpp
 
+# We want to run the `*_severe` debug and test targets; thus, we need
+# g++ >= 4.9 and clang++ >= 3.5
 compiler:
   - clang
   - gcc
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-4.9
+      - g++-4.9
+
+before_install:
+  - if [[ $CXX = g++ ]]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
 
 script:
   # compile and run optimized binary

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,17 @@
 language: cpp
 
 # We want to run the `*_severe` debug and test targets; thus, we need
+# to enable ptrace capability for (L/A)SAN which is currently not possible
+# with container-based builds on travis-ci
+# TODO: revert to `sudo: false` once the following are fixed/made possible
+# - https://github.com/google/sanitizers/issues/764
+# - https://github.com/travis-ci/travis-ci/issues/9033
+sudo: required
+
+matrix:
+  fast_finish: true
+
+# We want to run the `*_severe` debug and test targets; thus, we need
 # g++ >= 4.9 and clang++ >= 3.5
 compiler:
   - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
   # compile and run debug binary
   - make clean bin_debug_severe bint_run
   # compile and run (severe) unit tests
-  - make clean test_severe test_run
+  - ASAN_OPTIONS=detect_leaks=1 LSAN_OPTIONS=suppressions=.LSAN_suppr.txt make clean test_severe test_run
   # determine code coverage of unit tests
   - make clean cov test_run
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,16 @@ compiler:
   - gcc
 
 script:
-  - export CPPFLAGS=-DSWDEBUG && make cleaner bint_run
-  - make cleaner cov test_run
+  # compile and run optimized binary
+  - make clean bin bint_run
+  # compile and run debug binary
+  - make clean bin_debug_severe bint_run
+  # compile and run (severe) unit tests
+  - make clean test_severe test_run
+  # determine code coverage of unit tests
+  - make clean cov test_run
 
 after_success:
   - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
-  - make cleaner
+  # clean up
+  - make clean

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ You can help us in different ways:
 
 __Compilation__:
   * Requirements:
-    - a recent version of the `gcc` or `clang/llvm` toolchains
+    - the `gcc` or `clang/llvm` toolchains
+      - `gcc >= v4.9` and `clang >= v3.3` for the `*_severe` test/debug targets
     - POSIX- or GNU-compliant `make`
     - On Windows OS: an installation of `cygwin`
   * Build with `make` (see `make help` to print information about all
@@ -89,7 +90,12 @@ __Tests, documentation, and code__ form a trinity
     make clean                 # cleans build artifacts
     ```
   * Development/feature branches can only be merged into master if they pass
-    all checks
+    all checks on `appveyor` and `travis` continuous integration servers, i.e.,
+    run the following locally to prepare a pull-request or commit to be reviewed
+    ```
+    make clean bin_debug_severe bint_run
+    make clean test_severe test_run
+    ```
   * Informal and local integration tests example:
     1. Before coding, run `testing/` and produce reference output
         ```

--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ __Tests, documentation, and code__ form a trinity
     make clean bin_debug_severe bint_run
     make clean test_severe test_run
     ```
+  * Note that you may want/need to exclude known memory leaks from severe
+    testing (see https://github.com/DrylandEcology/SOILWAT2/issues/205):
+    ```
+    ASAN_OPTIONS=detect_leaks=1 LSAN_OPTIONS=suppressions=.LSAN_suppr.txt make clean test_severe test_run
+    ```
   * Informal and local integration tests example:
     1. Before coding, run `testing/` and produce reference output
         ```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ You can help us in different ways:
    [pull request](https://github.com/DrylandEcology/SOILWAT2/pulls)
 
 
+__Compilation__:
+  * Requirements:
+    - a recent version of the `gcc` or `clang/llvm` toolchains
+    - POSIX- or GNU-compliant `make`
+    - On Windows OS: an installation of `cygwin`
+  * Build with `make` (see `make help` to print information about all
+    available targets)
+
+
 __SOILWAT2 code is used as part of three applications__:
   * stand-alone (code flag `SOILWAT` is defined if neither `STEPWAT` nor
     `RSOILWAT` exist),
@@ -75,9 +84,9 @@ __Tests, documentation, and code__ form a trinity
   * Note: `SOILWAT2` is written in C whereas `GoogleTest` is a C++ framework.
   * Run unit tests locally on the command-line with
     ```
-    make test     # compiles the unit-test binary/executable (with `-DSWDEBUG`)
-    make test_run # executes the unit-test binary
-    make cleaner
+    make test test_run         # compiles and executes the unit-tests
+    make test_severe test_run  # compiles/executes with strict/severe flags
+    make clean                 # cleans build artifacts
     ```
   * Development/feature branches can only be merged into master if they pass
     all checks
@@ -85,7 +94,7 @@ __Tests, documentation, and code__ form a trinity
     1. Before coding, run `testing/` and produce reference output
         ```
         git checkout master
-        make cleaner bint_run
+        make bin bint_run
         cp -r testing/Output testing/Output_ref
         ```
     2. Develop your code and keep "testing/Output_ref" locally, i.e., don't
@@ -93,7 +102,7 @@ __Tests, documentation, and code__ form a trinity
     3. Regularly, e.g., before finalizing a commit, check that new code produces
     identical output (that is unless you work on output...)
         ```
-        make cleaner bint_run
+        make bin bint_run
         diff testing/Output/ testing/Output_ref/ -qs
         ```
 
@@ -116,19 +125,21 @@ __Tests, documentation, and code__ form a trinity
       ...
     }
     ```
-  * Clean, compile and run SOILWAT2-standalone in debugging mode with, e.g.,
+  * Clean, compile and run optimized SOILWAT2-standalone in debugging mode
+    with, e.g.,
     ```
-    make cleaner bint_run CPPFLAGS=-DSWDEBUG
+    make bin bint_run CPPFLAGS=-DSWDEBUG
     ```
-  * Alternatively, you can use the pre-configured debugging targets
-    `bin_debug` and `bind`, for instance, with
+  * Alternatively and potentially preferably, you can use the pre-configured
+    debugging targets
+    `bin_debug` and `bin_debug_severe`, for instance, with
     ```
-    make cleaner bind bint_run
+    make bin_debug_severe bint_run
     ```
   * If **valgrind** is installed, then you can call the target `bind_valgrind`
     (see description in `makefile`) with
     ```
-    make cleaner bind_valgrind
+    make bind_valgrind
     ```
 
 <br>

--- a/SW_Carbon.h
+++ b/SW_Carbon.h
@@ -5,30 +5,40 @@
  * @date   23 January 2017
  */
 #ifndef CARBON
-  #define CARBON             /**< A macro that only lets the variables in @f SW_Carbon.h be defined once. */
+#define CARBON             /**< A macro that only lets the variables in @f SW_Carbon.h be defined once. */
 
-  #include "SW_Defines.h"
+#include "SW_Defines.h"
 
 
-  /**
-   * @brief The main structure holding all CO2-related data.
-   */
-  typedef struct {
-    int
-      use_wue_mult,                      /**< A boolean integer indicating if WUE multipliers should be calculated. */
-      use_bio_mult;                      /**< A boolean integer indicating if biomass multipliers should be calculated. */
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-    char
-      scenario[64];                      /**< A 64-char array holding the scenario name for which we are extracting CO2 data from the carbon.in file. */
+/**
+ * @brief The main structure holding all CO2-related data.
+ */
+typedef struct {
+  int
+    use_wue_mult,                      /**< A boolean integer indicating if WUE multipliers should be calculated. */
+    use_bio_mult;                      /**< A boolean integer indicating if biomass multipliers should be calculated. */
 
-    double
-      ppm[MAX_NYEAR];                 /**< A 1D array holding atmospheric CO2 concentration values (units ppm) that are indexed by calendar year. Is typically only populated for the years that are being simulated. `ppm[index]` is the CO2 value for the calendar year `index + 1` */
+  char
+    scenario[64];                      /**< A 64-char array holding the scenario name for which we are extracting CO2 data from the carbon.in file. */
 
-  } SW_CARBON;
+  double
+    ppm[MAX_NYEAR];                 /**< A 1D array holding atmospheric CO2 concentration values (units ppm) that are indexed by calendar year. Is typically only populated for the years that are being simulated. `ppm[index]` is the CO2 value for the calendar year `index + 1` */
 
-  /* Function Declarations */
-  void SW_CBN_construct(void);
-  void SW_CBN_deconstruct(void);
-  void SW_CBN_read(void);
-  void calculate_CO2_multipliers(void);
+} SW_CARBON;
+
+/* Function Declarations */
+void SW_CBN_construct(void);
+void SW_CBN_deconstruct(void);
+void SW_CBN_read(void);
+void calculate_CO2_multipliers(void);
+
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/SW_Control.h
+++ b/SW_Control.h
@@ -18,6 +18,10 @@
 #ifndef SW_CONTROL_H
 #define SW_CONTROL_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void SW_CTL_init_model(const char *firstfile);
 void SW_CTL_clear_model(Bool full_reset);
 void SW_CTL_obtain_inputs(void);
@@ -27,6 +31,11 @@ void SW_CTL_run_current_year(void);
 
 #ifdef DEBUG_MEM
 void SW_CTL_SetMemoryRefs(void);
+#endif
+
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/SW_Defines.h
+++ b/SW_Defines.h
@@ -17,10 +17,14 @@
 /********************************************************/
 
 #ifndef SOILW_DEF_H
-	#define SOILW_DEF_H
+#define SOILW_DEF_H
 
 #include <math.h>  /* for atan() in tanfunc() below */
 #include "generic.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* Not sure if this parameter is variable or a consequence of algebra,
  * but it's different in the FORTRAN version than in the ELM doc.
@@ -149,5 +153,10 @@ typedef enum { eF,   /* file management */
                eVPD, /* vegetation production */
                eOUT  /* output */
 } ObjType;
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/SW_Files.h
+++ b/SW_Files.h
@@ -14,7 +14,11 @@
 /********************************************************/
 /********************************************************/
 #ifndef SW_FILES_H
-	#define SW_FILES_H
+#define SW_FILES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define SW_NFILES 23
 
@@ -41,6 +45,11 @@ void SW_CSV_F_INIT(const char *s);
 
 #ifdef DEBUG_MEM
 void SW_F_SetMemoryRefs(void);
+#endif
+
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/SW_Flow.h
+++ b/SW_Flow.h
@@ -1,3 +1,18 @@
+#ifndef SW_FLOW_H
+#define SW_FLOW_H
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void SW_FLW_construct(void);
 void SW_FLW_deconstruct(void);
 void SW_Water_Flow(void);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/SW_Flow_lib.h
+++ b/SW_Flow_lib.h
@@ -37,6 +37,10 @@
 #ifndef SW_WATERSUBS_H
 #define SW_WATERSUBS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Standing crop can only intercept so much precip
  * This is the limiter used inside stdcrop_intercepted()
  */
@@ -178,5 +182,10 @@ unsigned int adjust_Tsoil_by_freezing_and_thawing(double oldsTemp[], double sTem
 void soil_temperature_today(double *ptr_dTime, double deltaX, double sT1, double sTconst,
 	int nRgr, double sTempR[], double oldsTempR[], double vwcR[], double wpR[], double fcR[],
 	double bDensityR[], double csParam1, double csParam2, double shParam, Bool *ptr_stError);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/SW_Main_lib.c
+++ b/SW_Main_lib.c
@@ -36,7 +36,7 @@
 /* --------------------------------------------------- */
 
 /* see generic.h and filefuncs.h for more info on these vars */
-char inbuf[1024]; /* buffer used by input statements */
+char inbuf[MAX_FILENAMESIZE]; /* buffer used by input statements */
 char errstr[MAX_ERROR]; /* used to compose an error msg    */
 FILE *logfp; /* file handle for logging messages */
 int logged; /* boolean: true = we logged a msg */
@@ -62,7 +62,7 @@ void usage(void) {
   sw_error(0, "%s", s1);
 }
 
-char _firstfile[1024];
+char _firstfile[MAX_FILENAMESIZE];
 
 void init_args(int argc, char **argv) {
 	/* =================================================== */

--- a/SW_Markov.h
+++ b/SW_Markov.h
@@ -13,6 +13,10 @@
 #ifndef SW_MARKOV_H
 #define SW_MARKOV_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
 
 	/* pointers to arrays of probabilities for each day saves some space */
@@ -42,4 +46,10 @@ void SW_MKV_today(TimeInt doy, RealD *tmax, RealD *tmin, RealD *rain);
 void SW_MKV_SetMemoryRefs( void);
 #endif
 
+
+#ifdef __cplusplus
+}
 #endif
+
+#endif
+

--- a/SW_Model.h
+++ b/SW_Model.h
@@ -23,6 +23,10 @@
 #include "Times.h"
 #include "SW_Defines.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
 	TimeInt /* controlling dates for model run */
 	startyr, /* beginning year for model run */
@@ -53,5 +57,10 @@ void SW_MDL_construct(void);
 void SW_MDL_deconstruct(void);
 void SW_MDL_new_year(void);
 void SW_MDL_new_day(void);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/SW_Output.c
+++ b/SW_Output.c
@@ -1826,6 +1826,8 @@ int SW_OUT_read_onekey(OutKey k, OutSum sumtype, char period[], int first,
 		last = 366;
 		#ifndef RSOILWAT
 		strcpy(period, "YR");
+		#else
+		if (period) {} // avoid `-Wunused-parameter`
 		#endif
 
 	} else if ((k == eSW_AllVeg || k == eSW_ET || k == eSW_AllWthr || k == eSW_AllH2O))

--- a/SW_Output.h
+++ b/SW_Output.h
@@ -37,6 +37,10 @@
 #include "SW_Weather.h"
 #include "SW_VegProd.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 
 // Array-based output:
 #if defined(RSOILWAT) || defined(STEPWAT)
@@ -341,6 +345,11 @@ void get_co2effects_SXW(OutPeriod pd);
 
 #ifdef DEBUG_MEM
 	void SW_OUT_SetMemoryRefs(void);
+#endif
+
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/SW_Output_mock.c
+++ b/SW_Output_mock.c
@@ -72,8 +72,8 @@ IntUS ncol_OUT[SW_OUTNKEYS];
 
 
 // Mock definitions
-char const *key2str[] = {};
-char const *pd2longstr[] = {};
+char const *key2str[] = {"SW_MISSING"};
+char const *pd2longstr[] = {"SW_MISSING"};
 
 
 

--- a/SW_Output_outarray.h
+++ b/SW_Output_outarray.h
@@ -16,6 +16,11 @@
 #ifndef SW_OUTPUT_ARRAY_H
 #define SW_OUTPUT_ARRAY_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 /** iOUT returns the index to the `i`-th column for time period `pd` in an
   output array that is organized by columns where `i` is base0 and
   `pd` is `OutPeriod`. The index order has to match up with column names as
@@ -45,6 +50,11 @@ void get_outvalleader(RealD *p, OutPeriod pd);
 #ifdef STEPWAT
 void do_running_agg(RealD *p, RealD *psd, size_t k, IntU n, RealD x);
 void setGlobalSTEPWAT2_OutputVariables(void);
+#endif
+
+
+#ifdef __cplusplus
+}
 #endif
 
 

--- a/SW_Output_outtext.h
+++ b/SW_Output_outtext.h
@@ -16,6 +16,10 @@
 #ifndef SW_OUTPUT_TXT_H
 #define SW_OUTPUT_TXT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 
 typedef struct {
 	Bool make_soil[SW_OUTNPERIODS], make_regular[SW_OUTNPERIODS];
@@ -58,5 +62,10 @@ void get_outstrleader(OutPeriod pd, char *str);
 void write_headers_to_csv(OutPeriod pd, FILE *fp_reg, FILE *fp_soil, Bool does_agg);
 void find_TXToutputSoilReg_inUse(void);
 void SW_OUT_close_files(void);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/SW_Site.h
+++ b/SW_Site.h
@@ -49,6 +49,10 @@
 
 #include "SW_Defines.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 
 typedef unsigned int LyrIndex;
 
@@ -147,6 +151,11 @@ LyrIndex _newlayer(void);
 
 #ifdef DEBUG_MEM
 	void SW_SIT_SetMemoryRefs(void);
+#endif
+
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/SW_Sky.h
+++ b/SW_Sky.h
@@ -18,8 +18,12 @@
 #ifndef SW_SKY_H
 #define SW_SKY_H
 
-
 #include "SW_Times.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 
 typedef struct {
     RealD cloudcov     [MAX_MONTHS], /* monthly cloud cover (frac) */
@@ -39,5 +43,10 @@ typedef struct {
 void SW_SKY_read(void);
 void SW_SKY_init(double scale_sky[], double scale_wind[], double scale_rH[], double scale_transmissivity[]);
 void SW_SKY_construct(void);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/SW_SoilWater.h
+++ b/SW_SoilWater.h
@@ -41,6 +41,10 @@
 #ifndef SW_SOILWATER_H
 #define SW_SOILWATER_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "generic.h"
 #include "SW_Defines.h"
 #include "SW_Times.h"
@@ -151,6 +155,11 @@ void SW_WaterBalance_Checks(void);
 
 #ifdef DEBUG_MEM
 void SW_SWC_SetMemoryRefs(void);
+#endif
+
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/SW_Times.h
+++ b/SW_Times.h
@@ -33,6 +33,11 @@
 
 #include "Times.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 /*---------------------------------------------------------------*/
 typedef enum {
 	Yesterday, Today
@@ -54,5 +59,10 @@ typedef struct {
  * The user need only supply a 0/1 flag in the file
  * containing the start/end years.
  */
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/SW_VegEstab.h
+++ b/SW_VegEstab.h
@@ -21,6 +21,11 @@
 	#include "../ST_defines.h"
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 /* indices to bars[] */
 #define SW_GERM_BARS 0
 #define SW_ESTAB_BARS 1
@@ -121,5 +126,10 @@ void _echo_VegEstab(void);
  roots_wet                     ------  rootswet
 
  */
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/SW_VegProd.h
+++ b/SW_VegProd.h
@@ -37,6 +37,11 @@
 #include "SW_Defines.h"    /* for tanfunc_t*/
 #include "Times.h" 				// for MAX_MONTHS
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 #define BIO_INDEX 0        /**< An integer representing the index of the biomass multipliers in the VegType#co2_multipliers 2D array. */
 #define WUE_INDEX 1        /**< An integer representing the index of the WUE multipliers in the VegType#co2_multipliers 2D array. */
 
@@ -130,5 +135,10 @@ void SW_VPD_deconstruct(void);
 void apply_biomassCO2effect(double* new_biomass, double *biomass, double multiplier);
 void _echo_VegProd(void);
 void get_critical_rank(void);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/SW_Weather.h
+++ b/SW_Weather.h
@@ -27,6 +27,11 @@
 #include "SW_Times.h"
 #include "SW_Defines.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 /* missing values may be different than with other things */
 #define WTH_MISSING   999.
 
@@ -94,6 +99,11 @@ void SW_WTH_clear_runavg_list(void);
 
 #ifdef DEBUG_MEM
 void SW_WTH_SetMemoryRefs(void);
+#endif
+
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/Times.h
+++ b/Times.h
@@ -43,6 +43,11 @@
 #include <time.h>
 #include "generic.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 /*---------------------------------------------------------------*/
 #define MAX_MONTHS 12
 #define MAX_WEEKS 53
@@ -117,5 +122,10 @@ Bool isleapyear_now(void);
 Bool isleapyear(const TimeInt year);
 
 void interpolate_monthlyValues(double monthlyValues[], double dailyValues[]);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,14 +9,14 @@ install:
   - git submodule update --init --recursive
 
 # to run your custom scripts instead of automatic MSBuild
+# Note: appveyor doesn't have sanitizers -> cannot run *_severe test targets
 build_script:
   - set PATH=%PATH%;c:\cygwin\bin
   # compile and run optimized binary
   - make clean bin bint_run
   # compile and run debug binary
-  - make clean bin_debug_severe bint_run
-  # compile and run (severe) unit tests
+   - make clean bin_debug bint_run
+  # compile and run unit tests
   - make clean test test_run
-  - make clean test_severe test_run
   # clean up
   - make clean

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ build_script:
   # compile and run optimized binary
   - make clean bin bint_run
   # compile and run debug binary
-   - make clean bin_debug bint_run
+  - make clean bin_debug bint_run
   # compile and run unit tests
   - make clean test test_run
   # clean up

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,12 @@ install:
 # to run your custom scripts instead of automatic MSBuild
 build_script:
   - set PATH=%PATH%;c:\cygwin\bin
-  - set CPPFLAGS=-DSWDEBUG && make cleaner bint_run
-  - make cleaner testci test_run
-  - make cleaner
+  # compile and run optimized binary
+  - make clean bin bint_run
+  # compile and run debug binary
+  - make clean bin_debug_severe bint_run
+  # compile and run (severe) unit tests
+  - make clean test test_run
+  - make clean test_severe test_run
+  # clean up
+  - make clean

--- a/filefuncs.h
+++ b/filefuncs.h
@@ -11,6 +11,9 @@
 
 #include "generic.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /***************************************************
  * Function definitions
@@ -29,5 +32,10 @@ void sw_error(int errorcode, const char *format, ...);
 void LogError(FILE *fp, const int mode, const char *fmt, ...);
 
 extern char inbuf[]; /* declare in main, use anywhere */
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/generic.h
+++ b/generic.h
@@ -49,6 +49,11 @@
   #include <R_ext/Print.h>
 #endif
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /***************************************************
  * Basic definitions
  ***************************************************/
@@ -246,6 +251,11 @@ extern errstr[];
 #ifndef strdup
   char * sw_strdup(const char * s);
   #define strdup(x) sw_strdup(x)
+#endif
+
+
+#ifdef __cplusplus
+}
 #endif
 
 #define GENERIC_H

--- a/makefile
+++ b/makefile
@@ -199,7 +199,7 @@ bint_run : bint
 		./testing/$(target) -d ./testing -f files.in
 
 .PHONY : bind_valgrind
-bind_valgrind : bin_debug bind
+bind_valgrind : bin_debug bint
 		valgrind -v --track-origins=yes --leak-check=full ./testing/$(target) -d ./testing -f files.in
 
 

--- a/makefile
+++ b/makefile
@@ -75,6 +75,7 @@ instr_flags_severe = $(instr_flags) -fsanitize=undefined -fsanitize=address
 	# -fstack-protector-strong (gcc >= v4.9)
 	# (gcc >= 4.0) -D_FORTIFY_SOURCE: lightweight buffer overflow protection to some memory and string functions
 	# (gcc >= 4.8; llvm >= 3.1) -fsanitize=address: replaces `mudflap` run time checker; https://github.com/google/sanitizers/wiki/AddressSanitizer
+	# (gcc >= 4.9; llvm >= 3.3) -fsanitize=undefined
 
 # Precompiler and compiler flags and options
 sw_CPPFLAGS = $(CPPFLAGS)

--- a/makefile
+++ b/makefile
@@ -1,25 +1,35 @@
-#-----------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------
 # commands         explanations
-#-----------------------------------------------------------------------------------
-# make bin         compile the binary executable using optimizations
-# make bint        same as 'make bin' plus moves a copy of the binary to the
+#-------------------------------------------------------------------------------
+# help             display the top of this file, i.e., print explanations
+#
+# make all         (synonym to 'bin'): compile the binary executable using
+#                  optimizations
+# make bint        same as 'make bin' plus move a copy of the binary to the
 #                  'testing/' folder
-# make bint_run    same as 'make bint' plus executes the binary in the testing/ folder
+# make bint_run    same as 'make bint' plus execute the binary in testing/
+#
 # make lib         create SOILWAT2 library
-# make test        compile unit tests in 'test/ folder with googletest
-# make testci      compile unit tests with less severe flags due to older compiler versions in 'test/ folder with googletest
-# make test_run    run unit tests (in a previous step compiled with 'make test' or 'make testci')
+#
+# make test        compile unit tests in 'test/ folder (with googletest)
+# make test_severe compile unit tests with severe flags in 'test/'
+# make test_run    run unit tests (in a previous step compiled with 'make test'
+#                  or 'make test_severe')
+#
 # make bin_debug   compile the binary executable in debug mode
-# make bind        same as 'make bin_debug' plus moves a copy of the binary to the
-#                  'testing/' folder
-# make bind_valgrind	same as 'make bind' plus runs valgrind on the debug binary in the testing/ folder
+# make bin_debug_severe   same as 'make bin_debug' but with severe flags
+# make bind_valgrind      same as 'make bind' plus run valgrind on the debug
+#                  binary in the testing/ folder
+#
 # make cov         same as 'make test' but with code coverage support
-# make cov_run     run unit tests and gcov on each source file (in a previous step
-#                  compiled with 'make cov')
-# make cleaner     delete all of the o files, test files, libraries, and the binary exe
+# make cov_run     run unit tests and gcov on each source file (in a previous
+#                  step compiled with 'make cov')
+#
+# make clean       (synonym to 'cleaner'): delete all of the o files, test
+#                  files, libraries, and the binary exe(s)
 # make test_clean  delete test files and libraries
 # make cov_clean   delete files associated with code coverage
-#-----------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------
 
 uname_m = $(shell uname -m)
 
@@ -44,18 +54,24 @@ lib_target_cov = lib$(target_cov).a
 # RM = rm
 
 use_c11 = -std=c11
+use_gnu11 = -std=gnu11		# gnu11 required for googletest on Windows/cygwin
 use_gnu++11 = -std=gnu++11		# gnu++11 required for googletest on Windows/cygwin
 
 
 #------ FLAGS
 # Diagnostic warning/error messages
 warning_flags = -Wall -Wextra
-warning_flags_bin = $(warning_flags) -Wpedantic -Werror
+# Don't use 'warning_flags_severe*' for production builds and rSOILWAT2
+warning_flags_severe = $(warning_flags) -Wpedantic -Werror
+warnings_flags_severe_cxx = $(warning_flags_severe) -Wno-error
+	# TODO: address underlying problems so that we can eventually add -Werror:
+	#  - clang++: "treating 'c' input as 'c++' when in C++ mode"
+	#  - ISO C++ forbids variable length array: (clang++ uses -Wvla-extension
+	#    whereas g++ uses -Wvla) --> cannot compile c++ unit tests with -Werror
 
 # Instrumentation options for debugging and testing
 instr_flags = -fstack-protector-all
-instr_flags_severe = -D_FORTIFY_SOURCE=2 -Wno-macro-redefined \
-	-fsanitize=undefined -fsanitize=address
+instr_flags_severe = $(instr_flags) -fsanitize=undefined -fsanitize=address
 	# -fstack-protector-strong (gcc >= v4.9)
 	# (gcc >= 4.0) -D_FORTIFY_SOURCE: lightweight buffer overflow protection to some memory and string functions
 	# (gcc >= 4.8; llvm >= 3.1) -fsanitize=address: replaces `mudflap` run time checker; https://github.com/google/sanitizers/wiki/AddressSanitizer
@@ -63,11 +79,11 @@ instr_flags_severe = -D_FORTIFY_SOURCE=2 -Wno-macro-redefined \
 # Precompiler and compiler flags and options
 sw_CPPFLAGS = $(CPPFLAGS)
 sw_CFLAGS = $(CFLAGS)
-sw_CXXFLAGS = $(CXXFLAGS) -Wno-error=deprecated		# TODO: clang++: "treating 'c' input as 'c++' when in C++ mode"
+sw_CXXFLAGS = $(CXXFLAGS)
 
-bin_flags = -O2
+bin_flags = -O2 -fno-stack-protector
 debug_flags = -g -O0 -DSWDEBUG
-cov_flags = -coverage
+cov_flags = -O0 -coverage
 
 # Linker flags and libraries
 # order of libraries is important for GNU gcc (libSOILWAT2 depends on libm)
@@ -83,28 +99,25 @@ gtest_LDLIBS = -l$(gtest)
 
 
 #------ CODE FILES
-sources = $(sw_sources) SW_Main_lib.c SW_VegEstab.c SW_Control.c generic.c \
+sources_core = SW_Main_lib.c SW_VegEstab.c SW_Control.c generic.c \
 					rands.c Times.c mymemory.c filefuncs.c SW_Files.c SW_Model.c \
 					SW_Site.c SW_SoilWater.c SW_Markov.c SW_Weather.c SW_Sky.c \
-					SW_Output.c SW_Output_get_functions.c\
 					SW_VegProd.c SW_Flow_lib.c SW_Flow.c SW_Carbon.c
-objects = $(sources:.c=.o)
+
+sources_lib = $(sw_sources) $(sources_core) SW_Output.c SW_Output_get_functions.c
+objects_lib = $(sources_lib:.c=.o)
 
 # Unfortunately, we currently cannot include 'SW_Output.c' because
 #  - cannot increment expression of enum type (e.g., OutKey, OutPeriod)
 #  - assigning to 'OutKey' from incompatible type 'int'
 # ==> instead, we use 'SW_Output_mock.c' which provides mock versions of the
 # public functions (but will result in some compiler warnings)
-sources_tests = SW_Main_lib.c SW_VegEstab.c SW_Control.c generic.c \
-					rands.c Times.c mymemory.c filefuncs.c SW_Files.c SW_Model.c \
-					SW_Site.c SW_SoilWater.c SW_Markov.c SW_Weather.c SW_Sky.c \
-					SW_Output_mock.c \
-					SW_VegProd.c SW_Flow_lib.c SW_Flow.c SW_Carbon.c
-objects_tests = $(sources_tests:.c=.o)
+sources_lib_test = $(sources_core) SW_Output_mock.c
+objects_lib_test = $(sources_lib_test:.c=.o)
 
 
-bin_sources = SW_Main.c SW_Output_outtext.c # SOILWAT2-standalone
-bin_objects = $(bin_sources:.c=.o)
+sources_bin = SW_Main.c SW_Output_outtext.c # SOILWAT2-standalone
+objects_bin = $(sources_bin:.c=.o)
 
 
 gtest = gtest
@@ -121,84 +134,72 @@ bin : $(target)
 lib : $(lib_target)
 
 $(lib_target) :
-		$(CC) $(sw_CPPFLAGS) $(sw_CFLAGS) $(bin_flags) $(warning_flags_bin) \
-		$(use_c11) -c $(sources)
+		$(CC) $(sw_CPPFLAGS) $(sw_CFLAGS) $(bin_flags) $(warning_flags) \
+		$(use_c11) -c $(sources_lib)
 
 		-@$(RM) -f $(lib_target)
-		$(AR) -rcs $(lib_target) $(objects)
-		-@$(RM) -f $(objects)
+		$(AR) -rcs $(lib_target) $(objects_lib)
+		-@$(RM) -f $(objects_lib)
 
 
 $(lib_target_test) :
-		$(CXX) $(sw_CPPFLAGS) $(sw_CXXFLAGS) $(debug_flags) $(warning_flags) \
-		$(instr_flags) $(use_gnu++11) -c $(sources_tests)
+		$(CC) $(sw_CPPFLAGS) $(sw_CFLAGS) $(debug_flags) $(warning_flags) \
+		$(instr_flags) $(use_gnu11) -c $(sources_lib_test)
 
 		-@$(RM) -f $(lib_target_test)
-		$(AR) -rcs $(lib_target_test) $(objects_tests)
-		-@$(RM) -f $(objects_tests)
+		$(AR) -rcs $(lib_target_test) $(objects_lib_test)
+		-@$(RM) -f $(objects_lib_test)
 
-$(lib_target_severe) :
-		$(CXX) $(sw_CPPFLAGS) $(sw_CXXFLAGS) $(debug_flags) $(warning_flags) \
-		$(instr_flags_severe) $(use_gnu++11) -c $(sources_tests)
+$(lib_target_severe) :	# needs CXX because of '*_severe' flags which must match test binary build
+		$(CXX) $(sw_CPPFLAGS) $(sw_CXXFLAGS) $(debug_flags) $(warnings_flags_severe_cxx) \
+		$(instr_flags_severe) $(use_gnu++11) -c $(sources_lib_test)
 
 		-@$(RM) -f $(lib_target_severe)
-		$(AR) -rcs $(lib_target_severe) $(objects_tests)
-		-@$(RM) -f $(objects_tests)
+		$(AR) -rcs $(lib_target_severe) $(objects_lib_test)
+		-@$(RM) -f $(objects_lib_test)
 
-$(lib_target_cov) :
+$(lib_target_cov) :	# needs CXX because of 'coverage' flags which must match test binary build
 		$(CXX) $(sw_CPPFLAGS) $(sw_CXXFLAGS) $(debug_flags) $(warning_flags) \
-		$(instr_flags) $(cov_flags) $(use_gnu++11) -c $(sources_tests)
+		$(instr_flags) $(cov_flags) $(use_gnu++11) -c $(sources_lib_test)
 
 		-@$(RM) -f $(lib_target_cov)
-		$(AR) -rcs $(lib_target_cov) $(objects_tests)
-		-@$(RM) -f $(objects_tests)
+		$(AR) -rcs $(lib_target_cov) $(objects_lib_test)
+		-@$(RM) -f $(objects_lib_test)
 
 
 $(target) : $(lib_target)
-		$(CC) $(sw_CPPFLAGS) $(sw_CFLAGS) $(bin_flags) $(warning_flags_bin) \
+		$(CC) $(sw_CPPFLAGS) $(sw_CFLAGS) $(bin_flags) $(warning_flags) \
 		$(use_c11) \
-		-o $(target) $(bin_sources) $(target_LDLIBS) $(sw_LDFLAGS)
+		-o $(target) $(sources_bin) $(target_LDLIBS) $(sw_LDFLAGS)
 
-bin_debug :
-		$(CC) $(sw_CPPFLAGS) $(sw_CFLAGS) $(debug_flags) $(warning_flags) \
-		$(instr_flags_severe) $(use_c11) -c $(sources_tests)
+bin_debug_severe :
+		$(CC) $(sw_CPPFLAGS) $(sw_CFLAGS) $(debug_flags) $(warning_flags_severe) \
+		$(instr_flags_severe) $(use_c11) -c $(sources_lib_test)
 
 		-@$(RM) -f $(lib_target_severe)
-		$(AR) -rcs $(lib_target_severe) $(objects_tests)
-		-@$(RM) -f $(objects_tests)
+		$(AR) -rcs $(lib_target_severe) $(objects_lib_test)
+		-@$(RM) -f $(objects_lib_test)
 
-		$(CC) $(sw_CPPFLAGS) $(sw_CFLAGS) $(debug_flags) $(warning_flags) \
+		$(CC) $(sw_CPPFLAGS) $(sw_CFLAGS) $(debug_flags) $(warning_flags_severe) \
 		$(instr_flags_severe) $(use_c11) \
-		-o $(target) $(bin_sources) $(severe_LDLIBS) $(sw_LDFLAGS)
+		-o $(target) $(sources_bin) $(severe_LDLIBS) $(sw_LDFLAGS)
 
-bin_debug_ci :
-		$(CC) $(sw_CPPFLAGS) $(sw_CFLAGS) $(debug_flags) $(warning_flags) \
-		$(instr_flags) $(use_c11) -c $(sources_tests)
-
-		-@$(RM) -f $(lib_target_test)
-		$(AR) -rcs $(lib_target_test) $(objects_tests)
-		-@$(RM) -f $(objects_tests)
-
+bin_debug : $(lib_target_test)
 		$(CC) $(sw_CPPFLAGS) $(sw_CFLAGS) $(debug_flags) $(warning_flags) \
 		$(instr_flags) $(use_c11) \
-		-o $(target) $(bin_sources) $(test_LDLIBS) $(sw_LDFLAGS)
+		-o $(target) $(sources_bin) $(test_LDLIBS) $(sw_LDFLAGS)
 
 
 .PHONY : bint
-bint : bin
+bint :
 		cp $(target) testing/$(target)
 
 .PHONY : bint_run
 bint_run : bint
 		./testing/$(target) -d ./testing -f files.in
 
-.PHONY : bind
-bind : bin_debug
-		cp $(target) testing/$(target)
-
 .PHONY : bind_valgrind
-bind_valgrind : bin_debug_ci
-		cp $(target) testing/$(target)
+bind_valgrind : bin_debug bind
 		valgrind -v --track-origins=yes --leak-check=full ./testing/$(target) -d ./testing -f files.in
 
 
@@ -216,13 +217,13 @@ $(lib_gtest) :
 
 		@$(AR) -r $(lib_gtest) gtest-all.o
 
-test : $(lib_gtest) $(lib_target_severe)
-		$(CXX) $(sw_CPPFLAGS) $(sw_CXXFLAGS) $(debug_flags) $(warning_flags) \
+test_severe : $(lib_gtest) $(lib_target_severe)
+		$(CXX) $(sw_CPPFLAGS) $(sw_CXXFLAGS) $(debug_flags) $(warnings_flags_severe_cxx) \
 		$(instr_flags_severe) $(use_gnu++11) \
 		-isystem ${GTEST_DIR}/include -pthread \
 		test/*.cc -o $(bin_test) $(gtest_LDLIBS) $(severe_LDLIBS) $(sw_LDFLAGS)
 
-testci : $(lib_gtest) $(lib_target_test)
+test : $(lib_gtest) $(lib_target_test)
 		$(CXX) $(sw_CPPFLAGS) $(sw_CXXFLAGS) $(debug_flags) $(warning_flags) \
 		$(instr_flags) $(use_gnu++11) \
 		-isystem ${GTEST_DIR}/include -pthread \
@@ -248,7 +249,7 @@ cov_run : cov
 
 .PHONY : clean1
 clean1 :
-		-@$(RM) -f $(objects) $(bin_objects)
+		-@$(RM) -f $(objects_lib) $(objects_bin)
 
 .PHONY : clean2
 clean2 :
@@ -264,7 +265,7 @@ test_clean :
 		-@$(RM) -f gtest-all.o $(lib_gtest) $(bin_test)
 		-@$(RM) -f $(lib_target_test) $(lib_target_severe) $(lib_target_cov)
 		-@$(RM) -fr *.dSYM
-		-@$(RM) -f $(objects_tests)
+		-@$(RM) -f $(objects_lib_test)
 
 .PHONY : cov_clean
 cov_clean :
@@ -276,3 +277,9 @@ cleaner : clean1 clean2 bint_clean test_clean cov_clean
 
 .PHONY : clean
 clean : cleaner
+
+
+
+.PHONY : help
+help :
+		less makefile

--- a/makefile
+++ b/makefile
@@ -64,10 +64,9 @@ warning_flags = -Wall -Wextra
 # Don't use 'warning_flags_severe*' for production builds and rSOILWAT2
 warning_flags_severe = $(warning_flags) -Wpedantic -Werror
 warnings_flags_severe_cxx = $(warning_flags_severe) -Wno-error
-	# TODO: address underlying problems so that we can eventually add -Werror:
-	#  - clang++: "treating 'c' input as 'c++' when in C++ mode"
-	#  - ISO C++ forbids variable length array: (clang++ uses -Wvla-extension
-	#    whereas g++ uses -Wvla) --> cannot compile c++ unit tests with -Werror
+	# TODO: address underlying problems so that we can eliminate `-Wno-error`:
+	#  - compiler warning: treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated (https://github.com/DrylandEcology/SOILWAT2/issues/208)
+	#  - compiler warning: variable length arrays (https://github.com/DrylandEcology/SOILWAT2/issues/214)
 
 # Instrumentation options for debugging and testing
 instr_flags = -fstack-protector-all

--- a/memblock.h
+++ b/memblock.h
@@ -8,6 +8,10 @@
 #include <stdlib.h>
 #include <assert.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define bGarbage 0xCC
 /*typedef unsigned char byte*/
 typedef signed char flag;
@@ -51,5 +55,10 @@ flag fValidPointer(void *pv, size_t size);
 #define fPtrEqual(pLeft, pRight)   ((pLeft) == (pRight))
 #define fPtrLessEq(pLeft, pRight)  ((pLeft) <= (pRight))
 #define fPtrGrtrEq(pLeft, pRight)  ((pLeft) >= (pRight))
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/myMemory.h
+++ b/myMemory.h
@@ -13,6 +13,11 @@
 #include "memblock.h"
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 char *Str_Dup(const char *s); /* return pointer to malloc'ed dup of s */
 void *Mem_Malloc(size_t size, const char *funcname);
 void *Mem_Calloc(size_t nobjs, size_t size, const char *funcname);
@@ -20,5 +25,10 @@ void *Mem_ReAlloc(void *block, size_t sizeNew);
 void Mem_Free(void *block);
 void Mem_Set(void *block, byte c, size_t n);
 void Mem_Copy(void *dest, const void *src, size_t n);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/rands.c
+++ b/rands.c
@@ -13,6 +13,7 @@ long _randseed = 0L;
 
 #ifdef RSOILWAT
   #include <R_ext/Random.h> // for the random number generators
+  #include <Rmath.h> // for rnorm()
 #endif
 
 
@@ -328,7 +329,7 @@ double RandNorm(double mean, double stddev) {
 
 	#ifdef RSOILWAT
 		GetRNGstate();
-		y = norm_rand();
+		y = rnorm(mean, stddev);
 		PutRNGstate();
 
 	#else

--- a/rands.h
+++ b/rands.h
@@ -13,6 +13,10 @@
 #include <stdio.h>
 #include <float.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /***************************************************
  * Basic definitions
  ***************************************************/
@@ -50,6 +54,11 @@ float RandBeta(float aa, float bb);
 #define RandUni RandUni_fast
 #else
 #define RandUni RandUni_good
+#endif
+
+
+#ifdef __cplusplus
+}
 #endif
 
 #define RANDS_H

--- a/test/sw_maintest.cc
+++ b/test/sw_maintest.cc
@@ -48,11 +48,13 @@ const char * masterfile_test = "files.in"; // relative to 'dir_test'
 
 
 // Global variables which are defined in SW_Main_lib.c:
-extern char errstr[];
-extern FILE *logfp;
-extern int logged;
-extern Bool QuietMode, EchoInits;
-extern char _firstfile[];
+// We need to redefine them here because they are not included in the library
+char inbuf[MAX_FILENAMESIZE];
+char errstr[MAX_ERROR];
+FILE *logfp;
+int logged;
+Bool QuietMode, EchoInits;
+char _firstfile[MAX_FILENAMESIZE];
 
 
 
@@ -81,9 +83,9 @@ int main(int argc, char **argv) {
   res = RUN_ALL_TESTS();
 
   //--- Take down SOILWAT2 variables
-  SW_SIT_clear_layers();
-  SW_WTH_clear_runavg_list();
+  SW_CTL_clear_model(swTRUE); // de-allocate all memory
 
   //--- Return output of 'RUN_ALL_TESTS()', see https://github.com/google/googletest/blob/master/googletest/docs/FAQ.md#my-compiler-complains-about-ignoring-return-value-when-i-call-run_all_tests-why
   return res;
 }
+

--- a/test/test_SW_SoilWater.cc
+++ b/test/test_SW_SoilWater.cc
@@ -22,6 +22,8 @@ extern SW_SITE SW_Site;
 extern SW_VEGPROD SW_VegProd;
 
 namespace{
+  float tol = 1e-6;
+
   // Test the 'SW_SoilWater' function 'SW_VWCBulkRes'
   TEST(SWSoilWaterTest, SWVWCBulkRes){
     //declare mock INPUTS
@@ -61,8 +63,9 @@ namespace{
     SW_SWC_adjust_snow(temp_min, temp_max, ppt, &rain, &snow, &snowmelt);
     EXPECT_EQ(rain, 1);
     EXPECT_EQ(snow, 0);
-    Reset_SOILWAT2_after_UnitTest();
 
+    // Reset to previous global states
+    Reset_SOILWAT2_after_UnitTest();
   }
 
   // Test the 'SW_SoilWater' function 'SW_SWCbulk2SWPmatric'
@@ -77,7 +80,6 @@ namespace{
     swcBulk = 999;
     res = SW_SWCbulk2SWPmatric(fractionGravel, swcBulk, n);
     EXPECT_EQ(res, 0.0);
-    Reset_SOILWAT2_after_UnitTest();
 
     // test swp val
     swcBulk = 4;
@@ -89,38 +91,45 @@ namespace{
     RealD resExpect = .00013310902; // did math by hand to get this value
     RealD actualExpectDiff = fabs(res - resExpect);
     EXPECT_LT(actualExpectDiff, .0002);
+
+    // Reset to previous global states
+    Reset_SOILWAT2_after_UnitTest();
   }
 
   // Test the 'SW_SoilWater' function 'SW_SWPmatric2VWCBulk'
   TEST(SWSoilWaterTest, SWSWPmatric2VWCBulk){
     // set up mock variables
-    RealD fractionGravel = .1;
+    RealD fractionGravel;
     RealD swpMatric = 15.0;
     RealD p;
     RealD tExpect;
     RealD t;
-    RealD actualExpectDiff;
     RealD psisMatric = 18.608013;
     RealD binverseMatric = 0.188608;
     RealD thetaMatric = 41.37;
-    RealD testNumber;
-    LyrIndex n = 0;
-    SW_Site.lyr[n]->thetasMatric = thetaMatric;
-  	SW_Site.lyr[n]->psisMatric = psisMatric;
-  	SW_Site.lyr[n]->bMatric = binverseMatric;
 
-    // run tests for gravel fractions on the interval [.05, .8], step .05
-    for(testNumber = 1; testNumber <= 16; testNumber++){
-      fractionGravel = (testNumber / 20);
-      p = powe(psisMatric / (swpMatric * BARCONV), binverseMatric);
-      tExpect = thetaMatric * p * 0.01 * (1 - fractionGravel);
+    int i;
+    LyrIndex n = 0;
+
+    SW_Site.lyr[n]->thetasMatric = thetaMatric;
+    SW_Site.lyr[n]->psisMatric = psisMatric;
+    SW_Site.lyr[n]->bMatric = binverseMatric;
+
+    p = thetaMatric * 0.01 * \
+      powe(psisMatric / (swpMatric * BARCONV), binverseMatric);
+
+    // run tests for gravel fractions on the interval [.0, .8], step .05
+    for (i = 0; i <= 16; i++)
+    {
+      fractionGravel = i / 20.;
+      tExpect = p * (1 - fractionGravel);
       t = SW_SWPmatric2VWCBulk(fractionGravel, swpMatric, n);
-      actualExpectDiff = fabs(t - tExpect);
 
       // Tolerance for error since division with RealD introcuces some error
-      EXPECT_LT(actualExpectDiff, 0.0000001);
-
+      EXPECT_NEAR(t, tExpect, tol);
     }
+
+    // Reset to previous global states
     Reset_SOILWAT2_after_UnitTest();
   }
 }


### PR DESCRIPTION
- close #211

- function `SW_OUT_read_onekey`:  uses argument period if compiled with flag RSOILWAT to avoid `-Wunused-parameter`
- function `RandNorm`: if compiled with flag RSOILWAT, calls now function `rnorm` with two parameters `mean` and `sigma` from `Rmath.h` instead of `norm_rand`