### PR TITLE
Fix covariance value checks in Markov weather generator

### DIFF
--- a/SW_Markov.c
+++ b/SW_Markov.c
@@ -369,12 +369,11 @@ Bool SW_MKV_read_cov(void) {
 				t1, t2, lineno, MyFileName);
 		}
 
-		// Covariance values >= 0
-		if (!isfinite(t3) || !isfinite(t4) || !isfinite(t5) || !isfinite(t6) ||
-				LT(t3, 0.) || LT(t4, 0.) || LT(t5, 0.) || LT(t6, 0.))
+		// Covariance values are finite
+		if (!isfinite(t3) || !isfinite(t4) || !isfinite(t5) || !isfinite(t6))
 		{
 			msg_type = LOGFATAL;
-			sprintf(msg, "One of the covariance values is out of range "\
+			sprintf(msg, "One of the covariance values is not a real number "\
 				"(t3 = %f; t4 = %f; t5 = %f; t6 = %f) in line %d of file %s\n",
 				t3, t4, t5, t6, lineno, MyFileName);
 		}


### PR DESCRIPTION
- close #224
- address https://github.com/DrylandEcology/rSFSTEP2/issues/32

- function `SW_MKV_read_cov` was enforcing that covariance values >= 0 since commit 7fbdf6e which is wrong because covariance can take any real value.
-> Fixed by checking that covariance values are finite (real) numbers.