### PR TITLE
Addressed comments on pcg rng integration in pull request #233

### DIFF
--- a/SW_Markov.c
+++ b/SW_Markov.c
@@ -38,7 +38,7 @@
 /*                  Global Variables                   */
 /* --------------------------------------------------- */
 extern SW_MODEL SW_Model;
-extern pcg32_random_t markov_rng;
+pcg32_random_t markov_rng;
 SW_MARKOV SW_Markov; /* declared here, externed elsewhere */
 
 /* =================================================== */
@@ -146,6 +146,8 @@ void SW_MKV_construct(void) {
 	/* =================================================== */
 	SW_MARKOV *m = &SW_Markov;
 	size_t s = sizeof(RealD);
+	
+	RandSeed(0,&markov_rng);
 
 	m->wetprob = (RealD *) Mem_Calloc(MAX_DAYS, s, "SW_MKV_construct");
 	m->dryprob = (RealD *) Mem_Calloc(MAX_DAYS, s, "SW_MKV_construct");

--- a/SW_Model.c
+++ b/SW_Model.c
@@ -56,10 +56,6 @@
 extern SW_SITE SW_Site; /* for reset attribute */
 SW_MODEL SW_Model; /* declared here, externed elsewhere */
 
-#ifndef STEPWAT
-  pcg32_random_t markov_rng;
-#endif
-
 /* =================================================== */
 /*                Module-Level Variables               */
 /* --------------------------------------------------- */
@@ -92,11 +88,6 @@ void SW_MDL_construct(void) {
 		SW_Model.newperiod[pd] = swFALSE;
 	}
 	SW_Model.newperiod[eSW_Day] = swTRUE; // every day is a new day
-
-#ifndef STEPWAT
-	/* already set by user-provided seed in steppe */
-	RandSeed(0,&markov_rng);
-#endif
 }
 
 void SW_MDL_deconstruct(void)

--- a/rands.c
+++ b/rands.c
@@ -10,7 +10,7 @@
 #include "filefuncs.h"
 
 long _randseed = 0L;
-uint64_t stream = 1u;//stream id. this is given out to a pcg_rng then incremented.
+uint64_t stream = 1u; //stream id. this is given out to a pcg_rng then incremented.
 
 #ifdef RSOILWAT
   #include <R_ext/Random.h> // for the random number generators
@@ -20,7 +20,8 @@ uint64_t stream = 1u;//stream id. this is given out to a pcg_rng then incremente
 
 /*****************************************************/
 /**
-  \brief Sets the random number seed. This should only be done ONCE per iteration.
+  \brief Sets the random number seed. If using this function with STEPWAT2
+         only call RandSeed once per iteration.
 
   \param Seed is the initial state of the system. 0 indicates a random seed.
   \param pcg_rng is the random number generator to set.
@@ -40,13 +41,6 @@ void RandSeed(signed long seed, pcg32_random_t* pcg_rng) {
 
   //Increment the stream so no two generators have the same sequence.
   stream++;
-
-#ifndef RSOILWAT
-#if RAND_FAST
-  srand(labs(_randseed));
-#endif
-#endif
-
 }
 
 #define BUCKETSIZE 97
@@ -60,13 +54,26 @@ void RandSeed(signed long seed, pcg32_random_t* pcg_rng) {
   \returns: a double between 0 and 1.
 */
 double RandUni(pcg32_random_t* pcg_rng) {
+
+  int number;
+
+#ifdef RSOILWAT
+
+  GetRNGstate(); 
+	number = unif_rand();
+	PutRNGstate();
+
+#else
   // get a random unsigned int and cast it to a signed int.
-  int number = (int) pcg32_random_r(pcg_rng);
+  number = (int) pcg32_random_r(pcg_rng);
   // negative values are possible. This takes the absolute value.
   number = labs(number); 
-//printf("%f\n", number/(double)RAND_MAX);
+  //printf("%f\n", number/(double)RAND_MAX);
   // divide by RAND_MAX to get a value between 0 and 1.
-  return (double) number / RAND_MAX;
+  number = number / (double)RAND_MAX;
+#endif
+
+  return number;
 }
 
 /*****************************************************/


### PR DESCRIPTION
In SW_Markov.c:
markov pcg rng now declared and seeded here. If used in other programs like STEPWAT2 it should be externed.

In SW_Model.c:
Removed declaration of markov pcg rng. declaration now in SW_Markov.c.

In rands.c:
Added ifdef RSOILWAT case to RandUni()
Removed reference to RAND_FAST which is now obsolete. 
Changed documentation to better explain RandSeed to SOILWAT and STEPWAT users.