### PR TITLE
Bugfix#210 intermittent fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ __Tests, documentation, and code__ form a trinity
     make test_severe test_run  # compiles/executes with strict/severe flags
     make clean                 # cleans build artifacts
     ```
+  * If you want to run unit tests repeatedly (e.g., to sample a range of
+    random numbers), then you may use the bash-script `many_test_runs.sh` which
+    runs `N` number of times and reports only unit test failures, e.g.,
+    ```
+    ./many_test_runs.sh # will run a default (currently, 10) number of times
+    N=3 ./many_test_runs.sh # will run 3 replicates
+    ```
   * Development/feature branches can only be merged into master if they pass
     all checks on `appveyor` and `travis` continuous integration servers, i.e.,
     run the following locally to prepare a pull-request or commit to be reviewed

--- a/many_test_runs.sh
+++ b/many_test_runs.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# N=3 ./many_test_runs.sh: run unit tests repeatedly and report failures only
+# $N number of test runs; default 10 if empty or unset
+
+iters=${N:-10}
+sw_test=${sw_test:-"sw_test"}
+
+echo $(date): will run ${iters} test replicates.
+
+if [ ! -x sw_test ]; then
+  make test
+fi
+
+for i in $(seq 1 $iters); do
+  temp=$( ./sw_test | grep -i "Fail" )
+
+  if [ ! -z "${temp}" ]; then
+    echo Replicate $i failed with:
+    echo ${temp}
+  fi
+done
+
+echo $(date): Completed ${iters} test replicates.
+

--- a/test/test_SW_Flow_lib_temp.cc
+++ b/test/test_SW_Flow_lib_temp.cc
@@ -581,13 +581,6 @@ namespace {
     for (k = 0; k < nlyrs2; k++)
     {
       //swprintf("\n k %u, sTemp3 %f", k, sTemp3[k]);
-      if (sTemp3[k] == 999){
-        //isPassing = false;
-        for(i = 0; i < length(bDensity2); i++){
-          printf("bDensity2: %f\n",bDensity2[i]);
-          printf("fc2: %f\n", fc2[i]);
-        }
-      }
       EXPECT_GT(sTemp3[k], -100); // Sense check
       EXPECT_LT(sTemp3[k], 100); // Sense check
     }

--- a/test/test_SW_Flow_lib_temp.cc
+++ b/test/test_SW_Flow_lib_temp.cc
@@ -508,7 +508,6 @@ namespace {
   // is only called in the soil_temperature function
   TEST(SWFlowTempTest, MainSoilTemperatureFunction_LyrMAX) {
     // *****  Test when nlyrs = MAX_LAYERS  ***** //
-
     pcg32_random_t soilTemp_rng;
     RandSeed(0,&soilTemp_rng);
 
@@ -529,8 +528,8 @@ namespace {
     double swc2[nlyrs2], swc_sat2[nlyrs2], bDensity2[nlyrs2], fc2[nlyrs2], wp2[nlyrs2];
 
     for (i = 0; i < nlyrs2; i++) {
-      bDensity2[i] = fmaxf(RandNorm(1.,0.5,&soilTemp_rng), 0.1); // greater than 0.1
-      fc2[i] = fmaxf(RandNorm(1.5, 0.5,&soilTemp_rng), 0.1); // greater than 0.1
+      bDensity2[i] = fmaxf(RandNorm(1.,0.5,&soilTemp_rng), 0.129); // greater than 0.129
+      fc2[i] = fmaxf(RandNorm(1.5, 0.5,&soilTemp_rng), 0.129); // greater than 0.129
       swc_sat2[i] = fc2[i] + 0.2; //swc_sat > fc2
       swc2[i] =  fmax(swc_sat2[i] - 0.3, 0.01); // swc_sat > swc > 0
       wp2[i] = fmaxf(fc2[i] - 0.6, 0.1); // wp < fc
@@ -582,6 +581,13 @@ namespace {
     for (k = 0; k < nlyrs2; k++)
     {
       //swprintf("\n k %u, sTemp3 %f", k, sTemp3[k]);
+      if (sTemp3[k] == 999){
+        //isPassing = false;
+        for(i = 0; i < length(bDensity2); i++){
+          printf("bDensity2: %f\n",bDensity2[i]);
+          printf("fc2: %f\n", fc2[i]);
+        }
+      }
       EXPECT_GT(sTemp3[k], -100); // Sense check
       EXPECT_LT(sTemp3[k], 100); // Sense check
     }

--- a/test/test_SW_Flow_lib_temp.cc
+++ b/test/test_SW_Flow_lib_temp.cc
@@ -509,7 +509,8 @@ namespace {
   TEST(SWFlowTempTest, MainSoilTemperatureFunction_LyrMAX) {
     // *****  Test when nlyrs = MAX_LAYERS  ***** //
     pcg32_random_t soilTemp_rng;
-    RandSeed(0,&soilTemp_rng);
+    RandSeed(0, &soilTemp_rng);
+
 
     unsigned int i, k;
 
@@ -525,14 +526,21 @@ namespace {
     double width2[] = {5, 5, 5, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 20, 20, 20, 20, 20, 20};
     double oldsTemp3[] = {1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4};
     double sTemp3[] = {1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4};
-    double swc2[nlyrs2], swc_sat2[nlyrs2], bDensity2[nlyrs2], fc2[nlyrs2], wp2[nlyrs2];
+    double bDensity2[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+    // we don't need soil texture, but we need SWC(sat), SWC(field capacity),
+    // and SWC(wilting point)
+    double swc2[nlyrs2], swc_sat2[nlyrs2], fc2[nlyrs2], wp2[nlyrs2];
 
     for (i = 0; i < nlyrs2; i++) {
-      bDensity2[i] = fmaxf(RandNorm(1.,0.5,&soilTemp_rng), 0.129); // greater than 0.129
-      fc2[i] = fmaxf(RandNorm(1.5, 0.5,&soilTemp_rng), 0.129); // greater than 0.129
-      swc_sat2[i] = fc2[i] + 0.2; //swc_sat > fc2
-      swc2[i] =  fmax(swc_sat2[i] - 0.3, 0.01); // swc_sat > swc > 0
-      wp2[i] = fmaxf(fc2[i] - 0.6, 0.1); // wp < fc
+      // SWC(wilting point): width > swc_wp > 0
+      wp2[i] = 0.1 * width2[i];
+      // SWC(field capacity): width > swc_fc > swc_wp
+      fc2[i] = fminf(width2[i], wp2[i] + 0.15 * width2[i]);
+      // SWC(saturation): width > swc_sat > swc_fc
+      swc_sat2[i] = fminf(width2[i], fc2[i] + 0.2 * width2[i]);
+      // SWC: swc_sat >= SWC > 0; here, swc_fc >= SWC >= swc_wp
+      swc2[i] = RandUniFloatRange(wp2[i], fc2[i], &soilTemp_rng);
+
       //swprintf("\n i %u, bDensity %f, swc_sat %f, fc %f, swc %f,  wp %f",
       //  i, bDensity2[i],  swc_sat2[i], fc2[i], swc2[i], wp2[i] );
     }


### PR DESCRIPTION
This fixes the problem but is a hack so while it fixes this so our CIs pass, further investigation is necessary for a more permanent fix later on. This just changes the random number lower bound for `bDensity2[i]` from `.1` to `.129`. It still generates the value of `bDensity2[i]` randomly.  