### PR TITLE
Update error handling in `SW_SWCbulk2SWPmatric`

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,33 @@ __Tests, documentation, and code__ form a trinity
     ```
     ASAN_OPTIONS=detect_leaks=1 LSAN_OPTIONS=suppressions=.LSAN_suppr.txt make clean test_severe test_run
     ```
+
+    The address sanitizer may not work correctly and/or fail, if you use the
+    `Apple-clang` version shipped with macOS X. You may need to build `clang`
+    yourself
+    (see [Sanitizer issue #1026](https://github.com/google/sanitizers/issues/1026)):
+    e.g.,
+    ```
+    sudo port install clang-8.0 clang-select
+    sudo port select --set clang mp-clang-8.0
+    ```
+    and to revert to the default version
+    ```
+    sudo port select --set clang none
+    ```
+    If you installed `clang` in a non-default location, then you
+    may need to also fix names of shared dynamic libraries in the test
+    executable if you get the error `... dyld: Library not loaded ...`, e.g.,
+    ```
+    # build test executable with clang and leak detection
+    CC=clang CXX=clang++ ASAN_OPTIONS=detect_leaks=1 LSAN_OPTIONS=suppressions=.LSAN_suppr.txt make clean test_severe
+    otool -L sw_test # check faulty library path
+    # figure out correct library path and insert with:
+    install_name_tool -change /opt/local/libexec/llvm-8.0/lib/libclang_rt.asan_osx_dynamic.dylib /opt/local/libexec/llvm-8.0/lib/clang/8.0.0/lib/darwin/libclang_rt.asan_osx_dynamic.dylib sw_test
+    # run tests
+    make test_run
+    ```
+
   * Informal and local integration tests example:
     1. Before coding, run `testing/` and produce reference output
         ```

--- a/SW_SoilWater.c
+++ b/SW_SoilWater.c
@@ -925,12 +925,18 @@ RealD SW_SnowDepth(RealD SWE, RealD snowdensity) {
 }
 
 /**
-  @brief Calculates the soil water potential or the soil water content of the current layer as a functions
-         of soil texture at the layer.
+  @brief Calculates the soil water potential from soil water content of the
+         n-th soil layer.
 
   The equation and its coefficients are based on a
   paper by Cosby,Hornberger,Clapp,Ginn,  in WATER RESOURCES RESEARCH
   June 1984.  Moisture retention data was fit to the power function.
+
+  The code assumes the following conditions (which are checked during data input):
+      * width > 0 which is checked by function `_read_layers`
+      * fractionGravel in [0, 1] which is checked by function `_read_layers`
+      * thetasMatric > 0 which is checked by function `water_eqn`
+      * bMatric != 0 which is checked by function `water_eqn`
 
   @param fractionGravel Fraction of soil containing gravel.
   @param swcBulk Soilwater content of the current layer (cm/layer)
@@ -974,17 +980,28 @@ RealD SW_SWCbulk2SWPmatric(RealD fractionGravel, RealD swcBulk, LyrIndex n) {
 	 **********************************************************************/
 
 	SW_LAYER_INFO *lyr = SW_Site.lyr[n];
-	float theta1, swp = 0.;
+	RealD theta1, theta2, swp = .0;
 
 	if (missing(swcBulk) || ZRO(swcBulk))
 		return 0.0;
 
 	if (GT(swcBulk, 0.0)) {
-		if (EQ(fractionGravel,1.0))
-			theta1 = 0.0;
-		else
-			theta1 = (swcBulk / lyr->width) * 100. / (1. - fractionGravel);
-		swp = lyr->psisMatric / powe(theta1/lyr->thetasMatric, lyr->bMatric) / BARCONV;
+		// we have soil moisture
+
+		// calculate matric VWC from bulk VWC
+		theta1 = (swcBulk / lyr->width) * 100. / (1. - fractionGravel);
+
+		// calculate (VWC / VWC(saturated)) ^ b
+		theta2 = powe(theta1 / lyr->thetasMatric, lyr->bMatric);
+
+		if (isnan(theta2) || ZRO(theta2)) {
+			LogError(logfp, LOGFATAL, "SW_SWCbulk2SWPmatric(): Year = %d, DOY=%d, Layer = %d:\n"
+					"\tinvalid value of (theta / theta(saturated)) ^ b = %f (must be != 0)\n",
+					SW_Model.year, SW_Model.doy, n, theta2);
+		} else {
+			swp = lyr->psisMatric / theta2 / BARCONV;
+		}
+
 	} else {
 		LogError(logfp, LOGFATAL, "Invalid SWC value (%.4f) in SW_SWC_swc2potential.\n"
 				"    Year = %d, DOY=%d, Layer = %d\n", swcBulk, SW_Model.year, SW_Model.doy, n);

--- a/test/test_SW_SoilWater.cc
+++ b/test/test_SW_SoilWater.cc
@@ -169,8 +169,12 @@ namespace{
     // this would also lead to theta1 == 0 and division by zero
     // this situation does normally not occur because it is
     // checked during input by function `_read_layers`
-    res = SW_SWCbulk2SWPmatric(1., SW_Site.lyr[n]->swcBulk_fieldcap, n);
-    EXPECT_DOUBLE_EQ(res, 0.); // SWP "ought to be" infinity [bar]
+    // Note: this situation is tested by the death test
+    // `SWSWCbulk2SWPmatricDeathTest`: we cannot test it here because the
+    // Address Sanitizer would complain with `UndefinedBehaviorSanitizer`
+    // see [issue #231](https://github.com/DrylandEcology/SOILWAT2/issues/231)
+    // res = SW_SWCbulk2SWPmatric(1., SW_Site.lyr[n]->swcBulk_fieldcap, n);
+    // EXPECT_DOUBLE_EQ(res, 0.); // SWP "ought to be" infinity [bar]
 
     // if theta(sat, matric; Cosby et al. 1984) == 0: would be division by zero
     // this situation does normally not occur because it is
@@ -180,7 +184,6 @@ namespace{
     res = SW_SWCbulk2SWPmatric(SW_Site.lyr[n]->fractionVolBulk_gravel, 0., n);
     EXPECT_DOUBLE_EQ(res, 0.); // SWP "ought to be" infinity [bar]
     SW_Site.lyr[n]->thetasMatric = help;
-
 
     // if lyr->width == 0: would be division by zero
     // this situation does normally not occur because it is
@@ -210,7 +213,9 @@ namespace{
 
     // if theta1 == 0 (i.e., gravel == 1) && lyr->bMatric == 0:
     // would be division by NaN
-    // this is in normally checked during input by function `water_eqn`
+    // note: this case is in normally prevented due to checks of inputs by
+    // function `water_eqn` for `bMatric` and function `_read_layers` for
+    // `gravelFraction`
     help = SW_Site.lyr[n]->bMatric;
     SW_Site.lyr[n]->bMatric = 0.;
     EXPECT_DEATH_IF_SUPPORTED(SW_SWCbulk2SWPmatric(


### PR DESCRIPTION
close #231

- function `SW_SWCbulk2SWPmatric`:
* improved documentation about expectations
* added checks against 0 and NaN of the term "(theta / theta(saturated)) ^ b" --> new possibility for fatal error

- function `_read_layers`
* added checks to guarantee that soil layer width is > 0

- function `water_eqn`
* added checks to guarantee that theta(saturated) is > 0

- unit tests `SWSWCbulk2SWPmatric`
* improved documentation
* removed nonsensical tests
* added several tests to check that 0 < wilting point < field capacity is maintained
* added tests for edge cases of gravel fraction, theta(sat), and layer width

- unit tests `SWSWCbulk2SWPmatricDeathTest`
* improved documentation
* removed nonsensical tests
* added test for new fatal error if term "(theta / theta(saturated)) ^ b" becomes  0 or NaN