### PR TITLE
Bugfix 273 usertime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ sw_test
 # Doxygen documentation files: they should be produced locally
 doc/html/*
 doc/log_doxygen.log
+doc/Doxyfile.bak
 
 # Binary files
 SOILWAT2

--- a/SW_Carbon.c
+++ b/SW_Carbon.c
@@ -212,7 +212,7 @@ void SW_CBN_read(void)
  * default value of 1.0. Multipliers are only calculated for the years that will
  * be simulated.
  */
-void calculate_CO2_multipliers(void) {
+void SW_CBN_init_run(void) {
   int k;
   TimeInt year,
     simendyr = SW_Model.endyr + SW_Model.addtl_yr;

--- a/SW_Carbon.h
+++ b/SW_Carbon.h
@@ -34,7 +34,7 @@ typedef struct {
 void SW_CBN_construct(void);
 void SW_CBN_deconstruct(void);
 void SW_CBN_read(void);
-void calculate_CO2_multipliers(void);
+void SW_CBN_init_run(void);
 
 
 #ifdef __cplusplus

--- a/SW_Control.c
+++ b/SW_Control.c
@@ -90,11 +90,12 @@ void SW_CTL_setup_model(const char *firstfile) {
 	SW_F_construct(firstfile);
 	SW_MDL_construct();
 	SW_WTH_construct();
-	// SW_SKY_construct() not need
 	// delay SW_MKV_construct() until we know from inputs whether we need it
+	// SW_SKY_construct() not need
 	SW_SIT_construct();
 	SW_VES_construct();
 	SW_VPD_construct();
+	// SW_FLW_construct() not needed
 	SW_OUT_construct();
 	SW_SWC_construct();
 	SW_CBN_construct();
@@ -112,11 +113,12 @@ void SW_CTL_setup_model(const char *firstfile) {
 void SW_CTL_clear_model(Bool full_reset) {
 	SW_F_deconstruct();
 	SW_MDL_deconstruct();
-	SW_WTH_deconstruct(); // also calls SW_MKV_deconstruct() if needed
-	// SW_SKY_deconstruct() not need
+	SW_WTH_deconstruct(); // calls SW_MKV_deconstruct() if needed
+	// SW_SKY_deconstruct() not needed
 	SW_SIT_deconstruct();
 	SW_VES_deconstruct();
 	SW_VPD_deconstruct();
+	// SW_FLW_deconstruct() not needed
 	SW_OUT_deconstruct(full_reset);
 	SW_SWC_deconstruct();
 	SW_CBN_deconstruct();
@@ -131,13 +133,14 @@ void SW_CTL_init_run(void) {
 	// SW_F_init_run() not needed
 	// SW_MDL_init_run() not needed
 	SW_WTH_init_run();
+	// SW_MKV_init_run() not needed
 	SW_SKY_init_run();
 	SW_SIT_init_run();
 	// SW_VES_init_run() not needed
 	SW_VPD_init_run();
 	SW_FLW_init_run();
-	// SW_OUT_init_run() handled separately so that SW_CTL_init_run() may be
-	//   useful for rSOILWAT2 and STEPWAT2 applications
+	// SW_OUT_init_run() handled separately so that SW_CTL_init_run() can be
+	//   useful for unit tests, rSOILWAT2, and STEPWAT2 applications
 	SW_SWC_init_run();
 	SW_CBN_init_run();
 }
@@ -205,14 +208,17 @@ void SW_CTL_run_current_year(void) {
 */
 static void _begin_year(void) {
 
+	// SW_F_new_year() not needed
 	SW_MDL_new_year(); // call first to set up time-related arrays for this year
 	SW_WTH_new_year();
-	//SW_SIT_new_year() not needed
+	// SW_MKV_new_year() not needed
 	SW_SKY_new_year(); // Update daily climate variables from monthly values
+	//SW_SIT_new_year() not needed
 	SW_VES_new_year();
 	SW_VPD_new_year(); // Dynamic CO2 effects on vegetation
 	// SW_FLW_new_year() not needed
 	SW_SWC_new_year();
+	// SW_CBN_new_year() not needed
 	SW_OUT_new_year();
 }
 

--- a/SW_Control.c
+++ b/SW_Control.c
@@ -25,6 +25,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include "generic.h"
+#include "Times.h"
 #include "filefuncs.h"
 #include "rands.h"
 #include "SW_Defines.h"
@@ -38,6 +39,8 @@
 #include "SW_VegEstab.h"
 #include "SW_VegProd.h"
 #include "SW_Weather.h"
+#include "SW_Markov.h"
+#include "SW_Sky.h"
 #include "SW_Carbon.h"
 
 /* =================================================== */
@@ -47,6 +50,7 @@ extern SW_MODEL SW_Model;
 extern SW_VEGESTAB SW_VegEstab;
 extern SW_SITE SW_Site;
 extern SW_VEGPROD SW_VegProd;
+extern SW_WEATHER SW_Weather;
 
 /* =================================================== */
 /*                Module-Level Declarations            */
@@ -79,20 +83,20 @@ void SW_CTL_main(void) {
   }
 } /******* End Main Loop *********/
 
-/**
-@brief Initialize all structures, simulating a constructor call.
+/** @brief Setup and construct model (independent of inputs)
  */
-void SW_CTL_init_model(const char *firstfile) {
+void SW_CTL_setup_model(const char *firstfile) {
 
 	SW_F_construct(firstfile);
 	SW_MDL_construct();
 	SW_WTH_construct();
+	// SW_SKY_construct() not need
+	// delay SW_MKV_construct() until we know from inputs whether we need it
 	SW_SIT_construct();
 	SW_VES_construct();
 	SW_VPD_construct();
 	SW_OUT_construct();
 	SW_SWC_construct();
-	SW_FLW_construct();
 	SW_CBN_construct();
 }
 
@@ -108,15 +112,36 @@ void SW_CTL_init_model(const char *firstfile) {
 void SW_CTL_clear_model(Bool full_reset) {
 	SW_F_deconstruct();
 	SW_MDL_deconstruct();
-	SW_WTH_deconstruct();
+	SW_WTH_deconstruct(); // also calls SW_MKV_deconstruct() if needed
+	// SW_SKY_deconstruct() not need
 	SW_SIT_deconstruct();
 	SW_VES_deconstruct();
 	SW_VPD_deconstruct();
 	SW_OUT_deconstruct(full_reset);
 	SW_SWC_deconstruct();
-	SW_FLW_deconstruct();
 	SW_CBN_deconstruct();
 }
+
+/** @brief Initialize simulation run (based on user inputs)
+  Note: Time will only be set up correctly while carrying out a
+  simulation year, i.e., after calling _begin_year()
+*/
+void SW_CTL_init_run(void) {
+
+	// SW_F_init_run() not needed
+	// SW_MDL_init_run() not needed
+	SW_WTH_init_run();
+	SW_SKY_init_run();
+	SW_SIT_init_run();
+	// SW_VES_init_run() not needed
+	SW_VPD_init_run();
+	SW_FLW_init_run();
+	// SW_OUT_init_run() handled separately so that SW_CTL_init_run() may be
+	//   useful for rSOILWAT2 and STEPWAT2 applications
+	SW_SWC_init_run();
+	SW_CBN_init_run();
+}
+
 
 /**
 @brief Calls 'SW_SWC_water_flow' for each day.
@@ -179,14 +204,16 @@ void SW_CTL_run_current_year(void) {
       that read input yearly or produce output need to have this call.
 */
 static void _begin_year(void) {
-	SW_MDL_new_year();
-	SW_WTH_new_year();
-	SW_SWC_new_year();
-	SW_VES_new_year();
-	SW_OUT_new_year();
 
-	// Dynamic CO2 effects
-	SW_VPD_init();
+	SW_MDL_new_year(); // call first to set up time-related arrays for this year
+	SW_WTH_new_year();
+	//SW_SIT_new_year() not needed
+	SW_SKY_new_year(); // Update daily climate variables from monthly values
+	SW_VES_new_year();
+	SW_VPD_new_year(); // Dynamic CO2 effects on vegetation
+	// SW_FLW_new_year() not needed
+	SW_SWC_new_year();
+	SW_OUT_new_year();
 }
 
 static void _begin_day(void) {
@@ -199,6 +226,7 @@ static void _end_day(void) {
 	SW_WTH_end_day();
 	SW_SWC_end_day();
 }
+
 /**
 @brief Reads inputs from disk and makes a print statement if there is an error
         in doing so.
@@ -222,10 +250,22 @@ void SW_CTL_read_inputs_from_disk(void) {
   if (debug) swprintf(" > 'model'");
   #endif
 
-  SW_WTH_read(); // inputs also `climate/cloud/sky` and `SW_MKV_setup` if turned on
+  SW_WTH_read();
   #ifdef SWDEBUG
-  if (debug) swprintf(" > 'weather' + 'climate'");
+  if (debug) swprintf(" > 'weather'");
   #endif
+
+  SW_SKY_read();
+  #ifdef SWDEBUG
+  if (debug) swprintf(" > 'climate'");
+  #endif
+
+  if (SW_Weather.use_markov) {
+    SW_MKV_setup();
+    #ifdef SWDEBUG
+    if (debug) swprintf(" > 'weather generator'");
+    #endif
+  }
 
   SW_VPD_read();
   #ifdef SWDEBUG
@@ -259,13 +299,6 @@ void SW_CTL_read_inputs_from_disk(void) {
   #endif
 }
 
-/**
-@brief Calls SW_CTL_read_inputs_from_disk and calculate_CO2_multipliers.
-*/
-void SW_CTL_obtain_inputs(void) {
-  SW_CTL_read_inputs_from_disk();
-  calculate_CO2_multipliers();
-}
 
 
 #ifdef DEBUG_MEM

--- a/SW_Control.h
+++ b/SW_Control.h
@@ -22,9 +22,9 @@
 extern "C" {
 #endif
 
-void SW_CTL_init_model(const char *firstfile);
+void SW_CTL_setup_model(const char *firstfile);
 void SW_CTL_clear_model(Bool full_reset);
-void SW_CTL_obtain_inputs(void);
+void SW_CTL_init_run(void);
 void SW_CTL_read_inputs_from_disk(void);
 void SW_CTL_main(void); /* main controlling loop for SOILWAT  */
 void SW_CTL_run_current_year(void);

--- a/SW_Flow.c
+++ b/SW_Flow.c
@@ -200,8 +200,8 @@ static void arrays2records(void);
 /**
 @brief Initialize global variables between consecutive calls to SOILWAT.
 */
-void SW_FLW_construct(void) {
-	/* 06/26/2013	(rjm) added function SW_FLW_construct() to init global variables between consecutive calls to SoilWat as dynamic library */
+void SW_FLW_init_run(void) {
+	/* 06/26/2013	(rjm) added function SW_FLW_init_run() to init global variables between consecutive calls to SoilWat as dynamic library */
 	int i, k;
 
 	soil_temp_init = 0;
@@ -241,11 +241,7 @@ void SW_FLW_construct(void) {
 		veg_int_storage[k] = 0.;
 	}
 }
-/**
-@brief This function is blank.
-*/
-void SW_FLW_deconstruct(void)
-{}
+
 
 /* *************************************************** */
 /* *************************************************** */

--- a/SW_Flow.h
+++ b/SW_Flow.h
@@ -6,8 +6,7 @@
 extern "C" {
 #endif
 
-void SW_FLW_construct(void);
-void SW_FLW_deconstruct(void);
+void SW_FLW_init_run(void);
 void SW_Water_Flow(void);
 
 

--- a/SW_Main.c
+++ b/SW_Main.c
@@ -66,17 +66,28 @@ int main(int argc, char **argv) {
 
 	init_args(argc, argv);
 
-	SW_CTL_init_model(_firstfile);
-	SW_CTL_obtain_inputs();
+  // setup and construct model (independent of inputs)
+	SW_CTL_setup_model(_firstfile);
 
+	// read user inputs
+	SW_CTL_read_inputs_from_disk();
+
+	// initialize simulation run (based on user inputs)
+	SW_CTL_init_run();
+
+  // initialize output
 	SW_OUT_set_ncol();
 	SW_OUT_set_colnames();
 	SW_OUT_create_files(); // only used with SOILWAT2
 
+  // run simulation: loop through each year
 	SW_CTL_main();
 
+  // finish-up output
 	SW_OUT_close_files(); // not used with rSOILWAT2
-	SW_CTL_clear_model(swTRUE); // de-allocate all memory
+
+	// de-allocate all memory
+	SW_CTL_clear_model(swTRUE);
 
 	return 0;
 }

--- a/SW_Markov.c
+++ b/SW_Markov.c
@@ -206,6 +206,8 @@ void SW_MKV_construct(void) {
 		 its `main` at the beginning of each iteration */
 	RandSeed(0, &markov_rng);
 
+	m->ppt_events = 0;
+
 	m->wetprob = (RealD *) Mem_Calloc(MAX_DAYS, s, "SW_MKV_construct");
 	m->dryprob = (RealD *) Mem_Calloc(MAX_DAYS, s, "SW_MKV_construct");
 	m->avg_ppt = (RealD *) Mem_Calloc(MAX_DAYS, s, "SW_MKV_construct");
@@ -215,6 +217,7 @@ void SW_MKV_construct(void) {
 	m->cfnw = (RealD *) Mem_Calloc(MAX_DAYS, s, "SW_MKV_construct");
 	m->cfnd = (RealD *) Mem_Calloc(MAX_DAYS, s, "SW_MKV_construct");
 }
+
 /**
 @brief Markov deconstructor; frees up memory space.
 */

--- a/SW_Markov.c
+++ b/SW_Markov.c
@@ -26,6 +26,7 @@
 #include "generic.h"
 #include "filefuncs.h"
 #include "rands.h"
+#include "Times.h"
 #include "myMemory.h"
 #include "SW_Defines.h"
 #include "SW_Files.h"
@@ -263,7 +264,7 @@ void SW_MKV_deconstruct(void)
 /**
 @brief Calculates precipitation and temperature.
 
-@param doy0 Day of the year.
+@param doy0 Day of the year (base0).
 @param *tmax Maximum temperature (&deg;C).
 @param *tmin Mininum temperature (&deg;C).
 @param *rain Rainfall (cm).
@@ -303,7 +304,7 @@ void SW_MKV_today(TimeInt doy0, RealD *tmax, RealD *tmin, RealD *rain) {
 	}
 
 	/* Calculate temperature */
-	week = Doy2Week(doy0 + 1);
+	week = doy2week(doy0 + 1);
 
 	mvnorm(tmax, tmin,
 		SW_Markov.u_cov[week][0],    // mean weekly maximum daily temp

--- a/SW_Model.c
+++ b/SW_Model.c
@@ -240,7 +240,7 @@ void SW_MDL_new_year() {
 	SW_Model.simyear = SW_Model.year + SW_Model.addtl_yr;
 
 	m->firstdoy = (year == m->startyr) ? m->startstart : 1;
-	m->lastdoy = (year == m->endyr) ? m->endend : Time_lastDOY();
+	m->lastdoy = (year == m->endyr) ? m->endend : Time_get_lastdoy_y(year);
 }
 
 /**

--- a/SW_Model.c
+++ b/SW_Model.c
@@ -81,11 +81,11 @@ void SW_MDL_construct(void) {
 	 * execution (better called clean() or something)
 	 * will need to free all allocated memory first
 	 * before clearing structure.
-	 *
 	 */
 	OutPeriod pd;
 
-	Time_init();
+	Time_init_model(); // values of time are correct only after Time_new_year()
+
 	ForEachOutPeriod(pd)
 	{
 		SW_Model.newperiod[pd] = swFALSE;
@@ -226,7 +226,7 @@ void SW_MDL_read(void) {
 /**
 @brief Sets up time structures and calls modules that have yearly init routines.
 */
-void SW_MDL_new_year() {
+void SW_MDL_new_year(void) {
 	/* =================================================== */
 	/* 1/24/02 - added code for partial start and end years
 	 */
@@ -250,8 +250,8 @@ void SW_MDL_new_day(void) {
 
 	OutPeriod pd;
 
-	SW_Model.month = doy2month(SW_Model.doy);
-	SW_Model.week = doy2week(SW_Model.doy); /* more often an index */
+	SW_Model.month = doy2month(SW_Model.doy); /* base0 */
+	SW_Model.week = doy2week(SW_Model.doy); /* base0; more often an index */
 
 	/* in this case, we've finished the daily loop and are about
 	 * to flush the output */

--- a/SW_Site.c
+++ b/SW_Site.c
@@ -82,9 +82,6 @@ SW_SITE SW_Site; /* declared here, externed elsewhere */
 extern Bool EchoInits;
 extern char const *key2veg[];
 
-#ifdef RSOILWAT
-extern Bool collectInData;
-#endif
 
 /* transpiration regions  shallow, moderately shallow,  */
 /* deep and very deep. units are in layer numbers. */
@@ -448,12 +445,7 @@ void SW_SIT_read(void) {
 	}
 
 	_read_layers();
-	#ifndef RSOILWAT
-		init_site_info();
-	#else
-		if(!collectInData)
-			init_site_info();
-	#endif
+
 	if (EchoInits)
 		_echo_inputs();
 }
@@ -589,17 +581,10 @@ static void _read_layers(void) {
 	CloseFile(&f);
 
 	/* n_layers set in _newlayer() */
-	#ifdef RSOILWAT
-		if (v->deepdrain && !collectInData) {
-			lyrno = _newlayer();
-			v->lyr[lyrno]->width = 1.0;
-		}
-	#else
-		if (v->deepdrain) {
-			lyrno = _newlayer();
-			v->lyr[lyrno]->width = 1.0;
-		}
-	#endif
+  if (v->deepdrain) {
+    lyrno = _newlayer();
+    v->lyr[lyrno]->width = 1.0;
+  }
 }
 
 /**
@@ -734,7 +719,7 @@ void set_soillayers(LyrIndex nlyrs, RealF *dmax, RealF *matricd, RealF *f_gravel
   derive_soilRegions(nRegions, regionLowerBounds);
 
   // Re-initialize site parameters based on new soil layers
-  init_site_info();
+  SW_SIT_init_run();
 }
 
 
@@ -815,7 +800,7 @@ void derive_soilRegions(int nRegions, RealD *regionLowerBounds){
 	}
 }
 
-void init_site_info(void) {
+void SW_SIT_init_run(void) {
 	/* =================================================== */
 	/* potentially this routine can be called whether the
 	 * layer data came from a file or a function call which
@@ -1022,15 +1007,9 @@ void SW_SIT_clear_layers(void) {
 
 	j = SW_Site.n_layers;
 
-	#ifdef RSOILWAT
-		if (s->deepdrain && !collectInData) {
-			j++;
-		}
-	#else
-		if (s->deepdrain) {
-				j++;
-		}
-	#endif
+  if (s->deepdrain) {
+      j++;
+  }
 
 	for (i = 0; i < j; i++) {
 		free(s->lyr[i]);

--- a/SW_Site.h
+++ b/SW_Site.h
@@ -139,10 +139,10 @@ typedef struct {
 void water_eqn(RealD fractionGravel, RealD sand, RealD clay, LyrIndex n);
 void calculate_soilBulkDensity(RealD matricDensity, RealD fractionGravel, LyrIndex n);
 
-void init_site_info(void);
-void SW_SIT_read(void);
 void SW_SIT_construct(void);
 void SW_SIT_deconstruct(void);
+void SW_SIT_read(void);
+void SW_SIT_init_run(void);
 void _echo_inputs(void);
 
 /* these used to be in Layers */

--- a/SW_Sky.h
+++ b/SW_Sky.h
@@ -42,9 +42,8 @@ typedef struct {
 } SW_SKY;
 
 void SW_SKY_read(void);
-void SW_SKY_init(double scale_sky[], double scale_wind[], double scale_rH[], double scale_transmissivity[]);
-void SW_SKY_construct(void);
-
+void SW_SKY_init_run(void);
+void SW_SKY_new_year(void);
 
 #ifdef __cplusplus
 }

--- a/SW_SoilWater.h
+++ b/SW_SoilWater.h
@@ -136,6 +136,7 @@ void SW_SWC_construct(void);
 void SW_SWC_deconstruct(void);
 void SW_SWC_new_year(void);
 void SW_SWC_read(void);
+void SW_SWC_init_run(void);
 void _read_swc_hist(TimeInt year);
 void SW_SWC_water_flow(void);
 void calculate_repartitioned_soilwater(void);

--- a/SW_VegEstab.c
+++ b/SW_VegEstab.c
@@ -190,16 +190,16 @@ void SW_VES_read(void) {
 
 	CloseFile(&f);
 
-	Init_SW_VegEstab();
+	SW_VegEstab_construct();
 
 	if (EchoInits)
 		_echo_VegEstab();
 }
 
 /**
-@brief Initializer for SW_VegEstab.
+@brief Construct SW_VegEstab variable
 */
-void Init_SW_VegEstab(void)
+void SW_VegEstab_construct(void)
 {
 	IntU i;
 
@@ -208,7 +208,7 @@ void Init_SW_VegEstab(void)
 
 	if (SW_VegEstab.count > 0) {
 		SW_VegEstab.p_accu[eSW_Year]->days = (TimeInt *) Mem_Calloc(
-			SW_VegEstab.count, sizeof(TimeInt), "Init_SW_VegEstab()");
+			SW_VegEstab.count, sizeof(TimeInt), "SW_VegEstab_construct()");
 	}
 }
 

--- a/SW_VegEstab.h
+++ b/SW_VegEstab.h
@@ -94,7 +94,7 @@ void SW_VES_read(void);
 void SW_VES_construct(void);
 void SW_VES_deconstruct(void);
 void SW_VES_init(void);
-void Init_SW_VegEstab(void);
+void SW_VegEstab_construct(void);
 void SW_VES_checkestab(void);
 void SW_VES_new_year(void);
 void _spp_init(unsigned int sppnum);

--- a/SW_VegProd.c
+++ b/SW_VegProd.c
@@ -59,9 +59,6 @@ changed _echo_inits() to now display the bare ground components in logfile.log
 /* --------------------------------------------------- */
 extern Bool EchoInits;
 extern SW_MODEL SW_Model;
-#ifdef RSOILWAT
-extern Bool collectInData;
-#endif
 
 #ifdef STEPWAT
 	#include "../sxw.h"
@@ -515,11 +512,6 @@ void SW_VPD_read(void) {
   SW_VPD_fix_cover();
 
 	CloseFile(&f);
-#ifdef RSOILWAT
-	if (!collectInData)
-#endif
-
-	SW_VPD_init();
 
 	if (EchoInits)
 		_echo_VegProd();
@@ -570,7 +562,6 @@ void SW_VPD_fix_cover(void)
 */
 void SW_VPD_construct(void) {
 	/* =================================================== */
-	int year, k;
 	OutPeriod pd;
 
 	// Clear the module structure:
@@ -586,8 +577,15 @@ void SW_VPD_construct(void) {
 				sizeof(SW_VEGPROD_OUTPUTS), "SW_VPD_construct()");
 		}
 	}
+}
 
-	/* initialize the co2-multipliers */
+
+
+void SW_VPD_init_run(void) {
+  TimeInt year;
+  int k;
+
+  /* Set co2-multipliers to default */
   for (year = 0; year < MAX_NYEAR; year++)
   {
     ForEachVegType(k)
@@ -597,6 +595,7 @@ void SW_VPD_construct(void) {
     }
   }
 }
+
 
 /**
 @brief Deconstructor for SW_VegProd.
@@ -638,10 +637,12 @@ void apply_biomassCO2effect(double new_biomass[], double biomass[], double multi
   for (i = 0; i < 12; i++) new_biomass[i] = (biomass[i] * multiplier);
 }
 
+
+
 /**
-@brief Set up vegetation parameters to be used in the 'watrflow' subroutine.
+@brief Update vegetation parameters for new year
 */
-void SW_VPD_init(void) {
+void SW_VPD_new_year(void) {
 	/* ================================================== */
 	/*
 	* History:

--- a/SW_VegProd.h
+++ b/SW_VegProd.h
@@ -245,9 +245,10 @@ typedef struct {
 
 
 void SW_VPD_read(void);
-void SW_VPD_init(void);
+void SW_VPD_new_year(void);
 void SW_VPD_fix_cover(void);
 void SW_VPD_construct(void);
+void SW_VPD_init_run(void);
 void SW_VPD_deconstruct(void);
 void apply_biomassCO2effect(double* new_biomass, double *biomass, double multiplier);
 RealD sum_across_vegtypes(RealD *x);

--- a/SW_Weather.c
+++ b/SW_Weather.c
@@ -421,9 +421,10 @@ Bool _read_weather_hist(TimeInt year) {
 
 	SW_WEATHER_HIST *wh = &SW_Weather.hist;
 	FILE *f;
-	int x, lineno = 0, doy, k = 0;
-	// TimeInt mon, j;
-	RealF tmpmax, tmpmin, ppt, acc = 0.0;
+	int x, lineno = 0, doy;
+	// TimeInt mon, j, k = 0;
+	RealF tmpmax, tmpmin, ppt;
+	// RealF acc = 0.0;
 
 	char fname[MAX_FILENAMESIZE];
 
@@ -451,24 +452,31 @@ Bool _read_weather_hist(TimeInt year) {
 		}
 
 		/* --- Make the assignments ---- */
-		doy--;
+		doy--; // base1 -> base0
 		wh->temp_max[doy] = tmpmax;
 		wh->temp_min[doy] = tmpmin;
 		wh->temp_avg[doy] = (tmpmax + tmpmin) / 2.0;
 		wh->ppt[doy] = ppt;
 
+    // Calculate annual average temperature based on historical input, i.e.,
+    // the `temp_year_avg` calculated here is prospective and unsuitable when
+    // the weather generator is used to generate values for the
+    // current simulation year, e.g., STEPWAT2
+		/*
 		if (!missing(tmpmax) && !missing(tmpmin)) {
 			k++;
 			acc += wh->temp_avg[doy];
 		}
+		*/
 	} /* end of input lines */
 
-  // Calculate annual average temperature
-  // TODO: current code does not use `temp_year_avg` value -> remove?
-	wh->temp_year_avg = acc / (k + 0.0);
+  // Calculate annual average temperature based on historical input
+	// wh->temp_year_avg = acc / (k + 0.0);
 
-  // Calculate monthly average temperature
-  // TODO: current code does not use `temp_month_avg` value -> remove?
+  // Calculate monthly average temperature based on historical input
+  // the `temp_month_avg` calculated here is prospective and unsuitable when
+  // the weather generator is used to generate values for the
+  // current simulation year, e.g., STEPWAT2
   /*
 	for (mon = Jan; mon <= Dec; i++) {
 	  k = Time_days_in_month(mon);

--- a/SW_Weather.c
+++ b/SW_Weather.c
@@ -63,7 +63,11 @@ extern SW_MODEL SW_Model;
 
 SW_WEATHER SW_Weather; /* declared here, externed elsewhere */
 
-Bool weth_found; /* swTRUE=success reading this years weather file */
+/** `swTRUE`/`swFALSE` if historical daily meteorological inputs
+    are available/not available for the current simulation year
+*/
+Bool weth_found;
+
 RealD *runavg_list; /* used in run_tmp_avg() */
 
 /* =================================================== */
@@ -235,8 +239,13 @@ void SW_WTH_init_run(void) {
 	SW_Weather.soil_inf = 0.;
 }
 
-/**
-@brief Sets new year for SW_Weather.
+/** @brief Sets up daily meteorological inputs for current simulation year
+
+    @sideeffect
+      \ref weth_found is set to `swTRUE` if historical daily meteorological inputs
+      are successfully located;
+      otherwise, \ref weth_found is `swFALSE` and the weather generator
+      is required to produce daily meteorological inputs.
 */
 void SW_WTH_new_year(void) {
 
@@ -244,6 +253,7 @@ void SW_WTH_new_year(void) {
 
 	if (SW_Model.year < SW_Weather.yr.first) {
 		weth_found = swFALSE;
+
 	} else {
 		#ifdef RSOILWAT
 		weth_found = onSet_WTH_DATA_YEAR(SW_Model.year);
@@ -256,7 +266,7 @@ void SW_WTH_new_year(void) {
 		LogError(
 		  logfp,
 		  LOGFATAL,
-		  "Markov Simulator turned off and weather file found not for year %d",
+		  "Markov Simulator turned off and weather file not found for year %d",
 		  SW_Model.year
 		);
 	}
@@ -397,11 +407,19 @@ void SW_WTH_read(void) {
 	/* else we assume weather files match model run years */
 }
 
-/**
-@brief Read the historical (measured) weather files.  Format is day-of-month,
-      month number, year, doy, mintemp, maxtemp (ppt). Temperatures in (&deg;C).
 
-@param year
+/** @brief Read the historical (observed) weather file for a simulation year.
+
+    The naming convection of the weather input files:
+      `[weather-data path/][weather-file prefix].[year]`
+
+    Format of a input file (white-space separated values):
+      `doy maxtemp(&deg;C) mintemp (&deg;C) precipitation (cm)`
+
+    @param year
+
+    @return `swTRUE`/`swFALSE` if historical daily meteorological inputs are
+      successfully/unsuccessfully read in.
 */
 Bool _read_weather_hist(TimeInt year) {
 	/* =================================================== */

--- a/SW_Weather.c
+++ b/SW_Weather.c
@@ -60,7 +60,6 @@
 /*                  Global Variables                   */
 /* --------------------------------------------------- */
 extern SW_MODEL SW_Model;
-extern SW_MARKOV SW_Markov;
 
 SW_WEATHER SW_Weather; /* declared here, externed elsewhere */
 
@@ -228,8 +227,6 @@ void SW_WTH_init_run(void) {
 	 * (doy=1) and are below the critical temps for freezing
 	 * and with ppt=0 there's nothing to freeze.
 	 */
-	SW_Markov.ppt_events = 0;
-
 	SW_Weather.now.temp_max[Today] = SW_Weather.now.temp_min[Today] = 0.;
 	SW_Weather.now.ppt[Today] = SW_Weather.now.rain[Today] = 0.;
 	SW_Weather.snow = SW_Weather.snowmelt = SW_Weather.snowloss = 0.;

--- a/SW_Weather.c
+++ b/SW_Weather.c
@@ -366,7 +366,7 @@ void SW_WTH_read(void) {
 			w->use_markov = itob(atoi(inbuf));
 			break;
 		case 4:
-			w->yr.first = YearTo4Digit(atoi(inbuf));
+			w->yr.first = yearto4digit(atoi(inbuf));
 			break;
 		case 5:
 			w->days_in_runavg = atoi(inbuf);

--- a/SW_Weather.h
+++ b/SW_Weather.h
@@ -91,7 +91,7 @@ typedef struct {
 void SW_WTH_read(void);
 Bool _read_weather_hist(TimeInt year);
 void _clear_hist_weather(void);
-void SW_WTH_init(void);
+void SW_WTH_init_run(void);
 void SW_WTH_construct(void);
 void SW_WTH_deconstruct(void);
 void SW_WTH_new_day(void);

--- a/SW_Weather.h
+++ b/SW_Weather.h
@@ -47,8 +47,8 @@ typedef struct {
 
 typedef struct {
 	/* comes from historical weather files */
-	RealD temp_max[MAX_DAYS], temp_min[MAX_DAYS], temp_avg[MAX_DAYS], ppt[MAX_DAYS],
-	temp_month_avg[MAX_MONTHS], temp_year_avg;
+	RealD temp_max[MAX_DAYS], temp_min[MAX_DAYS], temp_avg[MAX_DAYS], ppt[MAX_DAYS];
+	// RealD temp_month_avg[MAX_MONTHS], temp_year_avg; // currently not used
 } SW_WEATHER_HIST;
 
 /* accumulators for output values hold only the */

--- a/Times.c
+++ b/Times.c
@@ -30,24 +30,21 @@
 #include "generic.h"
 #include "Times.h"
 
-#define MAX_DAYSTR 10
+
 /* =================================================== */
 /*                Module-Level Variables               */
 /* --------------------------------------------------- */
 
-/* cum_monthdays has one extra for the Doy2Month macro
- * to be able to determine the 12th month.  */
-static TimeInt monthdays[12] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
-static TimeInt days_in_month[MAX_MONTHS], cum_monthdays[MAX_MONTHS + 1];
 
-static time_t _timestamp;
-static struct tm _tym; /* "current" time for the code */
+static TimeInt
+  /* mark February to catch use cases without properly setting arrays via
+    a call to Time_new_year() */
+  monthdays[12] = { 31, NoDay, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
 
-static char _outs[MAX_DAYSTR + 1]; /* for day/month string funcs */
+static TimeInt
+  days_in_month[MAX_MONTHS], /* number of days per month for "current" year */
+  cum_monthdays[MAX_MONTHS]; /* monthly cumulative number of days for "current" year */
 
-static void _reinit(void);
-static TimeInt _yearto4digit_t(void);
-static void _remaketime(void);
 
 /* =================================================== */
 /* =================================================== */
@@ -55,442 +52,125 @@ static void _remaketime(void);
 /* --------------------------------------------------- */
 
 /**
-@brief Initializes the time.
+@brief Setup time array.
 */
-void Time_init(void) {
-	/* =================================================== */
+void Time_init_model(void) {
+  // called by `SW_MDL_construct()`
 
 	memcpy(days_in_month, monthdays, sizeof(TimeInt) * MAX_MONTHS);
-	memset(cum_monthdays, 0, sizeof(TimeInt) * MAX_MONTHS);
-	cum_monthdays[NoMonth] = 1000;
-
-	Time_now();
 }
 
 /**
-@brief Sets current structure to present time.
-*/
-void Time_now(void) {
-	/* =================================================== */
+  @brief Prepares information for a new year -- considering leap/noleap years.
 
-	time_t x = time(NULL );
+  This function must be called prior to using Time_days_in_month(),
+  doy2month(), doy2mday(), or interpolate_monthlyValues().
 
-	memcpy(&_tym, (struct tm *) localtime(&x), sizeof(struct tm));
-
-  /*
-  // Initialize to Jan 1, 1970
-  _tym.tm_year = 70;
-  _tym.tm_mon = 0;
-  _tym.tm_mday = 1;
-  _tym.tm_hour = 0;
-  _tym.tm_min = 0;
-  _tym.tm_sec = 0;
-  mktime(&_tym);
-
-  //printf("%s\n", asctime(&_tym));
-  */
-	_reinit();
-}
-
-/**
-@brief Makes a new year.
+  @param year A (Gregorian) calendar year; not abbreviated.
 */
 void Time_new_year(TimeInt year) {
+  // called by `SW_MDL_new_year()`
 
-	year = yearto4digit(year);
-	_tym.tm_year = (int) year - 1900;
-	_reinit();
-	Time_set_doy(1);
+	/* set the year's month-days arrays depending on leap/noleap year */
+	TimeInt m;
 
-}
+	days_in_month[Feb] = isleapyear(year) ? 29 : 28;
 
-/**
-@brief Sets current day to tomorrow and changes the year if needed.
-*/
-void Time_next_day(void) {
-
-	if ((TimeInt) _tym.tm_yday == cum_monthdays[Dec]) {
-		_tym.tm_year++;
-		_reinit();
-	} else {
-		Time_set_doy(++_tym.tm_yday);
+	cum_monthdays[Jan] = days_in_month[Jan];
+	for (m = Feb; m < NoMonth; m++)
+	{
+		cum_monthdays[m] = days_in_month[m] + cum_monthdays[m - 1];
 	}
-
-}
-
-/**
-@brief Sets the internal yearday and year to match year. Makes sure the month
-			and month-day are correct for yearday. <br>
-			Does not change current doy, to do this use new_year()
-@param year
-*/
-void Time_set_year(TimeInt year) {
-
-	year = yearto4digit(year);
-
-	if (year == _yearto4digit_t())
-		return;
-
-	_tym.tm_year = (int) year - 1900;
-	_reinit();
-	_tym.tm_mday = (int) doy2mday((TimeInt) _tym.tm_yday);
-	_tym.tm_mon = (int) doy2month((TimeInt) _tym.tm_yday);
-	_remaketime();
-
-}
-
-/**
-@brief Sets the day of the year.
-
-@param doy Day of the year.
-*/
-void Time_set_doy(const TimeInt doy) {
-	/* =================================================== */
-
-	_tym.tm_yday = (int) doy;
-	_tym.tm_mday = (int) doy2mday(doy);
-	_tym.tm_mon = (int) doy2month(doy);
-	_remaketime();
-}
-
-/**
-@brief Sets the mday.
-
-@param day
-*/
-void Time_set_mday(const TimeInt day) {
-
-	_tym.tm_mday = (int) day;
-	_remaketime();
-
-}
-
-/**
-@brief Sets the month.
-
-@param mon Month.
-*/
-void Time_set_month(const TimeInt mon) {
-
-	_tym.tm_mon = (int) mon;
-	_remaketime();
-
-}
-
-/**
-@brief Returns the timestamp of the 'model' time. To get actual timestamp,
-			call Time_timestamp_now().
-@return _timestamp
-*/
-time_t Time_timestamp(void) {
-	/* returns the timestamp of the "model" time.  to get
-	 * actual timestamp, call Time_timestamp_now()
-	 */
-	return _timestamp;
-
-}
-
-/**
-@brief Returns the timestamp of the current real time.
-
-@return time
-*/
-time_t Time_timestamp_now(void) {
-	/* =================================================== */
-	/* returns the timestamp of the current real time.
-	 */
-	return time(NULL );
-
 }
 
 
 /**
-@brief Returns days in a given month.
+  @brief Determine how many days a month has.
 
-@param month
+  @param month Number of month (base0) [Jan-Dec = 0-11]
 
-@return days_in_month
+  @return Number of days [1-366].
 */
 TimeInt Time_days_in_month(TimeInt month) {
+  // called by `average_for()`
 
 	return days_in_month[month];
 }
 
-/**
-@brief Returns a time value.
-
-@return (asctime(&_tym))
-*/
-char *Time_printtime(void) {
-
-	return (asctime(&_tym));
-}
 
 /**
-@brief Time formatted to daynmshort.
+  @brief Determine last day of the year, checks for leapyear.
 
-@return _outs
-*/
-char *Time_daynmshort(void) {
-	/* =================================================== */
-
-	strftime(_outs, MAX_DAYSTR, "%a", &_tym);
-	return _outs;
-}
-
-/**
-@brief doy2mday and doy2month formatted to daynmshort_d.
-
-@return _outs
-*/
-char *Time_daynmshort_d(const TimeInt doy) {
-	/* =================================================== */
-	struct tm tmp = _tym;
-
-	tmp.tm_mday = doy2mday(doy);
-	tmp.tm_mon = doy2month(doy);
-	strftime(_outs, MAX_DAYSTR, "%a", &tmp);
-	return _outs;
-}
-
-/**
-@brief mday and mon formatted to daynmshort_d.
-
-@return _outs
-*/
-char *Time_daynmshort_dm(const TimeInt mday, const TimeInt mon) {
-	/* =================================================== */
-	struct tm tmp = _tym;
-
-	tmp.tm_mday = mday;
-	tmp.tm_mon = mon;
-	strftime(_outs, MAX_DAYSTR, "%a", &tmp);
-	return _outs;
-}
-
-/**
-@brief Time formatting.
-
-@return _outs
-*/
-char *Time_daynmlong(void) {
-	/* =================================================== */
-
-	strftime(_outs, MAX_DAYSTR, "%A", &_tym);
-	return _outs;
-}
-
-/**
-@brief Time formatting.
-
-@param doy Day of the year.
-
-@return _outs
-*/
-char *Time_daynmlong_d(const TimeInt doy) {
-	/* =================================================== */
-	struct tm tmp = _tym;
-
-	tmp.tm_mday = doy2mday(doy);
-	tmp.tm_mon = doy2month(doy);
-	strftime(_outs, MAX_DAYSTR, "%A", &tmp);
-	return _outs;
-}
-
-/**
-@brief Time formatting.
-
-@param mday day in Month, day format.
-@param mon Month.
-
-@return _outs
-*/
-char *Time_daynmlong_dm(const TimeInt mday, const TimeInt mon) {
-	/* =================================================== */
-	struct tm tmp = _tym;
-
-	tmp.tm_mday = mday;
-	tmp.tm_mon = mon;
-	strftime(_outs, MAX_DAYSTR, "%A", &tmp);
-	return _outs;
-}
-
-/* =================================================== */
-/* simple methods to return state values */
-
-/**
-@brief Gets the year.
-
-@return _yearto4digit_t()
-*/
-TimeInt Time_get_year(void) {
-	return _yearto4digit_t();
-}
-
-/**
-@brief Gets day of the year.
-
-@return (TimeInt) _tym.tm_yday
-*/
-TimeInt Time_get_doy(void) {
-	return (TimeInt) _tym.tm_yday;
-}
-
-/**
-@brief Gets the month.
-
-@return (TimeInt) _tym.tm_mon
-*/
-TimeInt Time_get_month(void) {
-	return (TimeInt) _tym.tm_mon;
-}
-
-/**
-@brief Gets the week.
-
-@return doy2week(_tym.tm_yday)
-*/
-TimeInt Time_get_week(void) {
-	return doy2week(_tym.tm_yday);
-}
-/**
-@brief Gets mday.
-
-@return (TimeInt) _tym.tm_mday
-*/
-TimeInt Time_get_mday(void) {
-	return (TimeInt) _tym.tm_mday;
-}
-
-/**
-@brief Gets the hour.
-
-@return (TimeInt) _tym.tm_hour
-*/
-TimeInt Time_get_hour(void) {
-	return (TimeInt) _tym.tm_hour;
-}
-
-/**
-@brief Gets current minutes.
-
-@return (TimeInt) _tym.tm_min
-*/
-TimeInt Time_get_mins(void) {
-	return (TimeInt) _tym.tm_min;
-}
-
-/**
-@brief Gets current seconds.
-
-@return (TimeInt) _tym.tm_sec
-*/
-TimeInt Time_get_secs(void) {
-	return (TimeInt) _tym.tm_sec;
-}
-
-
-/**
-@brief Gets last day of the year, checks for leapyear.
-
-@return 366 or 365
+  @return 366 or 365
 */
 TimeInt Time_get_lastdoy_y(TimeInt year) {
 	return isleapyear(year) ? 366 : 365;
 }
 
-/* =================================================== */
-/* =================================================== */
-/* These next six tend to get called a lot and they're
- * pretty independent of the current time, so I'm
- * removing the preceeding Time_ to shorten the calls in
- * the code
- */
 
 /**
-@brief Doy is base1, mon becomes base0 month containing doy.
-  	note mon can't become 13, so any day after Nov 30
-  	returns Dec.
-@param doy Day of the year.
-@return mon for the month.
+  @brief Determine month of the year
+
+  @param doy Day of the year (base1) [1-366].
+  @return Month (base0) [Jan-Dec = 0-11].
+
 */
 TimeInt doy2month(const TimeInt doy) {
-	/* =================================================== */
-	/* doy is base1, mon becomes base0 month containing doy.
-	 * note mon can't become 13, so any day after Nov 30
-	 * returns Dec.
-	 */
 	TimeInt mon;
 
 	for (mon = Jan; mon < Dec && doy > cum_monthdays[mon]; mon++)
 		;
 	return mon;
-
 }
 
 /**
-@brief Doy is base1, mon becomes base0 month containing doy.
-  	note mon can't become 13, so any day after Nov 30
-  	returns Dec.
-@param doy Day of the year.
-@return doy in mday format.
+  @brief Determine day of the month
+
+  @param doy Day of the year (base1) [1-366].
+  @return Day of the month [1-31].
 */
 TimeInt doy2mday(const TimeInt doy) {
-
   return (doy <= days_in_month[Jan]) ? doy : doy - cum_monthdays[doy2month(doy) - 1];
 }
 
 /**
-@brief Enter with doy base1 and return base0 number of 7 day
-  	periods (weeks) since beginning of year. Note that week
-  	number doesn't necessarily correspond to the calendar week.
-  	Jan 1 starts on different days depending on the year.  In
-  	2000 it started on Sun: each year later it starts 1 day
-  	later, each year earlier it started one day earlier.
-@param doy Day of the year.
-@return (TimeInt) ((yr > 100) ? yr : (yr < 50) ? 2000 + yr : 1900 + yr)
+  @brief Determine 7-day period ("week") of the year
+
+  @param doy Day of the year (base1) [1-366].
+  @return Week number (base0) [0-51].
 */
 TimeInt doy2week(TimeInt doy) {
-
 	return ((TimeInt) (((doy) - 1) / WKDAYS));
 }
 
 /**
-@brief Returns the year, but with the capability to handle Y2K problems.
+  @brief Formatting values as (Gregorian) calendar year.
 
-@return TimeInt
+  To handle legacy Y2K problems, it maps values of 0-50 to 2000-2050,
+  values of 51-100 to 1951-2000, and passes through all other values unchanged.
+  Useful for formatting user inputs.
+
+  @return A value corresponding to a (Gregorian) calendar year.
 */
 TimeInt yearto4digit(TimeInt yr) {
-
+  // called by SW_MDL_read(), SW_WTH_read(), SW_SWC_read()
 	return (TimeInt) ((yr > 100) ? yr : (yr < 50) ? 2000 + yr : 1900 + yr);
-
 }
 
-/**
-@brief Is it a leap year? Checks current year.
-
-@return Yes or no.
-*/
-Bool isleapyear_now(void) {
-	/* =================================================== */
-	/* check current year from struct tm */
-	return isleapyear(_yearto4digit_t());
-}
 
 /**
-@brief Is it a leap year?
+  @brief Is a (Gregorian) calendar year a leap year?
 
-@return Yes or no.
+  @param year A (Gregorian) calendar year.
+  @return A Boolean TRUE/FALSE.
 */
 Bool isleapyear(const TimeInt year) {
-	/* =================================================== */
+	TimeInt t = (year / 100) * 100;
 
-	int yr = (year > 100) ? year : yearto4digit(year);
-	int t = (yr / 100) * 100;
-
-	return (Bool) (((yr % 4) == 0) && (((t) != yr) || ((yr % 400) == 0)));
-
+	return (Bool) (((year % 4) == 0) && (((t) != year) || ((year % 400) == 0)));
 }
+
+
 /**
  @brief Linear interpolation of monthly value; monthly values are assumed to representative for the 15th of a month
 
@@ -532,35 +212,4 @@ void interpolate_monthlyValues(double monthlyValues[], double dailyValues[]) {
 			  * (mday - 15.) / nmdays;
 		}
 	}
-}
-
-/* =================================================== */
-/* =================================================== */
-/*           "Private" Function Definitions            */
-/* --------------------------------------------------- */
-
-static void _reinit(void) {
-	/* --------------------------------------------------- */
-	/* reset the year's month-days arrays */
-	TimeInt m;
-
-	days_in_month[Feb] = (isleapyear_now()) ? 29 : 28;
-	cum_monthdays[Jan] = days_in_month[Jan];
-	for (m = Feb; m < NoMonth; m++)
-		cum_monthdays[m] = days_in_month[m] + cum_monthdays[m - 1];
-}
-
-static TimeInt _yearto4digit_t(void) {
-	/* --------------------------------------------------- */
-	/* convert (struct tm).tm_year to 4 digit */
-
-	return (TimeInt) (_tym.tm_year + 1900);
-
-}
-
-static void _remaketime(void) {
-	/* --------------------------------------------------- */
-
-	_timestamp = mktime(&_tym);
-
 }

--- a/Times.c
+++ b/Times.c
@@ -512,7 +512,7 @@ Bool isleapyear(const TimeInt year) {
    only sub-setted by base1 objects in the model.
  **/
 void interpolate_monthlyValues(double monthlyValues[], double dailyValues[]) {
-	unsigned int doy, mday, month, month2 = NoMonth;
+	unsigned int doy, mday, month, month2 = NoMonth, nmdays;
 	double sign = 1.;
 
 	for (doy = 1; doy <= MAX_DAYS; doy++) {
@@ -521,16 +521,22 @@ void interpolate_monthlyValues(double monthlyValues[], double dailyValues[]) {
 
 		if (mday == 15) {
 			dailyValues[doy] = monthlyValues[month];
+
 		} else {
 			if (mday >= 15) {
 				month2 = (month == Dec) ? Jan : month + 1;
 				sign = 1;
+				nmdays = days_in_month[month];
+
 			} else {
 				month2 = (month == Jan) ? Dec : month - 1;
 				sign = -1;
+				nmdays = days_in_month[month2];
 			}
 
-			dailyValues[doy] = monthlyValues[month] + sign * (monthlyValues[month2] - monthlyValues[month]) / (monthdays[month]) * (mday - 15.);
+			dailyValues[doy] = monthlyValues[month]
+			  + sign * (monthlyValues[month2] - monthlyValues[month])
+			  * (mday - 15.) / nmdays;
 		}
 	}
 }

--- a/Times.c
+++ b/Times.c
@@ -73,10 +73,23 @@ void Time_init(void) {
 */
 void Time_now(void) {
 	/* =================================================== */
+
 	time_t x = time(NULL );
 
 	memcpy(&_tym, (struct tm *) localtime(&x), sizeof(struct tm));
 
+  /*
+  // Initialize to Jan 1, 1970
+  _tym.tm_year = 70;
+  _tym.tm_mon = 0;
+  _tym.tm_mday = 1;
+  _tym.tm_hour = 0;
+  _tym.tm_min = 0;
+  _tym.tm_sec = 0;
+  mktime(&_tym);
+
+  //printf("%s\n", asctime(&_tym));
+  */
 	_reinit();
 }
 

--- a/Times.c
+++ b/Times.c
@@ -37,7 +37,6 @@
 
 /* cum_monthdays has one extra for the Doy2Month macro
  * to be able to determine the 12th month.  */
-static TimeInt last_doy;
 static TimeInt monthdays[12] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
 static TimeInt days_in_month[MAX_MONTHS], cum_monthdays[MAX_MONTHS + 1];
 
@@ -110,7 +109,7 @@ void Time_new_year(TimeInt year) {
 */
 void Time_next_day(void) {
 
-	if ((TimeInt) _tym.tm_yday == last_doy) {
+	if ((TimeInt) _tym.tm_yday == cum_monthdays[Dec]) {
 		_tym.tm_year++;
 		_reinit();
 	} else {
@@ -204,15 +203,6 @@ time_t Time_timestamp_now(void) {
 
 }
 
-/**
-@brief Returns the last day of the year.
-
-@return cum_monthdays[Dec]
-*/
-TimeInt Time_lastDOY(void) {
-
-	return cum_monthdays[Dec];
-}
 
 /**
 @brief Returns days in a given month.
@@ -399,14 +389,6 @@ TimeInt Time_get_secs(void) {
 	return (TimeInt) _tym.tm_sec;
 }
 
-/**
-@brief Gets the last day of the year.
-
-@return last_doy
-*/
-TimeInt Time_get_lastdoy(void) {
-	return last_doy;
-}
 
 /**
 @brief Gets last day of the year, checks for leapyear.
@@ -566,8 +548,6 @@ static void _reinit(void) {
 	cum_monthdays[Jan] = days_in_month[Jan];
 	for (m = Feb; m < NoMonth; m++)
 		cum_monthdays[m] = days_in_month[m] + cum_monthdays[m - 1];
-
-	last_doy = cum_monthdays[Dec];
 }
 
 static TimeInt _yearto4digit_t(void) {

--- a/Times.c
+++ b/Times.c
@@ -442,9 +442,7 @@ TimeInt doy2month(const TimeInt doy) {
 */
 TimeInt doy2mday(const TimeInt doy) {
 
-	TimeInt mon = doy2month(doy);
-	return (mon == Jan) ? doy : doy - cum_monthdays[mon - 1];
-
+  return (doy <= days_in_month[Jan]) ? doy : doy - cum_monthdays[doy2month(doy) - 1];
 }
 
 /**

--- a/Times.h
+++ b/Times.h
@@ -69,6 +69,7 @@ extern "C" {
 #define Dec 11
 #define NoMonth 12
 
+#define NoDay 999
 
 typedef unsigned int TimeInt;
 
@@ -82,41 +83,17 @@ typedef unsigned int TimeInt;
  */
 
 /*=======  SUBROUTINES ========*/
-void Time_init(void);
-void Time_now(void);
+void Time_init_model(void);
 void Time_new_year(TimeInt year);
-void Time_next_day(void);
-void Time_set_year(TimeInt year);
-void Time_set_doy(const TimeInt doy);
-void Time_set_mday(const TimeInt day);
-void Time_set_month(const TimeInt mon);
-time_t Time_timestamp(void);
-time_t Time_timestamp_now(void);
+
 TimeInt Time_days_in_month(TimeInt month);
-
-char *Time_printtime(void);
-char *Time_daynmshort(void);
-char *Time_daynmshort_d(const TimeInt doy);
-char *Time_daynmshort_dm(const TimeInt mday, const TimeInt mon);
-char *Time_daynmlong(void);
-char *Time_daynmlong_d(const TimeInt doy);
-char *Time_daynmlong_dm(const TimeInt mday, const TimeInt mon);
-
-TimeInt Time_get_year(void);
-TimeInt Time_get_doy(void);
-TimeInt Time_get_month(void);
-TimeInt Time_get_week(void);
-TimeInt Time_get_mday(void);
-TimeInt Time_get_hour(void);
-TimeInt Time_get_mins(void);
-TimeInt Time_get_secs(void);
 TimeInt Time_get_lastdoy_y(TimeInt year);
 
 TimeInt doy2month(const TimeInt doy);
 TimeInt doy2mday(const TimeInt doy);
 TimeInt doy2week(TimeInt doy);
 TimeInt yearto4digit(TimeInt yr);
-Bool isleapyear_now(void);
+
 Bool isleapyear(const TimeInt year);
 
 void interpolate_monthlyValues(double monthlyValues[], double dailyValues[]);

--- a/Times.h
+++ b/Times.h
@@ -93,7 +93,6 @@ void Time_set_month(const TimeInt mon);
 time_t Time_timestamp(void);
 time_t Time_timestamp_now(void);
 TimeInt Time_days_in_month(TimeInt month);
-TimeInt Time_lastDOY(void);
 
 char *Time_printtime(void);
 char *Time_daynmshort(void);
@@ -111,7 +110,6 @@ TimeInt Time_get_mday(void);
 TimeInt Time_get_hour(void);
 TimeInt Time_get_mins(void);
 TimeInt Time_get_secs(void);
-TimeInt Time_get_lastdoy(void);
 TimeInt Time_get_lastdoy_y(TimeInt year);
 
 TimeInt doy2month(const TimeInt doy);

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1,4 +1,4 @@
-# Doxyfile 1.8.16
+# Doxyfile 1.8.17
 
 # This file describes the settings to be used by the documentation system
 # doxygen (www.doxygen.org) for a project.
@@ -309,7 +309,7 @@ OPTIMIZE_OUTPUT_SLICE  = NO
 # parses. With this tag you can assign which parser to use for a given
 # extension. Doxygen has a built-in mapping, but you can override or extend it
 # using this tag. The format is ext=language, where ext is a file extension, and
-# language is one of the parsers supported by doxygen: IDL, Java, Javascript,
+# language is one of the parsers supported by doxygen: IDL, Java, JavaScript,
 # Csharp (C#), C, C++, D, PHP, md (Markdown), Objective-C, Python, Slice,
 # Fortran (fixed format Fortran: FortranFixed, free formatted Fortran:
 # FortranFree, unknown formatted Fortran: Fortran. In the later case the parser
@@ -535,8 +535,8 @@ HIDE_UNDOC_MEMBERS     = NO
 HIDE_UNDOC_CLASSES     = NO
 
 # If the HIDE_FRIEND_COMPOUNDS tag is set to YES, doxygen will hide all friend
-# (class|struct|union) declarations. If set to NO, these declarations will be
-# included in the documentation.
+# declarations. If set to NO, these declarations will be included in the
+# documentation.
 # The default value is: NO.
 
 HIDE_FRIEND_COMPOUNDS  = NO
@@ -854,8 +854,10 @@ INPUT_ENCODING         = UTF-8
 # If left blank the following patterns are tested:*.c, *.cc, *.cxx, *.cpp,
 # *.c++, *.java, *.ii, *.ixx, *.ipp, *.i++, *.inl, *.idl, *.ddl, *.odl, *.h,
 # *.hh, *.hxx, *.hpp, *.h++, *.cs, *.d, *.php, *.php4, *.php5, *.phtml, *.inc,
-# *.m, *.markdown, *.md, *.mm, *.dox, *.py, *.pyw, *.f90, *.f95, *.f03, *.f08,
-# *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf, *.qsf and *.ice.
+# *.m, *.markdown, *.md, *.mm, *.dox (to be provided as doxygen C comment),
+# *.doc (to be provided as doxygen C comment), *.txt (to be provided as doxygen
+# C comment), *.py, *.pyw, *.f90, *.f95, *.f03, *.f08, *.f, *.for, *.tcl, *.vhd,
+# *.vhdl, *.ucf, *.qsf and *.ice.
 
 FILE_PATTERNS          = *.c \
                          *.h \
@@ -1230,9 +1232,9 @@ HTML_TIMESTAMP         = YES
 
 # If the HTML_DYNAMIC_MENUS tag is set to YES then the generated HTML
 # documentation will contain a main index with vertical navigation menus that
-# are dynamically created via Javascript. If disabled, the navigation index will
+# are dynamically created via JavaScript. If disabled, the navigation index will
 # consists of multiple levels of tabs that are statically embedded in every HTML
-# page. Disable this option to support browsers that do not have Javascript,
+# page. Disable this option to support browsers that do not have JavaScript,
 # like the Qt help browser.
 # The default value is: YES.
 # This tag requires that the tag GENERATE_HTML is set to YES.
@@ -1520,8 +1522,14 @@ FORMULA_FONTSIZE       = 10
 
 FORMULA_TRANSPARENT    = YES
 
+# The FORMULA_MACROFILE can contain LaTeX \newcommand and \renewcommand commands
+# to create new LaTeX commands to be used in formulas as building blocks. See
+# the section "Including formulas" for details.
+
+FORMULA_MACROFILE      =
+
 # Enable the USE_MATHJAX option to render LaTeX formulas using MathJax (see
-# https://www.mathjax.org) which uses client side Javascript for the rendering
+# https://www.mathjax.org) which uses client side JavaScript for the rendering
 # instead of using pre-rendered bitmaps. Use this if you do not have LaTeX
 # installed or if you want to formulas look prettier in the HTML output. When
 # enabled you may also need to install MathJax separately and configure the path
@@ -1591,7 +1599,7 @@ MATHJAX_CODEFILE       =
 SEARCHENGINE           = YES
 
 # When the SERVER_BASED_SEARCH tag is enabled the search engine will be
-# implemented using a web server instead of a web client using Javascript. There
+# implemented using a web server instead of a web client using JavaScript. There
 # are two flavors of web server based searching depending on the EXTERNAL_SEARCH
 # setting. When disabled, doxygen will generate a PHP script for searching and
 # an index file used by the script. When EXTERNAL_SEARCH is enabled the indexing

--- a/generic.c
+++ b/generic.c
@@ -179,14 +179,6 @@ void UnComment(char *s) {
 }
 
 
-/**************************************************************/
-Bool Is_LeapYear(int yr) {
-	/* yr must be a 4 digit year number */
-
-	int t = (yr / 100) * 100;
-
-	return (Bool) (((yr % 4) == 0) && (((t) != yr) || ((yr % 400) == 0)));
-}
 
 /**************************************************************************************************************************************
  PURPOSE: Calculate a linear interpolation between two points, for use in soil_temperature function

--- a/generic.h
+++ b/generic.h
@@ -94,14 +94,6 @@ extern "C" {
 
 #define isnull(a) (NULL == (a))
 
-/* -------  Some Time macros that should be always on ------ */
-#define YearTo4Digit(y) ((TimeInt)(( (y) > 100)  \
-                      ? (y)                      \
-                      : ((y)<50) ? 2000+(y)      \
-                                    : 1900+(y) ) )
-#define WEEKDAYS 7
-#define Doy2Week(d) ((TimeInt)(((d)-1) /WEEKDAYS))
-
 /* ---------   Redefine basic types to be more malleable ---- */
 typedef float RealF;
 typedef double RealD;
@@ -231,7 +223,6 @@ char *Str_ToUpper(char *s, char *r);
 char *Str_ToLower(char *s, char *r);
 int Str_CompareI(char *t, char *s);
 void UnComment(char *s);
-Bool Is_LeapYear(int yr);
 double interpolation(double x1, double x2, double y1, double y2, double deltaX);
 void st_getBounds(unsigned int *x1, unsigned int *x2, unsigned int *equal, unsigned int size, double depth, double bounds[]);
 double lobfM(double xs[], double ys[], unsigned int n);

--- a/test/sw_testhelpers.cc
+++ b/test/sw_testhelpers.cc
@@ -46,21 +46,15 @@ extern SW_MODEL SW_Model;
 void Reset_SOILWAT2_after_UnitTest(void) {
   SW_CTL_clear_model(swFALSE);
 
-  SW_CTL_init_model(_firstfile);
-  SW_CTL_obtain_inputs();
+  SW_CTL_setup_model(_firstfile);
+  SW_CTL_read_inputs_from_disk();
+  SW_CTL_init_run();
 
 
   // Next two function calls will require SW_Output.c
   //   (see issue #85 'Make SW_Output.c comptabile with c++ to include in unit testing code')
   // SW_OUT_set_ncol();
   // SW_OUT_set_colnames();
-
-
-  // Set year to first (Gregorian) calendar year of testing simulation:
-  // In a regular SOILWAT2 run, this is set via:
-  //   SW_CTL_main > SW_CTL_run_current_year >
-  //     _begin_year > SW_MDL_new_year > Time_new_year
-  Time_new_year(SW_Model.startyr);
 }
 
 

--- a/test/sw_testhelpers.cc
+++ b/test/sw_testhelpers.cc
@@ -49,9 +49,18 @@ void Reset_SOILWAT2_after_UnitTest(void) {
   SW_CTL_init_model(_firstfile);
   SW_CTL_obtain_inputs();
 
-  // Next two function calls will require SW_Output.c (see issue #85 'Make SW_Output.c comptabile with c++ to include in unit testing code')
+
+  // Next two function calls will require SW_Output.c
+  //   (see issue #85 'Make SW_Output.c comptabile with c++ to include in unit testing code')
   // SW_OUT_set_ncol();
   // SW_OUT_set_colnames();
+
+
+  // Set year to first (Gregorian) calendar year of testing simulation:
+  // In a regular SOILWAT2 run, this is set via:
+  //   SW_CTL_main > SW_CTL_run_current_year >
+  //     _begin_year > SW_MDL_new_year > Time_new_year
+  Time_new_year(SW_Model.startyr);
 }
 
 

--- a/test/test_SW_Carbon.cc
+++ b/test/test_SW_Carbon.cc
@@ -112,7 +112,7 @@ namespace {
     SW_Model.addtl_yr = 0;
 
     SW_CBN_read();
-    calculate_CO2_multipliers();
+    SW_CBN_init_run();
 
     for (year = SW_Model.startyr + SW_Model.addtl_yr; year <= simendyr; year++) {
       ForEachVegType(k) {

--- a/test/test_SW_VegProd.cc
+++ b/test/test_SW_VegProd.cc
@@ -71,6 +71,7 @@ namespace {
   // Test the SW_VEGPROD constructor 'SW_VPD_construct'
   TEST(VegTest, Constructor) {
     SW_VPD_construct();
+    SW_VPD_init_run();
 
     ForEachVegType(k) {
       EXPECT_DOUBLE_EQ(1., v->veg[k].co2_multipliers[BIO_INDEX][0]);

--- a/test/test_Times.cc
+++ b/test/test_Times.cc
@@ -20,55 +20,120 @@
 #include "sw_testhelpers.h"
 
 namespace{
-  // Test the 'Times.c' function 'interpolate_monthlyValues'
-  TEST(TimesTest, interpolateMonthlyValues){
+  // Test the 'Times.c' function 'xintpl_monthlyValues'
+  double valXd(double v1, double v2, int sign, int mday, int delta_days) {
+    return v1 + (v2 - v1) * sign * (mday - 15.) / delta_days;
+  }
+
+  TEST(TimesTest, interpolate_monthlyValues) {
     // point to the structure that contains cloud coverage monthly values
     SW_SKY SW_Sky;
-    SW_SKY *interpolate = &SW_Sky;
-    unsigned int i;
-    // set all monthlyValues all 10 to ensure we know what monthlyValues
-    // are being used to interpolate dailyValues
-    for (i = 0; i < length(interpolate -> cloudcov); i++){
-      interpolate -> cloudcov[i] = 10;
+    SW_SKY *xintpl = &SW_Sky;
+
+    unsigned int i, k, doy, lpadd,
+      years[] = {1980, 1981}; // leap year, non-leap year
+
+    Bool isMon1;
+
+    // Loop through years and tests
+    for (k = 0; k < length(years); k++) {
+      Time_new_year(years[k]);
+      lpadd = isleapyear(years[k]) ? 1 : 0;
+
+      // Test: all monthlyValues equal to 10
+      //   (not affected by leap/nonleap yrs)
+      for (i = 0; i < length(xintpl -> cloudcov); i++) {
+        xintpl -> cloudcov[i] = 10;
+      }
+      xintpl -> cloudcov_daily[0] = 0;
+
+      interpolate_monthlyValues(xintpl -> cloudcov, xintpl -> cloudcov_daily);
+
+      // value for daily index 0 is unchanged because we use here a base1 index
+      EXPECT_NEAR(xintpl -> cloudcov_daily[0], 0, tol9);
+
+      // Expect all xintpld values to be the same (constant input)
+      for (doy = 1; doy <= Time_get_lastdoy_y(years[k]); doy++) {
+        EXPECT_NEAR(xintpl -> cloudcov_daily[doy], 10.0, tol9);
+      }
+
+
+      // Test: all monthlyValues equal to 10 except December and March are 20
+      //   (affected by leap/nonleap yrs)
+      xintpl -> cloudcov[Mar] = 20;
+      xintpl -> cloudcov[Dec] = 20;
+
+      interpolate_monthlyValues(xintpl -> cloudcov, xintpl -> cloudcov_daily);
+
+      /* for (doy = 1; doy <= Time_get_lastdoy_y(years[k]); doy++) {
+        printf(
+          "yr=%d/doy=%d/mday=%d: val=%.6f\n",
+          years[k], doy, doy2mday(doy),
+          xintpl -> cloudcov_daily[doy]
+        );
+      } */
+
+
+      // value for daily index 0 is unchanged because we use here a base1 index
+      EXPECT_NEAR(xintpl -> cloudcov_daily[0], 0, tol9);
+
+      // Expect mid-Nov to mid-Jan and mid-Feb to mid-Apr values to vary,
+      // all other are the same
+
+      // Expect Jan 1 to Jan 15 to vary
+      for (doy = 1; doy <= 15; doy++) {
+        EXPECT_NEAR(
+          xintpl -> cloudcov_daily[doy],
+          valXd(10, 20, -1, doy2mday(doy), 31),
+          tol9
+        );
+      }
+
+      // Expect Jan 15 to Feb 15 to have same values as the constant input
+      for (doy = 15; doy <= 46; doy++) {
+        EXPECT_NEAR(xintpl -> cloudcov_daily[doy], 10.0, tol9);
+      }
+
+      // Expect Feb 16 to March 15 to vary (account for leap years)
+      for (doy = 46; doy <= 74 + lpadd; doy++) {
+        isMon1 = (Bool)(doy <= 59 + lpadd);
+        EXPECT_NEAR(
+          xintpl -> cloudcov_daily[doy],
+          valXd(
+            isMon1 ? 10 : 20,
+            isMon1 ? 20 : 10,
+            isMon1 ? 1 : -1,
+            doy2mday(doy),
+            28 + lpadd
+          ),
+          tol9
+        ) << "year = " << years[k] << " doy = " << doy << " mday = " << doy2mday(doy);
+      }
+
+      // Expect Apr 15 to Nov 15 to have same values as the constant input
+      for (doy = 105 + lpadd; doy <= 319 + lpadd; doy++) {
+        EXPECT_NEAR(xintpl -> cloudcov_daily[doy], 10.0, tol9);
+      }
+
+      // Expect Dec 1 to Dec 31 to vary
+      for (doy = 335 + lpadd; doy <= 365 + lpadd; doy++) {
+        isMon1 = (Bool)(doy < 349 + lpadd);
+        EXPECT_NEAR(
+          xintpl -> cloudcov_daily[doy],
+          valXd(
+            20, // Dec value
+            10, // Nov or Jan value
+            isMon1 ? -1 : 1,
+            doy2mday(doy),
+            isMon1 ? 30 : 31
+          ),
+          tol9
+        ) << "year = " << years[k] << " doy = " << doy << " mday = " << doy2mday(doy);
+      }
+
+
+      // Reset to previous global states
+      Reset_SOILWAT2_after_UnitTest();
     }
-    interpolate -> cloudcov_daily[0] = 0;
-
-    // test various obtained values
-    interpolate_monthlyValues(interpolate -> cloudcov, interpolate -> cloudcov_daily);
-    // inperpolate_monthlyValues should not change index 0 because we used
-    // base1 indices
-    EXPECT_DOUBLE_EQ(interpolate -> cloudcov_daily[0], 0);
-    EXPECT_DOUBLE_EQ(interpolate -> cloudcov_daily[1], 10.0);
-    // test top conditional, day < 15
-    EXPECT_DOUBLE_EQ(interpolate -> cloudcov_daily[14], 10.0);
-    // test middle conditional, day >= 15
-    EXPECT_DOUBLE_EQ(interpolate -> cloudcov_daily[15], 10.0);
-    EXPECT_DOUBLE_EQ(interpolate -> cloudcov_daily[365], 10.0);
-    // Reset to previous global states
-    Reset_SOILWAT2_after_UnitTest();
-
-    // change first value to 20 and test the changes to the interpolated daily values
-    interpolate -> cloudcov[0] = 20;
-
-    interpolate_monthlyValues(interpolate -> cloudcov, interpolate -> cloudcov_daily);
-    // calculated by hand
-    EXPECT_DOUBLE_EQ(interpolate -> cloudcov_daily[0], 0);
-    EXPECT_DOUBLE_EQ(interpolate -> cloudcov_daily[1], 15.483870967741936);
-    EXPECT_DOUBLE_EQ(interpolate -> cloudcov_daily[14], 19.6774193548387);
-    EXPECT_DOUBLE_EQ(interpolate -> cloudcov_daily[13], 19.354838709677419);
-    EXPECT_DOUBLE_EQ(interpolate -> cloudcov_daily[31], 14.838709677419356);
-    EXPECT_DOUBLE_EQ(interpolate -> cloudcov_daily[365], 15.161290322580644);
-    // test last day on leap year
-    EXPECT_DOUBLE_EQ(interpolate -> cloudcov_daily[MAX_DAYS], 15.483870967741936);
-
-    // change december monthly value to ensure meaningful final interpolation
-    interpolate -> cloudcov[11] = 12;
-
-    interpolate_monthlyValues(interpolate -> cloudcov, interpolate -> cloudcov_daily);
-    EXPECT_DOUBLE_EQ(interpolate -> cloudcov_daily[365], 16.129032258064516);
-    // test last day on leap year
-    EXPECT_DOUBLE_EQ(interpolate -> cloudcov_daily[MAX_DAYS], 16.387096774193548);
-    // Reset to previous global states
-    Reset_SOILWAT2_after_UnitTest();
   }
 }

--- a/test/test_Times.cc
+++ b/test/test_Times.cc
@@ -20,6 +20,42 @@
 #include "sw_testhelpers.h"
 
 namespace{
+  TEST(TimesTest, leap_year_consequences) {
+    unsigned int k, lpadd,
+      years[] = {1900, 1980, 1981, 2000}; // noleap, leap, noleap, leap years
+
+    Bool kleap,
+      isleap[] = {swFALSE, swTRUE, swFALSE, swTRUE};
+
+    // Loop through years and tests
+    for (k = 0; k < length(years); k++) {
+      Time_new_year(years[k]);
+      kleap = isleapyear(years[k]);
+
+      lpadd = kleap ? 1 : 0;
+
+      EXPECT_EQ(kleap, isleap[k]);
+      EXPECT_EQ(Time_days_in_month(Feb), 28 + lpadd);
+      EXPECT_EQ(Time_get_lastdoy_y(years[k]), 365 + lpadd);
+
+      EXPECT_EQ(doy2month(1), Jan); // first day of January
+      EXPECT_EQ(doy2month(59 + lpadd), Feb); // last day of February
+      EXPECT_EQ(doy2month(60 + lpadd), Mar); // first day of March
+      EXPECT_EQ(doy2month(365 + lpadd), Dec); // last day of December
+
+      EXPECT_EQ(doy2mday(1), 1); // first day of January
+      EXPECT_EQ(doy2mday(59 + lpadd), 28 + lpadd); // last day of February
+      EXPECT_EQ(doy2mday(60 + lpadd), 1); // first day of March
+      EXPECT_EQ(doy2mday(365 + lpadd), 31); // last day of December
+
+      EXPECT_EQ(doy2week(1), 0); // first day of first (base0) 7-day period
+      EXPECT_EQ(doy2week(7), 0); // last day of first 7-day period
+      EXPECT_EQ(doy2week(8), 1); // first day of second 7-day period
+      EXPECT_EQ(doy2week(365 + lpadd), 52);
+    }
+  }
+
+
   // Test the 'Times.c' function 'xintpl_monthlyValues'
   double valXd(double v1, double v2, int sign, int mday, int delta_days) {
     return v1 + (v2 - v1) * sign * (mday - 15.) / delta_days;

--- a/tools/check_SOILWAT2.sh
+++ b/tools/check_SOILWAT2.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Runs several tests for SOILWAT2
+# - is currently set up for use with macports
+# - expects clang as default compiler
+
+
+#--- List of (builtin and macport) compilers
+declare -a port_compilers=("none" "mp-gcc9" "mp-clang-9.0")
+declare -a ccs=("clang" "gcc" "clang")
+declare -a cxxs=("clang++" "g++" "clang++")
+
+ncomp=${#ccs[@]}
+
+
+#--- Loop through tests and compilers
+for ((k = 0; k < ncomp; k++)); do
+  echo $'\n'$'\n'$'\n'Test SOILWAT2 with ${port_compilers[k]} ------------------
+
+  echo $'\n'Set compiler ...
+  if [ "${port_compilers[k]}" != "none" ]; then
+    sudo port select --set ${ccs[k]} ${port_compilers[k]}
+  fi
+
+  echo $'\n'`"${ccs[k]}" --version`
+  echo $'\n'`"${cxxs[k]}" --version`
+
+
+  echo $'\n'$'\n'Run binary with ${port_compilers[k]} ...
+  CC=${ccs[k]} CXX=${cxxs[k]} make clean bin bint_run
+  CC=${ccs[k]} CXX=${cxxs[k]} make clean bin_debug_severe bint_run
+  if command -v valgrind >/dev/null 2>&1; then
+    CC=${ccs[k]} CXX=${cxxs[k]} make bind_valgrind bint_run
+  fi
+
+  echo $'\n'$'\n'Run tests with ${port_compilers[k]} ...
+  CC=${ccs[k]} CXX=${cxxs[k]} make clean test test_run
+  CC=${ccs[k]} CXX=${cxxs[k]} make clean test_severe test_run
+
+  echo $'\n'$'\n'Run sanitizer on tests with ${port_compilers[k]}: exclude known leaks ...
+  CC=${ccs[k]} CXX=${cxxs[k]} ASAN_OPTIONS=detect_leaks=1 LSAN_OPTIONS=suppressions=.LSAN_suppr.txt make clean test_severe test_run
+
+
+  echo $'\n'$'\n'Unset compiler ...
+  if [ "${port_compilers[k]}" != "none" ]; then
+    sudo port select --set ${ccs[k]} none
+  fi
+done
+
+echo Complete!$'\n'
+
+
+#--- Cleanup
+unset -v ccs
+unset -v cxxs
+unset -v port_compilers


### PR DESCRIPTION
Restructure of model setup, user inputs, run initialization, and setting a new year
to avoid that output depends on the time when the code is executed (#273)