### PR TITLE
Dev v6.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,14 @@ following output is implemented:
       CPPFLAGS=-DSW2_SolarPosition_Test__hourangles_by_lats make test test_run
       Rscript tools/plot__SW2_SolarPosition_Test__hourangles_by_lats.R
 ```
+
+  - PET plots as function of radiation, relative humidity, wind speed, and cover
+
+```{.sh}
+      CPPFLAGS=-DSW2_PET_Test__petfunc_by_temps make test test_run
+      Rscript tools/plot__SW2_PET_Test__petfunc_by_temps.R
+```
+
 <br>
 
 

--- a/SW_Control.c
+++ b/SW_Control.c
@@ -34,6 +34,7 @@
 #include "SW_Model.h"
 #include "SW_Output.h"
 #include "SW_Site.h"
+#include "SW_Flow_lib.h"
 #include "SW_Flow_lib_PET.h"
 #include "SW_Flow.h"
 #include "SW_SoilWater.h"
@@ -141,6 +142,7 @@ void SW_CTL_init_run(void) {
 	// SW_VES_init_run() not needed
 	SW_VPD_init_run();
 	SW_FLW_init_run();
+	SW_ST_init_run();
 	// SW_OUT_init_run() handled separately so that SW_CTL_init_run() can be
 	//   useful for unit tests, rSOILWAT2, and STEPWAT2 applications
 	SW_SWC_init_run();

--- a/SW_Defines.h
+++ b/SW_Defines.h
@@ -26,6 +26,23 @@
 extern "C" {
 #endif
 
+/* SOILWAT2 version and compile time metadata */
+#ifndef SW2_VERSION
+  #define SW2_VERSION "unset"
+#endif
+
+#ifndef USERNAME
+  #define USERNAME "unset"
+#endif
+
+#ifndef HOSTNAME
+  #define HOSTNAME "unset"
+#endif
+
+#define BUILD_DATE __DATE__
+#define BUILD_TIME __TIME__
+
+
 /* Not sure if this parameter is variable or a consequence of algebra,
  * but it's different in the FORTRAN version than in the ELM doc.
  * If deemed to need changing, might as well recompile rather than

--- a/SW_Flow.c
+++ b/SW_Flow.c
@@ -135,8 +135,7 @@ extern SW_WEATHER SW_Weather;
 extern SW_VEGPROD SW_VegProd;
 extern SW_SKY SW_Sky;
 
-extern unsigned int soil_temp_init; // simply keeps track of whether or not the values for the soil_temperature function have been initialized.  0 for no, 1 for yes.
-extern unsigned int fusion_pool_init;
+extern unsigned int soil_temp_init;
 extern char const *key2veg[];
 
 /* *************************************************** */
@@ -204,8 +203,6 @@ void SW_FLW_init_run(void) {
 	/* 06/26/2013	(rjm) added function SW_FLW_init_run() to init global variables between consecutive calls to SoilWat as dynamic library */
 	int i, k;
 
-	soil_temp_init = 0;
-	fusion_pool_init = 0;
 
 	//These only have to be cleared if a loop is wrong in the code.
 	for (i = 0; i < MAX_LAYERS; i++) {
@@ -289,7 +286,7 @@ void SW_Water_Flow(void) {
 			 before water flow of first day because we use un/frozen states), but
 			 calculate soil temperature at end of each day
 		*/
-		SW_ST_init_run(
+		SW_ST_setup_run(
 			w->now.temp_avg[Today],
 			lyrSWCBulk,
 			lyrSWCBulk_Saturated,

--- a/SW_Flow.c
+++ b/SW_Flow.c
@@ -283,6 +283,32 @@ void SW_Water_Flow(void) {
 	}
 	#endif
 
+
+	if (SW_Site.use_soil_temp && !soil_temp_init) {
+		/* We initialize soil temperature (and un/frozen state of soil layers)
+			 before water flow of first day because we use un/frozen states), but
+			 calculate soil temperature at end of each day
+		*/
+		SW_ST_init_run(
+			w->now.temp_avg[Today],
+			lyrSWCBulk,
+			lyrSWCBulk_Saturated,
+			lyrbDensity,
+			lyrWidths,
+			lyroldsTemp,
+			surfaceTemp,
+			SW_Site.n_layers,
+			lyrSWCBulk_FieldCaps,
+			lyrSWCBulk_Wiltpts,
+			SW_Site.Tsoil_constant,
+			SW_Site.stDeltaX,
+			SW_Site.stMaxDepth,
+			SW_Site.stNRGR,
+			&SW_Soilwat.soiltempError
+		);
+	}
+
+
 	/* Solar radiation and PET */
 	x = v->bare_cov.albedo * v->bare_cov.fCover;
 	ForEachVegType(k)
@@ -711,7 +737,7 @@ void SW_Water_Flow(void) {
 	if (SW_Site.use_soil_temp) {
 		soil_temperature(w->now.temp_avg[Today], sw->pet, sw->aet, x, lyrSWCBulk,
 			lyrSWCBulk_Saturated, lyrbDensity, lyrWidths, lyroldsTemp, lyrsTemp, surfaceTemp,
-			SW_Site.n_layers, lyrSWCBulk_FieldCaps, lyrSWCBulk_Wiltpts, SW_Site.bmLimiter,
+			SW_Site.n_layers, SW_Site.bmLimiter,
 			SW_Site.t1Param1, SW_Site.t1Param2, SW_Site.t1Param3, SW_Site.csParam1,
 			SW_Site.csParam2, SW_Site.shParam, sw->snowdepth, SW_Site.Tsoil_constant,
 			SW_Site.stDeltaX, SW_Site.stMaxDepth, SW_Site.stNRGR, sw->snowpack[Today],
@@ -771,8 +797,9 @@ static void records2arrays(void) {
 			}
 		}
 
-		ForEachEvapLayer(i)
+		ForEachEvapLayer(i) {
 			lyrEvapCo[i] = SW_Site.lyr[i]->evap_coeff;
+		}
 
 	} /* end firsttime stuff */
 

--- a/SW_Flow.c
+++ b/SW_Flow.c
@@ -661,13 +661,19 @@ void SW_Water_Flow(void) {
 
 
 	/* Calculate percolation for unsaturated soil water conditions. */
-	/* 01/06/2011	(drs) call to infiltrate_water_low() has to be the last swc affecting calculation */
+	/* 01/06/2011	(drs) call to infiltrate_water_low() has to be the last swc
+		 affecting calculation */
 
 	w->soil_inf += standingWater[Today];
-	infiltrate_water_low(lyrSWCBulk, lyrDrain, &drainout, SW_Site.n_layers,
+
+	infiltrate_water_low(
+		lyrSWCBulk, lyrDrain, &drainout, SW_Site.n_layers,
 		SW_Site.slow_drain_coeff, SLOW_DRAIN_DEPTH, lyrSWCBulk_FieldCaps, lyrWidths,
-		lyrSWCBulk_Mins, lyrSWCBulk_Saturated, lyrImpermeability, &standingWater[Today]);
-	w->soil_inf -= standingWater[Today]; // adjust soil_infiltration for water pushed back to surface
+		lyrSWCBulk_Mins, lyrSWCBulk_Saturated, lyrImpermeability, &standingWater[Today]
+	);
+
+	// adjust soil_infiltration for water pushed back to surface
+	w->soil_inf -= standingWater[Today];
 
 	sw->surfaceWater = standingWater[Today];
 

--- a/SW_Flow_lib.c
+++ b/SW_Flow_lib.c
@@ -1172,6 +1172,76 @@ double surface_temperature_under_snow(double airTempAvg, double snow){
 	return tSoilAvg;
 }
 
+
+
+
+/**
+	@brief Initialize soil temperature for a simulation run.
+
+	@param airTemp Average daily air temperature (&deg;C).
+	@param swc Soilwater content in each layer before drainage
+		(m<SUP>3</SUP> H<SUB>2</SUB>O).
+	@param swc_sat The satured soil water content of the soil layers (cm/cm).
+	@param bDensity An array of the bulk density of the whole soil per soil layer
+		(g/cm<SUP>3</SUP>).
+	@param width The width of the layers (cm).
+	@param oldsTemp An array of yesterday's temperature values (&deg;C).
+	@param surfaceTemp Current surface air temperatature (&deg;C).
+	@param nlyrs Number of layers in the soil profile.
+	@param fc An array of the field capacity of the soil layers (cm/layer).
+	@param wp An array of the wilting point of the soil layers (cm/layer).
+	@param sTconst Constant soil temperature (&deg;C).
+	@param deltaX Distance between profile points
+		(default is 15 cm from Parton's equation @cite Parton1984).
+	@param theMaxDepth Lower bound of the equation
+		(default is 180 cm from Parton's equation @cite Parton1984).
+	@param nRgr Number of regressions
+		(1 extra is needed for the sTempR and oldsTempR for the last layer.
+	@param *ptr_stError Boolean indicating whether there was an error.
+
+	@sideeffect *ptr_stError Updated boolean indicating if there was an error.
+*/
+void SW_ST_init_run(
+	double airTemp,
+	double swc[],
+	double swc_sat[],
+	double bDensity[],
+	double width[],
+	double oldsTemp[],
+	double surfaceTemp[2],
+	unsigned int nlyrs,
+	double fc[],
+	double wp[],
+	double sTconst,
+	double deltaX,
+	double theMaxDepth,
+	unsigned int nRgr,
+	Bool *ptr_stError
+) {
+
+	#ifdef SWDEBUG
+	int debug = 0;
+	#endif
+
+	if (!soil_temp_init) {
+		#ifdef SWDEBUG
+		if (debug) {
+			swprintf("\nCalling soil_temperature_init\n");
+		}
+		#endif
+
+		surfaceTemp[Today] = airTemp;
+		soil_temperature_init(
+			bDensity, width,
+			oldsTemp, sTconst,
+			nlyrs, fc, wp,
+			deltaX, theMaxDepth, nRgr,
+			ptr_stError
+		);
+		set_frozen_unfrozen(nlyrs, oldsTemp, swc, swc_sat, width);
+	}
+}
+
 /**
 @brief Initialize soil structure and properties for soil temperature simulation.
 
@@ -1360,6 +1430,7 @@ void soil_temperature_init(double bDensity[], double width[], double oldsTemp[],
 	}
   #endif
 }
+
 
 /**
 @brief Function to determine if a soil layer is frozen/unfrozen, as well as change
@@ -1735,8 +1806,6 @@ Equations based on Eitzinger, Parton, and Hartman 2000. @cite Eitzinger2000, Par
 @param sTemp Temperatature values of soil layers (&deg;C).
 @param surfaceTemp Current surface air temperatature (&deg;C).
 @param nlyrs Number of layers in the soil profile.
-@param fc An array of the field capacity of the soil layers (cm/layer).
-@param wp An array of the wilting point of the soil layers (cm/layer).
 @param bmLimiter Biomass limiter constant (300 g/m<SUP>2</SUP>).
 @param t1Param1 Constant for the avg temp at the top of soil equation (15).
 @param t1Param2 Constant for the avg temp at the top of soil equation (-4).
@@ -1759,7 +1828,7 @@ Equations based on Eitzinger, Parton, and Hartman 2000. @cite Eitzinger2000, Par
 
 void soil_temperature(double airTemp, double pet, double aet, double biomass,
 	double swc[], double swc_sat[], double bDensity[], double width[], double oldsTemp[],
-	double sTemp[], double surfaceTemp[2], unsigned int nlyrs, double fc[], double wp[],
+	double sTemp[], double surfaceTemp[2], unsigned int nlyrs,
 	double bmLimiter, double t1Param1, double t1Param2, double t1Param3, double csParam1,
 	double csParam2, double shParam, double snowdepth, double sTconst, double deltaX,
 	double theMaxDepth, unsigned int nRgr, double snow, Bool *ptr_stError) {
@@ -1795,18 +1864,14 @@ void soil_temperature(double airTemp, double pet, double aet, double biomass,
 	#endif
 
 	if (!soil_temp_init) {
-		#ifdef SWDEBUG
-		if (debug) {
-			swprintf("\nCalling soil_temperature_init\n");
-		}
-		#endif
+		*ptr_stError = swTRUE;
 
-		surfaceTemp[Today] = airTemp;
-		set_frozen_unfrozen(nlyrs, oldsTemp, swc, swc_sat, width);
-		soil_temperature_init(bDensity, width, oldsTemp, sTconst, nlyrs, fc, wp, deltaX,
-			theMaxDepth, nRgr, ptr_stError);
+		LogError(
+			logfp,
+			LOGFATAL,
+			"SOILWAT2 ERROR soil temperature module was not initialized.\n"
+		);
 	}
-
 
 	// calculating T1, the average daily soil surface temperature
 	if (GT(snowdepth, 0.0)) {
@@ -1880,8 +1945,8 @@ void soil_temperature(double airTemp, double pet, double aet, double biomass,
 
 		swprintf("\nlayer values:");
 		for (i = 0; i < nlyrs; i++) {
-			swprintf("\ni %2d width %f depth %f vwc %f fc %f wp %f oldsTemp %f bDensity %f",
-			i, width[i], st->depths[i], vwc[i], fc[i], wp[i], oldsTemp[i], bDensity[i]);
+			swprintf("\ni %2d width %f depth %f vwc %f bDensity %f",
+			i, width[i], st->depths[i], vwc[i], bDensity[i]);
 		}
 		swprintf("\n");
 	}

--- a/SW_Flow_lib.h
+++ b/SW_Flow_lib.h
@@ -123,8 +123,6 @@ void soil_temperature(double airTemp,
 					  double sTemp[],
 					  double surfaceTemp[2],
 					  unsigned int nlyrs,
-					  double fc[],
-					  double wp[],
 					  double bmLimiter,
 					  double t1Param1,
 					  double t1Param2,
@@ -154,6 +152,24 @@ void lyrSoil_to_lyrTemp(double cor[MAX_ST_RGR][MAX_LAYERS + 1], unsigned int nly
 		double res[]);
 
 double surface_temperature_under_snow(double airTempAvg, double snow);
+
+void SW_ST_init_run(
+	double airTemp,
+	double swc[],
+	double swc_sat[],
+	double bDensity[],
+	double width[],
+	double oldsTemp[],
+	double surfaceTemp[],
+	unsigned int nlyrs,
+	double fc[],
+	double wp[],
+	double sTconst,
+	double deltaX,
+	double theMaxDepth,
+	unsigned int nRgr,
+	Bool *ptr_stError
+);
 
 void soil_temperature_init(double bDensity[], double width[], double oldsTemp[],
 	double sTconst, unsigned int nlyrs, double fc[], double wp[], double deltaX,

--- a/SW_Flow_lib.h
+++ b/SW_Flow_lib.h
@@ -153,7 +153,9 @@ void lyrSoil_to_lyrTemp(double cor[MAX_ST_RGR][MAX_LAYERS + 1], unsigned int nly
 
 double surface_temperature_under_snow(double airTempAvg, double snow);
 
-void SW_ST_init_run(
+void SW_ST_init_run(void);
+
+void SW_ST_setup_run(
 	double airTemp,
 	double swc[],
 	double swc_sat[],
@@ -171,7 +173,7 @@ void SW_ST_init_run(
 	Bool *ptr_stError
 );
 
-void soil_temperature_init(double bDensity[], double width[], double oldsTemp[],
+void soil_temperature_setup(double bDensity[], double width[], double oldsTemp[],
 	double sTconst, unsigned int nlyrs, double fc[], double wp[], double deltaX,
 	double theMaxDepth, unsigned int nRgr, Bool *ptr_stError);
 

--- a/SW_Main.c
+++ b/SW_Main.c
@@ -66,6 +66,11 @@ int main(int argc, char **argv) {
 
 	init_args(argc, argv);
 
+	// Print version if not in quiet mode
+	if (!QuietMode) {
+		print_version();
+	}
+
   // setup and construct model (independent of inputs)
 	SW_CTL_setup_model(_firstfile);
 

--- a/SW_Site.c
+++ b/SW_Site.c
@@ -598,7 +598,9 @@ static void _read_layers(void) {
 			&soiltemp
 		);
 
-		if (x < 10) {
+		/* Check that we have 12 values per layer */
+		/* Adjust number if new variables are added */
+		if (x != 12) {
 			CloseFile(&f);
 			LogError(
 				logfp,

--- a/SW_Site.c
+++ b/SW_Site.c
@@ -1023,6 +1023,8 @@ void SW_SIT_init_run(void) {
 						"  %s transpiration coefficient > 0 (%d) in '%s'.\n"
 						"  Please fix the discrepancy and try again.\n",
 						SW_F_name(eSite), r + 1, key2veg[k], s, SW_F_name(eLayers));
+			} else {
+				lyr->my_transp_rgn[k] = 0;
 			}
 		}
 
@@ -1224,7 +1226,6 @@ void SW_SIT_clear_layers(void) {
 */
 void SW_SIT_init_counts(void) {
 	int k;
-	LyrIndex i;
 	SW_SITE *s = &SW_Site;
 
 	// Reset counts
@@ -1236,11 +1237,6 @@ void SW_SIT_init_counts(void) {
 	ForEachVegType(k)
 	{
 		s->n_transp_lyrs[k] = 0;
-
-		ForEachSoilLayer(i)
-		{
-			s->lyr[i]->my_transp_rgn[k] = 0;
-		}
 	}
 }
 

--- a/SW_Site.c
+++ b/SW_Site.c
@@ -1004,7 +1004,7 @@ void SW_SIT_init_run(void) {
 				lyr->fractionVolBulk_gravel,
 				lyr->fractionWeightMatric_sand,
 				lyr->fractionWeightMatric_clay,
-				lyr->swcBulk_saturated / lyr->width
+				lyr->swcBulk_saturated / ((1. - lyr->fractionVolBulk_gravel) * lyr->width)
 			);
 
 			/* residual SWC at -3 MPa (Fredlund DG, Xing AQ (1994)

--- a/SW_Site.c
+++ b/SW_Site.c
@@ -540,15 +540,10 @@ static void _read_layers(void) {
 			fval = matricd;
 			errtype = Str_Dup("soil density");
 
-		} else if (LT(f_gravel, 0.) || GT(f_gravel, 0.5)) { // 0 <= gravel < 1
+		} else if (LT(f_gravel, 0.) || GE(f_gravel, 1.)) {
 			fail = swTRUE;
 			fval = f_gravel;
 			errtype = Str_Dup("gravel content");
-
-			swprintf("\nGravel content is either too HIGH (1 > 0.5 >), or too LOW (<0.0): %0.3f", f_gravel);
-			swprintf("\nParameterization for Brooks-Corey equation may fall outside of valid range.");
-			swprintf("\nThis can cause implausible SWP values.");
-			swprintf("\nConsider setting SWC minimum in siteparam.in file.");
 
 		} else if (LE(psand, 0.)) {
 			fail = swTRUE;

--- a/SW_Site.h
+++ b/SW_Site.h
@@ -57,30 +57,38 @@ extern "C" {
 typedef unsigned int LyrIndex;
 
 typedef struct {
+	/* bulk = relating to the whole soil, i.e., matric + rock/gravel/coarse fragments */
+	/* matric = relating to the < 2 mm fraction of the soil, i.e., sand, clay, and silt */
 
-	RealD width, /* width of the soil layer (cm) */
-		soilBulk_density, /* bulk soil density of the whole soil, i.e., including rock/gravel component, (g/cm3) */
+	RealD
+		/* Inputs */
+		width, /* width of the soil layer (cm) */
+		soilMatric_density, /* matric soil density of the < 2 mm fraction, i.e., gravel component excluded, (g/cm3) */
 		evap_coeff, /* prop. of total soil evap from this layer */
 		transp_coeff[NVEGTYPES], /* prop. of total transp from this layer    */
-		soilMatric_density, /* matric soil density of the < 2 mm fraction, i.e., gravel component excluded, (g/cm3) */
 		fractionVolBulk_gravel, /* gravel content (> 2 mm) as volume-fraction of bulk soil (g/cm3) */
 		fractionWeightMatric_sand, /* sand content (< 2 mm & > . mm) as weight-fraction of matric soil (g/g) */
 		fractionWeightMatric_clay, /* clay content (< . mm & > . mm) as weight-fraction of matric soil (g/g) */
-		swcBulk_fieldcap, /* field_cap * width                        */
-		swcBulk_wiltpt, /* wilting_pt * width                       */
-		swcBulk_wet, /* swc considered "wet" (cm) *width         */
-		swcBulk_init, /* start the model at this swc (cm) *width  */
-		swcBulk_min, /* swc cannot go below this (cm) *width     */
-		swcBulk_saturated, /* saturated soil water content (cm) * width */
 		impermeability, /* fraction of how impermeable a layer is (0=permeable, 1=impermeable)    */
-		swcBulk_atSWPcrit[NVEGTYPES], /* swc at the critical soil water potential */
+		sTemp, /* initial soil temperature for each soil layer */
 
-		thetasMatric, /* This group is parameters for */
-		psisMatric, /* Cosby et al. (1982) SWC <-> SWP */
-		bMatric, /* conversion functions. */
-		binverseMatric,
+		/* Derived soil characteristics */
+		soilBulk_density, /* bulk soil density of the whole soil, i.e., including rock/gravel component, (g/cm3) */
+		swcBulk_fieldcap, /* Soil water content (SWC) corresponding to field capacity (SWP = -0.033 MPa) [cm] */
+		swcBulk_wiltpt, /* SWC corresponding to wilting point (SWP = -1.5 MPa) [cm] */
+		swcBulk_min, /* Minimal SWC [cm] */
+		swcBulk_wet, /* SWC considered "wet" [cm] */
+		swcBulk_init, /* Initial SWC for first day of simulation [cm] */
+		swcBulk_atSWPcrit[NVEGTYPES], /* SWC corresponding to critical SWP for transpiration */
 
-		sTemp; /* initial soil temperature for each soil layer */
+		/* Saxton et al. 2006 */
+		swcBulk_saturated, /* saturated bulk SWC [cm] */
+
+		/* Cosby et al. (1984): SOILWAT2's soil water retention curve */
+		thetasMatric, /* saturated matric SWC [cm] */
+		psisMatric, /* saturated matric SWP [cm] */
+		bMatric, /* slope of the logarithmic retention curve */
+		binverseMatric; /* inverse of bMatric */
 
 	LyrIndex my_transp_rgn[NVEGTYPES]; /* which transp zones from Site am I in? */
 } SW_LAYER_INFO;

--- a/SW_Site.h
+++ b/SW_Site.h
@@ -138,10 +138,13 @@ typedef struct {
 
 
 void water_eqn(RealD fractionGravel, RealD sand, RealD clay, LyrIndex n);
-void calculate_soilBulkDensity(RealD matricDensity, RealD fractionGravel, LyrIndex n);
+RealD calculate_soilBulkDensity(RealD matricDensity, RealD fractionGravel);
+LyrIndex nlayers_bsevap();
+void nlayers_vegroots(LyrIndex n_transp_lyrs[]);
 
 void SW_SIT_construct(void);
 void SW_SIT_deconstruct(void);
+void SW_SIT_init_counts(void);
 void SW_SIT_read(void);
 void SW_SIT_init_run(void);
 void _echo_inputs(void);
@@ -149,6 +152,8 @@ void _echo_inputs(void);
 /* these used to be in Layers */
 void SW_SIT_clear_layers(void);
 LyrIndex _newlayer(void);
+void add_deepdrain_layer(void);
+
 void set_soillayers(LyrIndex nlyrs, RealF *dmax, RealF *matricd, RealF *f_gravel,
   RealF *evco, RealF *trco_grass, RealF *trco_shrub, RealF *trco_tree,
   RealF *trco_forb, RealF *psand, RealF *pclay, RealF *imperm, RealF *soiltemp,

--- a/SW_SoilWater.c
+++ b/SW_SoilWater.c
@@ -1132,16 +1132,31 @@ History:
 
 ---------------------*/
 
-  if (clay < .05 || clay > .6 || sand < .05 || sand > .7){
-    LogError(logfp, LOGWARN, "Sand and/or clay values out of valid range, simulation outputs may differ.");
+  if (clay < .05 || clay > .6 || sand < .05 || sand > .7) {
+    LogError(
+      logfp,
+      LOGWARN,
+      "Sand and/or clay values out of valid range, simulation outputs may differ."
+    );
     return SW_MISSING;
-  }
-  else{
+
+  } else {
     RealD res;
-  	sand *= 100.;
-  	clay *= 100.;
-  	res = (-0.0182482 + 0.00087269 * sand + 0.00513488 * clay + 0.02939286 * porosity - 0.00015395 * squared(clay) - 0.0010827 * sand * porosity
-  			- 0.00018233 * squared(clay) * squared(porosity) + 0.00030703 * squared(clay) * porosity - 0.0023584 * squared(porosity) * clay) * (1 - fractionGravel);
+    sand *= 100.;
+    clay *= 100.;
+
+    res = (1. - fractionGravel) * (
+      - 0.0182482 \
+      + 0.00087269 * sand \
+      + 0.00513488 * clay \
+      + 0.02939286 * porosity \
+      - 0.00015395 * squared(clay) \
+      - 0.0010827 * sand * porosity \
+      - 0.00018233 * squared(clay) * squared(porosity) \
+      + 0.00030703 * squared(clay) * porosity \
+      - 0.0023584 * squared(porosity) * clay
+    );
+
     return (fmax(res, 0.));
   }
 }

--- a/SW_SoilWater.c
+++ b/SW_SoilWater.c
@@ -1006,17 +1006,19 @@ RealD SW_SnowDepth(RealD SWE, RealD snowdensity) {
   paper by Cosby,Hornberger,Clapp,Ginn,  in WATER RESOURCES RESEARCH
   June 1984.  Moisture retention data was fit to the power function.
 
-  The code assumes the following conditions (which are checked during data input):
-      * width > 0 which is checked by function `_read_layers`
-      * fractionGravel in [0, 1] which is checked by function `_read_layers`
-      * thetasMatric > 0 which is checked by function `water_eqn`
-      * bMatric != 0 which is checked by function `water_eqn`
+  The code assumes the following conditions:
+      * checked by `SW_SIT_init_run()`
+          * width > 0
+          * fractionGravel, sand, clay, and sand + clay in [0, 1]
+      * checked by function `water_eqn()`
+          * thetasMatric > 0
+          * bMatric != 0
 
   @param fractionGravel Fraction of soil containing gravel.
   @param swcBulk Soilwater content of the current layer (cm/layer)
   @param n Layer number to index the **lyr pointer
 
-  @return swb Soilwater potential of the current layer or soilwater content (if swflag=swFALSE)
+  @return soil water potential
 **/
 
 RealD SW_SWCbulk2SWPmatric(RealD fractionGravel, RealD swcBulk, LyrIndex n) {
@@ -1061,7 +1063,7 @@ HISTORY:
 	if (GT(swcBulk, 0.0)) {
 		// we have soil moisture
 
-		// calculate matric VWC from bulk VWC
+		// calculate matric VWC [cm / cm %] from bulk VWC
 		theta1 = (swcBulk / lyr->width) * 100. / (1. - fractionGravel);
 
 		// calculate (VWC / VWC(saturated)) ^ b

--- a/doc/additional_pages/SOILWAT2_Output_Variables.csv
+++ b/doc/additional_pages/SOILWAT2_Output_Variables.csv
@@ -1,0 +1,24 @@
+﻿Variable Group,By soil layer,Description
+temp_air,,"max., min, average air temperature (C; input)"
+precip,,"total precipitation (cm; input), rain, snow-fall, snowmelt, and snowloss (cm)"
+infiltration,,"infiltration (cm), runoff (cm)"
+vwc_bulk,x,bulk volumetric soilwater (cm / cm)
+vwc_matric,x,matric volumetric soilwater (cm / cm)
+swc_bulk,x,bulk soil water content (cm)
+swa,x,"plant available soil water (cm): trees, shrubs, forbs, grasses"
+swp_matric,x,matric soil water potential (-bars)
+surface_water,,surface water (cm)
+transp,x,"water extracted for transpiration (cm): total, trees, shrubs, forbs, grasses"
+evap_soil,x,bare-soil evaporation (cm)
+evap_surface,,"evaporation of intercepted rain (cm): total, trees, shrubs, forbs, grasses, litter, surface water"
+interception,,"intercepted rain (cm): total, trees, shrubs, forbs, grasses, and litter (cm)"
+percolation,x,water percolated among layers (cm)
+hydred,x,"hydraulic redistribution from each layer (cm): total, trees, shrubs, forbs, grasses"
+aet,,actual evapotranspiration (cm)
+pet,,"potential evapotranspiration (cm), extraterrestrial horizontal solar irradiation [MJ/m2], extraterrestrial tilted solar irradiation [MJ/m2], global horizontal irradiation [MJ/m2], global tilted irradiation [MJ/m2]"
+wetdays,x,days above -1.5 MPa
+snowpack,,"snowpack water equivalent (cm), snowdepth (cm)"
+deep_drain,,deep drainage = diffuse recharge (cm)
+temp_soil,x,soil temperature (C)
+co2effects,,"vegetation CO2-effect (multiplier) for trees, shrubs, forbs, grasses; WUE CO2-effect (multiplier) for trees, shrubs, forbs, grasses"
+vegetation,,"vegetation: cover (%) for trees, shrubs, forbs, grasses; biomass (g/m2 as component of total) for total, trees, shrubs, forbs, grasses, and litter; live biomass (g/m2 as component of total) total, trees, shrubs, forbs, grasses"

--- a/makefile
+++ b/makefile
@@ -38,7 +38,13 @@
 # make compiler_version print version information of CC and CXX compilers
 #-------------------------------------------------------------------------------
 
-uname_m = $(shell uname -m)
+#------ Identification
+SW2_VERSION := "$(shell git describe --abbrev=7 --dirty --always --tags)"
+HOSTNAME := "$(shell uname -sn)"
+
+sw_info = -DSW2_VERSION=\"$(SW2_VERSION)\" \
+					-DUSERNAME=\"$(USER)\" \
+					-DHOSTNAME=\"$(HOSTNAME)\"
 
 
 #------ OUTPUT NAMES
@@ -101,7 +107,7 @@ instr_flags_severe = \
 
 
 # Precompiler and compiler flags and options
-sw_CPPFLAGS = $(CPPFLAGS)
+sw_CPPFLAGS = $(CPPFLAGS) $(sw_info)
 sw_CFLAGS = $(CFLAGS)
 sw_CXXFLAGS = $(CXXFLAGS)
 

--- a/test/test_SW_Flow_Lib.cc
+++ b/test/test_SW_Flow_Lib.cc
@@ -898,8 +898,12 @@ namespace
   {
     //INPUTS
     unsigned int nlyrs, i, k;
-    double drainout = 0.1, sdrainpar = 0.6, sdraindpth = 6, standingWater = 0.;
-    double swc[MAX_LAYERS], drain[MAX_LAYERS], swcfc[MAX_LAYERS];
+    double
+      sum_delta_swc, small, drainout, standingWater,
+      sdrainpar = 0.02, // SW_Site.slow_drain_coeff
+      sdraindpth = SLOW_DRAIN_DEPTH;
+    double swc_init[MAX_LAYERS], swc[MAX_LAYERS];
+    double drain[MAX_LAYERS], swcfc[MAX_LAYERS];
     double width[MAX_LAYERS], swcmin[MAX_LAYERS], swcsat[MAX_LAYERS];
     double impermeability[MAX_LAYERS] = {0.};
 
@@ -915,433 +919,195 @@ namespace
         nlyrs = MAX_LAYERS; // test 2: MAX_LAYERS soil layers
       }
 
-      if(k == 1) //nlyrs = MAX_LAYERS
-      {
-
-        //Setup soil layers
-        create_test_soillayers(nlyrs);
-        drainout = 0.1, standingWater = 0;
-        ForEachSoilLayer(i)
-        {
-          // copy soil layer values into arrays so that they can be passed as
-          // example: swc as mean of wilting point and field capacity
-          swc[i] = (s->lyr[i]->swcBulk_fieldcap + s->lyr[i]->swcBulk_wiltpt)
-            / 2.;
-          drain[i] = 1.;
-          swcfc[i] = s->lyr[i]->swcBulk_fieldcap;
-          width[i] = s->lyr[i]->width;
-          swcmin[i] = s->lyr[i]->swcBulk_min;
-          swcsat[i] = s->lyr[i]->swcBulk_saturated;
-        }
-
-        //INPUTS for expected outputs
-        double swcExpected0[MAX_LAYERS] = {
-          0.335102, 0.084524, 0.369557, 0.092513, 0.072265,
-          0.578848, 0.079652, 0.079652, 0.179332, 0.365506,
-          0.749107, 0.073229, 0.072265, 0.578848, 0.079652,
-          0.079652, 0.059777, 0.073101, 0.074911, 0.366146,
-          0.722649, 0.723560, 0.796521, 1.593042, 3.223746};
-        double drainExpected0[MAX_LAYERS];
-        double drainoutExpected = 0.1, standingWaterExpected = 0.;
-        ForEachSoilLayer(i)
-        {
-          drainExpected0[i] = 1.;
-        }
-        //Begin TEST for if swc[i] <= swcmin[i]
-        //Inputs for swc and swcmin have been swapped
-        ForEachSoilLayer(i)
-        {
-          swc[i] = s->lyr[i]->swcBulk_min;
-          swcmin[i] = (s->lyr[i]->swcBulk_fieldcap + s->lyr[i]->swcBulk_wiltpt)
-            / 2.;
-          drain[i] = 1.;
-        }
-
-        infiltrate_water_low(swc, drain, &drainout, nlyrs, sdrainpar,
-          sdraindpth, swcfc, width, swcmin, swcsat, impermeability,
-          &standingWater);
-        //drainout expected to be 0.1
-        EXPECT_NEAR(drainoutExpected, drainout, tol6);
-        //standingWater expected to be 0.
-        EXPECT_NEAR(standingWaterExpected, standingWater, tol6);
-
-        ForEachSoilLayer(i)
-        {
-          EXPECT_NEAR(swc[i], swcExpected0[i], tol6) <<
-            "infiltrate_water_low: swc != expected for layer " << 1 + i;
-          EXPECT_NEAR(drain[i], drainExpected0[i], tol6) <<
-            "infiltrate_water_low: drain != expected for layer " << 1 + i;
-        }
-
-        //Reset to previous global states.
-        Reset_SOILWAT2_after_UnitTest();
-
-        //Begin TEST for if swc[i] > swcmin[i]
-        //Setup soil layers
-        create_test_soillayers(nlyrs);
-        //Reset INPUTS; swc[i] > swcmin[i]
-        ForEachSoilLayer(i)
-        {
-          swc[i] = (s->lyr[i]->swcBulk_fieldcap + s->lyr[i]->swcBulk_wiltpt)
-            / 2.;
-          drain[i] = 1.;
-          swcfc[i] = s->lyr[i]->swcBulk_fieldcap;
-          width[i] = s->lyr[i]->width;
-          swcmin[i] = s->lyr[i]->swcBulk_min;
-          swcsat[i] = s->lyr[i]->swcBulk_saturated;
-        }
-        drainout = 0.1, standingWater = 0;
-
-        //Reset expected outcomes
-        double swcExpected1[MAX_LAYERS] = {
-          0.399392, 0.084524, 0.940897, 0.258086, 0.232875,
-          1.850324, 0.167824, 0.167824, 0.440474, 0.919427,
-          2.204563, 0.229410, 0.232875, 1.850324, 0.167824,
-          0.167824, 0.146825, 0.183885, 0.220456, 1.147049,
-          2.328750, 2.312906, 1.678236, 3.400368, 6.776540};
-        double drainExpected1[MAX_LAYERS] = {
-          1.426497, 1.548844, 1.600000, 1.600000, 1.600000,
-          1.600000, 1.600000, 1.600000, 1.600000, 1.600000,
-          1.600000, 1.600000, 1.600000, 1.600000, 1.600000,
-          1.600000, 1.600000, 1.600000, 1.600000, 1.600000,
-          1.600000, 1.600000, 1.600000, 1.556104, 1.507181};
-        standingWaterExpected = 0, drainoutExpected = 0.607181;
-
-        infiltrate_water_low(swc, drain, &drainout, nlyrs, sdrainpar,
-          sdraindpth, swcfc, width, swcmin, swcsat, impermeability,
-          &standingWater);
-
-        //drainout is expected to be 0.1
-        EXPECT_NEAR(drainoutExpected, drainout, tol6);
-        //standingWater is expected to be 0.
-        EXPECT_NEAR(standingWater, standingWaterExpected, tol6);
-
-        ForEachSoilLayer(i)
-        {
-          EXPECT_NEAR(swc[i], swcExpected1[i], tol6) <<
-            "infiltrate_water_low: swc != expected for layer " << 1 + i;
-          EXPECT_NEAR(drain[i], drainExpected1[i], tol6) <<
-            "infiltrate_water_low: drain != expected for layer " << 1 + i;
-        }
-
-        //Reset to previous global states.
-        Reset_SOILWAT2_after_UnitTest();
-
-        //Setup soil layers
-        create_test_soillayers(nlyrs);
-
-        //Begin TEST for if swc[j] > swcsat[j]
-        //Reset INPUTS; swc[j] > swcsat[j]
-        //swc and swcsat have been swapped
-        ForEachSoilLayer(i)
-        {
-          swcsat[i] = ((s->lyr[i]->swcBulk_fieldcap + s->lyr[i]->swcBulk_wiltpt)
-            / 2.);
-          swc[i] = s->lyr[i]->swcBulk_saturated;
-          drain[i] = 1;
-        }
-        standingWater = 0, drainout = 0.1;
-
-        //INPUTS for expected outputs
-        double swcExpected2[MAX_LAYERS] = {
-          0.825889, 0.206871, 0.992054, 0.258086, 0.232875,
-          1.850324, 0.167824, 0.167824, 0.440474, 0.919427,
-          2.204563, 0.229410, 0.232875, 1.850324, 0.167824,
-          0.167824, 0.146825, 0.183885, 0.220456, 1.147049,
-          2.328750, 2.312906, 1.678236, 3.356472, 6.727619};
-        double drainExpected2[MAX_LAYERS] = {
-          -19.455442, -19.300536, -18.690795, -18.534689, -18.393543,
-          -17.261477, -17.113211, -16.964945, -16.483618, -15.795148,
-          -14.440166, -14.301405, -14.160259, -13.028194, -12.879927,
-          -12.731661, -12.571219, -12.433525, -12.298027, -11.604222,
-          -10.192758, -8.777677, -7.295012, -4.329682, 1.6};
-        standingWaterExpected = 21.35793, drainoutExpected = 0.7;
-
-        infiltrate_water_low(swc, drain, &drainout, nlyrs, sdrainpar,
-          sdraindpth, swcfc, width, swcmin, swcsat, impermeability,
-          &standingWater);
-
-        //drainout is expected to be 0.1
-        EXPECT_NEAR(drainoutExpected, drainout, tol6);
-        //standingWater is expected to be 0.
-        EXPECT_NEAR(standingWater, standingWaterExpected, tol6);
-
-        ForEachSoilLayer(i)
-        {
-        EXPECT_NEAR(swc[i], swcExpected2[i], tol6) <<
-          "infiltrate_water_low: swc != expected for layer " << 1 + i;
-        EXPECT_NEAR(drain[i], drainExpected2[i], tol6) <<
-          "infiltrate_water_low: drain != expected for layer " << 1 + i;
-        }
-
-        //Reset to previous global states.
-        Reset_SOILWAT2_after_UnitTest();
-
-        //Setup soil layers
-        create_test_soillayers(nlyrs);
-
-        //Begin TEST for if swc[j] <= swcsat[j]
-        //INPUTS
-        //Reset INPUTS; swc[j] <= swcsat[j]
-        //swc and swcsat have been reset
-        ForEachSoilLayer(i)
-        {
-          swc[i] = (s->lyr[i]->swcBulk_fieldcap + s->lyr[i]->swcBulk_wiltpt)
-            / 2.;
-          drain[i] = 1.;
-          swcfc[i] = s->lyr[i]->swcBulk_fieldcap;
-          width[i] = s->lyr[i]->width;
-          swcmin[i] = s->lyr[i]->swcBulk_min;
-          swcsat[i] = s->lyr[i]->swcBulk_saturated;
-        }
-        standingWater = 0, drainout = 0.1;
-
-        //INPUTS for expected outputs
-        double swcExpected3[MAX_LAYERS] = {
-          0.399392, 0.084524, 0.940896, 0.258086, 0.232875,
-          1.850324, 0.167824, 0.167824, 0.440474, 0.919427,
-          2.204563, 0.229410, 0.232875, 1.850324, 0.167824,
-          0.167824, 0.146825, 0.183885, 0.220456, 1.147049,
-          2.328750, 2.312906, 1.678236, 3.400368, 6.776541};
-        double drainExpected3[MAX_LAYERS] = {
-          1.426497, 1.548844, 1.600000, 1.600000, 1.600000,
-          1.600000, 1.600000, 1.600000, 1.600000, 1.600000,
-          1.600000, 1.600000, 1.600000, 1.600000, 1.600000,
-          1.600000, 1.600000, 1.600000, 1.600000, 1.600000,
-          1.600000, 1.600000, 1.600000, 1.556104, 1.507182};
-        standingWaterExpected = 0, drainoutExpected = 0.607181;
-
-        infiltrate_water_low(swc, drain, &drainout, nlyrs, sdrainpar,
-          sdraindpth, swcfc, width, swcmin, swcsat, impermeability,
-          &standingWater);
-
-        //drainout is expected to be 0.607181
-        EXPECT_NEAR(drainoutExpected, drainout, tol6);
-        //standingWater is expected to be 0.
-        EXPECT_NEAR(standingWater, standingWaterExpected, tol6);
-
-        ForEachSoilLayer(i)
-        {
-          EXPECT_NEAR(swc[i], swcExpected3[i], tol6) <<
-            "infiltrate_water_low: swc != expected for layer " << 1 + i;
-          EXPECT_NEAR(drain[i], drainExpected3[i], tol6) <<
-            "infiltrate_water_low: drain != expected for layer " << 1 + i;
-        }
-
-      }
-      //Reset to previous global states.
-      Reset_SOILWAT2_after_UnitTest();
-
-      //Setup soil layers
+      // Setup soil layers
       create_test_soillayers(nlyrs);
-      if(k == 0) //nlyrs = 1
+
+      // Initialize soil arrays to be independent of soil texture...
+      ForEachSoilLayer(i)
       {
-        //INPUTS for one layer
-        ForEachSoilLayer(i)
-        {
-          // copy soil layer values into arrays so that they can be passed as
-          // example: swc as mean of wilting point and field capacity
-          swc[i] = (s->lyr[i]->swcBulk_fieldcap + s->lyr[i]->swcBulk_wiltpt)
-            / 2.;
-          drain[i] = 1.;
-          swcfc[i] = s->lyr[i]->swcBulk_fieldcap;
-          width[i] = s->lyr[i]->width;
-          swcmin[i] = s->lyr[i]->swcBulk_min;
-          swcsat[i] = s->lyr[i]->swcBulk_saturated;
-        }
-        //INPUTS for expected outputs
-        double swcExpected_1[1] = {0.335102};
-        double drainExpected_1[1] = {1.};
-        double drainoutExpected = 0.1, standingWaterExpected = 0;
-
-        //Begin TEST for if swc[i] <= swcmin[i]
-        //Inputs for swc and swcmin have been swapped
-        ForEachSoilLayer(i)
-        {
-          swc[i] = s->lyr[i]->swcBulk_min;
-          swcmin[i] = (s->lyr[i]->swcBulk_fieldcap + s->lyr[i]->swcBulk_wiltpt)
-            / 2.;
-        }
-        infiltrate_water_low(swc, drain, &drainout, nlyrs, sdrainpar,
-          sdraindpth, swcfc, width, swcmin, swcsat, impermeability,
-          &standingWater);
-
-        //drainout is expected to be 0.1
-        EXPECT_NEAR(drainoutExpected, drainout, tol6);
-        //standingWater is expected to be 0.
-        EXPECT_NEAR(standingWater, standingWaterExpected, tol6);
-
-        //swc is expected to match 0.335102
-        EXPECT_NEAR(swc[0], swcExpected_1[0], tol6);
-        //drain is expected to match 1.
-        EXPECT_DOUBLE_EQ(drain[0], drainExpected_1[0]);
-
-        //Reset to previous global states.
-        Reset_SOILWAT2_after_UnitTest();
-
-        //Setup soil layers
-        create_test_soillayers(nlyrs);
-
-        //Begin TEST for if swc[i] > swcmin[i]
-        standingWater = 0, drainout = 0.1;
-        ForEachSoilLayer(i)
-        {
-          swc[i] = (s->lyr[i]->swcBulk_fieldcap + s->lyr[i]->swcBulk_wiltpt)
-            / 2.;
-          swcmin[i] = s->lyr[i]->swcBulk_min;
-          drain[i] = 1.;
-        }
-        double swcExpected2_1[1] = {0.399392};
-        double drainExpected2_1[1] = {1.426497};
-        standingWaterExpected = 0., drainoutExpected = 0.526497;
-
-        infiltrate_water_low(swc, drain, &drainout, nlyrs, sdrainpar,
-          sdraindpth, swcfc, width, swcmin, swcsat, impermeability,
-          &standingWater);
-
-        //drainout is expected to be 0.526497
-        EXPECT_NEAR(drainoutExpected, drainout, tol6);
-        //standingWater is expected to be 0.
-        EXPECT_NEAR(standingWater, standingWaterExpected, tol6);
-
-        //swc is expected to match 0.399392
-        EXPECT_NEAR(swc[0], swcExpected2_1[0], tol6);
-        //drain is expected to match 1.426497
-        EXPECT_NEAR(drain[0], drainExpected2_1[0], tol6);
-
-        //Reset to previous global states.
-        Reset_SOILWAT2_after_UnitTest();
-
-        //Setup soil layers
-        create_test_soillayers(nlyrs);
-
-        //Begin TEST for if lyrFrozen == true
-        //INPUTS for expected outputs
-        double swcExpected3_1[1] = {0.821624};
-        double drainoutExpectedf = 0.104265;
-        //Set lyrFrozen
-        ForEachSoilLayer(i)
-        {
-          st->lyrFrozen[i] = swTRUE;
-        }
-
-        infiltrate_water_low(swc, drain, &drainout, nlyrs, sdrainpar,
-          sdraindpth, swcfc, width, swcmin, swcsat, impermeability,
-          &standingWater);
-
-        if (st->lyrFrozen[i] == swTRUE)
-        {
-          //standingWater is expected to be 0.
-          EXPECT_NEAR(standingWater, standingWaterExpected, tol6);
-          //drainout is expected to be 0.104265
-          EXPECT_NEAR(drainoutExpectedf, drainout, tol6);
-          //swc is expected to match 0.821624
-          EXPECT_NEAR(swc[0], swcExpected3_1[0], tol6);
-          //drain is expected to match 1.426497
-          EXPECT_NEAR(drain[0], drainExpected2_1[0], tol6);
-        }
-        //Reset to previous global states.
-        Reset_SOILWAT2_after_UnitTest();
-        //Setup soil layers
-        create_test_soillayers(nlyrs);
-
-        //Begin TEST for if lyrFrozen == false
-        ForEachSoilLayer(i)
-        {
-          st->lyrFrozen[i] = swFALSE;
-          swc[i] = (s->lyr[i]->swcBulk_fieldcap + s->lyr[i]->swcBulk_wiltpt)
-            / 2.;
-          drain[i] = 1.;
-          swcfc[i] = s->lyr[i]->swcBulk_fieldcap;
-          width[i] = s->lyr[i]->width;
-          swcmin[i] = s->lyr[i]->swcBulk_min;
-          swcsat[i] = s->lyr[i]->swcBulk_saturated;
-        }
-
-        //Reset to previous global states.
-        Reset_SOILWAT2_after_UnitTest();
-
-        //Setup soil layers
-        create_test_soillayers(nlyrs);
-
-        //Begin TEST for if swc[j] > swcsat[j]
-
-        //INPUTS
-        //swc and swcsat have been swapped
-        standingWater = 0, drainout = 0.1;
-        ForEachSoilLayer(i)
-        {
-          swcsat[i] = (s->lyr[i]->swcBulk_fieldcap + s->lyr[i]->swcBulk_wiltpt)
-            / 2.;
-          drain[i] = 1.;
-          swcfc[i] = s->lyr[i]->swcBulk_fieldcap;
-          width[i] = s->lyr[i]->width;
-          swcmin[i] = s->lyr[i]->swcBulk_min;
-          swc[i] = s->lyr[i]->swcBulk_saturated;
-        }
-
-        //INPUTS for expected outputs
-        double swcExpected4_1[1] = {0.825889};
-        double drainExpected4_1[1] = {1.6};
-        standingWaterExpected = 0.302488, drainoutExpected = 0.7;
-
-        infiltrate_water_low(swc, drain, &drainout, nlyrs, sdrainpar,
-          sdraindpth, swcfc, width, swcmin, swcsat, impermeability,
-          &standingWater);
-
-        //drainout is expected to be 0.7
-        EXPECT_NEAR(drainout, drainoutExpected, tol6);
-        //standingWater expected to be 0.302488
-        EXPECT_NEAR(standingWater, standingWaterExpected, tol6);
-        //swc is expected to match 0.825889
-        EXPECT_NEAR(swc[0], swcExpected4_1[0], tol6);
-        //drain is expected to match 1.6
-        EXPECT_NEAR(drain[0], drainExpected4_1[0], tol6);
-
-        //Reset to previous global states.
-        Reset_SOILWAT2_after_UnitTest();
-
-        //Setup soil layers
-        create_test_soillayers(nlyrs);
-
-        //Begin TEST for if swc[j] <= swcsat[j]
-        //Reset INPUTS; swc[j] <= swcsat[j]
-        //swc and swcsat have been reset
-        standingWater = 0, drainout = 0.1;
-        ForEachSoilLayer(i)
-        {
-          swc[i] = (s->lyr[i]->swcBulk_fieldcap + s->lyr[i]->swcBulk_wiltpt)
-            / 2.;
-          drain[i] = 1.;
-          swcfc[i] = s->lyr[i]->swcBulk_fieldcap;
-          width[i] = s->lyr[i]->width;
-          swcmin[i] = s->lyr[i]->swcBulk_min;
-          swcsat[i] = s->lyr[i]->swcBulk_saturated;
-        }
-
-        //INPUTS for expected outputs
-        double swcExpected5_1[1] = {0.399392};
-        double drainExpected5_1[1] = {1.426497};
-        standingWaterExpected = 0., drainoutExpected = 0.526497;
-
-        infiltrate_water_low(swc, drain, &drainout, nlyrs, sdrainpar,
-          sdraindpth, swcfc, width, swcmin, swcsat, impermeability,
-          &standingWater);
-
-        //drainout is expected to be 0.526497
-        EXPECT_NEAR(drainout, drainoutExpected, tol6);
-        //standingWater expected to be 0.
-        EXPECT_NEAR(standingWater, standingWaterExpected, tol6);
-        //swc is expected to be 0.399392
-        EXPECT_NEAR(swc[0], swcExpected5_1[0], tol6);
-        //drain is expected to be 1.426497
-        EXPECT_NEAR(drain[0], drainExpected5_1[0], tol6);
-
+        width[i] = s->lyr[i]->width;
+        swcfc[i] = 0.25 * width[i];
+        swcmin[i] = 0.05 * width[i];
+        swcsat[i] = 0.35 * width[i];
       }
-      //Reset to previous global states.
-      Reset_SOILWAT2_after_UnitTest();
+
+
+      //--- (1) TEST:
+      //        if swc[i] <= swcmin[i],
+      //        then expect drain = 0
+
+      // Set initial values
+      drainout = 0.;
+      standingWater = 0;
+
+      ForEachSoilLayer(i)
+      {
+        swc_init[i] = 0.5 * swcmin[i];
+        swc[i] = swc_init[i];
+        drain[i] = 0.;
+      }
+
+      // Call function to test
+      infiltrate_water_low(
+        swc, drain, &drainout, nlyrs, sdrainpar,
+        sdraindpth, swcfc, width, swcmin, swcsat, impermeability,
+        &standingWater
+      );
+
+      // Expectation: drainout = 0
+      EXPECT_NEAR(drainout, 0., tol6);
+
+      // Expectation: standingWater = 0
+      EXPECT_NEAR(standingWater, 0., tol6);
+
+      // Expectations: (i) drain[i] = 0; (ii) delta(swc[i]) = 0
+      ForEachSoilLayer(i)
+      {
+        EXPECT_NEAR(drain[i], 0., tol6) <<
+          "infiltrate_water_low: drain != 0 for layer " << 1 + i;
+        EXPECT_NEAR(swc[i], swc_init[i], tol6) <<
+          "infiltrate_water_low: swc != swc_init for layer " << 1 + i;
+      }
+
+
+      //--- (2) TEST:
+      //        if swc_fc > swc[i] > swcmin[i],
+      //        then expect drain > 0
+
+      // Set initial values
+      drainout = 0.;
+      standingWater = 0;
+
+      ForEachSoilLayer(i)
+      {
+        swc_init[i] = 0.9 * swcfc[i];
+        swc[i] = swc_init[i];
+        drain[i] = 0.;
+      }
+
+      // Call function to test
+      infiltrate_water_low(
+        swc, drain, &drainout, nlyrs, sdrainpar,
+        sdraindpth, swcfc, width, swcmin, swcsat, impermeability,
+        &standingWater
+      );
+
+      // Expectation: drainout > 0
+      EXPECT_GT(drainout, 0.);
+
+      // Expectation: standingWater = 0
+      EXPECT_NEAR(standingWater, 0., tol6);
+
+      // Expectations: (i) drain[i] > 0; (ii) sum(delta(swc[i])) < 0
+      sum_delta_swc = 0.;
+      ForEachSoilLayer(i)
+      {
+        EXPECT_GT(drain[i], 0.) <<
+          "infiltrate_water_low: drain !> 0 for layer " << 1 + i;
+        sum_delta_swc += swc[i] - swc_init[i];
+      }
+      EXPECT_LT(sum_delta_swc, 0.) <<
+        "infiltrate_water_low: sum(delta(swc[i])) !< 0 for layer " << 1 + i;
+
+
+      //--- (3) TEST:
+      //        if swc_sat ~ swc[i] > swc_fc[i],
+      //        then expect drain < 0 && ponded > 0
+
+      // Set initial values
+      drainout = 0.;
+      standingWater = 0;
+
+      ForEachSoilLayer(i)
+      {
+        swc_init[i] = 1.1 * swcsat[i];
+        swc[i] = swc_init[i];
+        drain[i] = 0.;
+      }
+
+      // Call function to test
+      infiltrate_water_low(
+        swc, drain, &drainout, nlyrs, sdrainpar,
+        sdraindpth, swcfc, width, swcmin, swcsat, impermeability,
+        &standingWater
+      );
+
+      // Expectation: drainout > 0
+      EXPECT_GT(drainout, 0.);
+
+      // Expectation: standingWater > 0
+      EXPECT_GT(standingWater, 0.);
+
+      // Expectations: (i) drain[i] < 0; (ii) sum(delta(swc[i])) < 0
+      sum_delta_swc = 0.;
+      ForEachSoilLayer(i)
+      {
+        if (i + 1 < nlyrs) {
+          EXPECT_LT(drain[i], 0.) <<
+            "infiltrate_water_low: drain !< 0 for layer " << 1 + i;
+        } else {
+          EXPECT_NEAR(drain[i], sdrainpar, tol6) <<
+            "infiltrate_water_low: drain != sdrainpar for last layer " << 1 + i;
+        }
+        sum_delta_swc += swc[i] - swc_init[i];
+      }
+      EXPECT_LT(sum_delta_swc, 0.) <<
+        "infiltrate_water_low: sum(delta(swc[i])) !< 0 for layer " << 1 + i;
+
+
+      //--- (4) TEST:
+      //        if lyrFrozen[i],
+      //        then expect drain[i] to be small
+      small = tol3;
+
+      // Set initial values
+      drainout = 0.;
+      standingWater = 0;
+
+      ForEachSoilLayer(i)
+      {
+        swc_init[i] = 0.9 * swcfc[i];
+        swc[i] = swc_init[i];
+        drain[i] = 0.;
+        st->lyrFrozen[i] = swTRUE;
+      }
+
+      // Call function to test
+      infiltrate_water_low(
+        swc, drain, &drainout, nlyrs, sdrainpar,
+        sdraindpth, swcfc, width, swcmin, swcsat, impermeability,
+        &standingWater
+      );
+
+      // Expectation: small > drainout > 0
+      EXPECT_GT(drainout, 0.);
+      EXPECT_LT(drainout, small);
+
+      // Expectation: standingWater = 0
+      EXPECT_NEAR(standingWater, 0., tol6);
+
+      // Expectations: (i) small > drain[i] > 0; (ii) delta(swc[i]) ~ 0
+      ForEachSoilLayer(i)
+      {
+        EXPECT_GT(drain[i], 0.) <<
+          "infiltrate_water_low: drain !> 0 for layer " << 1 + i;
+        EXPECT_LT(drain[i], small) <<
+          "infiltrate_water_low: small !> drain for layer " << 1 + i;
+        EXPECT_NEAR(swc[i], swc_init[i], small) <<
+          "infiltrate_water_low: swc !~ swc_init for layer " << 1 + i;
+      }
+
+      // Reset frozen status
+      ForEachSoilLayer(i)
+      {
+        st->lyrFrozen[i] = swFALSE;
+      }
     }
+
+    // Reset to previous global states.
+    Reset_SOILWAT2_after_UnitTest();
   }
+
 
   //TEST for hydraulic_redistribution when nlyrs = MAX_LAYERS and nlyrs = 1
   TEST(SWFlowTest, hydraulic_redistribution)

--- a/test/test_SW_Flow_Lib_PET.cc
+++ b/test/test_SW_Flow_Lib_PET.cc
@@ -1042,4 +1042,108 @@ namespace
     SW_PET_init_run(); // Re-init radiation memoization
   }
 
+
+
+  #ifdef SW2_PET_Test__petfunc_by_temps
+  // Run SOILWAT2 unit tests with flag
+  // ```
+  //   CPPFLAGS=-DSW2_PET_Test__petfunc_by_temps make test test_run
+  // ```
+  //
+  // Produce plots based on output generated above
+  // ```
+  //   Rscript tools/plot__SW2_PET_Test__petfunc_by_temps.R
+  // ```
+  TEST(SW2_PET_Test, petfunc_by_temps)
+  {
+    int doy, k1, k2, k3, k4, k5;
+
+    double
+      pet,
+      temp, RH, windspeed, cloudcover, fH_gt,
+      H_gt, H_oh, H_ot, H_gh,
+      elev = 0.,
+      lat = 40.,
+      slope = 0.,
+      aspect = SW_MISSING,
+      reflec = 0.15;
+
+    FILE *fp;
+    char fname[FILENAME_MAX];
+
+    strcpy(fname, output_prefix);
+    strcat(fname, "Table__SW2_PET_Test__petfunc_by_temps.csv");
+    fp = OpenFile(fname, "w");
+
+    // Column names
+    fprintf(
+      fp,
+      "Temperature_C, RH_pct, windspeed_m_per_s, cloudcover_pct, fH_gt, PET_mm"
+      "\n"
+    );
+
+    // Loop over treatment factors
+    for (k1 = -40; k1 < 60; k1++)
+    {
+      temp = k1;
+
+      for (k2 = 0; k2 <= 10; k2++)
+      {
+        RH = 10. * k2;
+
+        for (k3 = 0; k3 <= 3; k3++)
+        {
+          windspeed = squared(k3);
+
+          for (k4 = 0; k4 <= 3; k4++)
+          {
+            cloudcover = 33.3 * k4;
+
+            for (k5 = -1; k5 <= 1; k5++)
+            {
+              fH_gt = 1 + k5 * 0.2;
+              pet = 0.;
+
+              for (doy = 1; doy <= 365; doy++)
+              {
+
+                H_gt = fH_gt * solar_radiation(
+                  doy,
+                  lat, elev, slope, aspect, reflec,
+                  cloudcover, RH, temp,
+                  &H_oh, &H_ot, &H_gh
+                );
+
+                pet += petfunc(
+                  H_gt,
+                  temp,
+                  elev, reflec,
+                  RH, windspeed, cloudcover
+                );
+              }
+
+              fprintf(
+                fp,
+                "%f, %f, %f, %f, %f, %f\n",
+                temp,
+                RH,
+                windspeed,
+                cloudcover,
+                fH_gt,
+                pet
+              );
+
+              fflush(fp);
+            }
+          }
+        }
+      }
+    }
+
+    // Clean up
+    CloseFile(&fp);
+  }
+  #endif // end of SW2_PET_Test__petfunc_by_temps
+
+
 }

--- a/test/test_SW_Flow_lib_temp.cc
+++ b/test/test_SW_Flow_lib_temp.cc
@@ -448,9 +448,18 @@ namespace {
     double swc[] = {1.0}, swc_sat[] = {1.5}, bDensity[] = {1.8}, width[] = {20},
     oldsTemp[] = {5.0}, sTemp[] = {4.0}, fc[] = {2.6}, wp[] = {1.0};
 
+    SW_ST_init_run(
+      airTemp,
+      swc, swc_sat,
+      bDensity, width,
+      oldsTemp, surfaceTemp,
+      nlyrs, fc, wp,
+      sTconst, deltaX, theMaxDepth,
+      nRgr, &ptr_stError
+    );
 
     soil_temperature(airTemp, pet, aet, biomass, swc, swc_sat, bDensity, width,
-      oldsTemp, sTemp, surfaceTemp, nlyrs, fc, wp, bmLimiter, t1Param1, t1Param2,
+      oldsTemp, sTemp, surfaceTemp, nlyrs, bmLimiter, t1Param1, t1Param2,
       t1Param3, csParam1, csParam2, shParam, snowdepth, sTconst, deltaX, theMaxDepth,
       nRgr, snow, &ptr_stError);
 
@@ -464,7 +473,7 @@ namespace {
     snowdepth = 0;
 
     soil_temperature(airTemp, pet, aet, biomass, swc, swc_sat, bDensity, width,
-      oldsTemp, sTemp, surfaceTemp, nlyrs, fc, wp, bmLimiter, t1Param1, t1Param2,
+      oldsTemp, sTemp, surfaceTemp, nlyrs, bmLimiter, t1Param1, t1Param2,
       t1Param3, csParam1, csParam2, shParam, snowdepth, sTconst, deltaX, theMaxDepth,
       nRgr, snow, &ptr_stError);
 
@@ -476,7 +485,7 @@ namespace {
     biomass = 305;
 
     soil_temperature(airTemp, pet, aet, biomass, swc, swc_sat, bDensity, width,
-      oldsTemp, sTemp, surfaceTemp, nlyrs, fc, wp, bmLimiter, t1Param1, t1Param2,
+      oldsTemp, sTemp, surfaceTemp, nlyrs, bmLimiter, t1Param1, t1Param2,
       t1Param3, csParam1, csParam2, shParam, snowdepth, sTconst, deltaX, theMaxDepth,
       nRgr, snow, &ptr_stError);
 
@@ -505,19 +514,34 @@ namespace {
     // ptr_stError should be set to TRUE if soil_temperature_today fails (i.e. unrealistic temp values)
     double *sTemp2 = new double[nlyrs];
     double *oldsTemp2 = new double[nlyrs];
+
+    surfaceTemp[Today] = airTemp = 1500.;
+
     for (i = 0; i < nlyrs; i++)
     {
-      sTemp2[i] = RandNorm(150, 1,&MSTF_Lyer1_rng);
-      oldsTemp2[i] = RandNorm(150, 1,&MSTF_Lyer1_rng);
+      sTemp2[i] = RandNorm(surfaceTemp[Today], 1, &MSTF_Lyer1_rng);
+      oldsTemp2[i] = RandNorm(surfaceTemp[Today], 1, &MSTF_Lyer1_rng);
     }
 
+    SW_ST_init_run(
+      airTemp,
+      swc, swc_sat,
+      bDensity, width,
+      oldsTemp, surfaceTemp,
+      nlyrs, fc, wp,
+      sTconst, deltaX, theMaxDepth,
+      nRgr, &ptr_stError
+    );
+
+    EXPECT_EQ(ptr_stError, swFALSE);
+
     soil_temperature(airTemp, pet, aet, biomass, swc, swc_sat, bDensity, width,
-      oldsTemp2, sTemp2, surfaceTemp, nlyrs, fc, wp, bmLimiter, t1Param1, t1Param2,
+      oldsTemp2, sTemp2, surfaceTemp, nlyrs, bmLimiter, t1Param1, t1Param2,
       t1Param3, csParam1, csParam2, shParam, snowdepth, sTconst, deltaX, theMaxDepth,
       nRgr, snow, &ptr_stError);
 
-    // Check that ptr_stError is TRUE
-    EXPECT_EQ(ptr_stError, 1);
+    // Check that error has occurred as indicated by ptr_stError
+    EXPECT_EQ(ptr_stError, swTRUE);
 
     //Reset to global state
     Reset_SOILWAT2_after_UnitTest();
@@ -549,7 +573,7 @@ namespace {
     double sTemp3[] = {1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4};
     double bDensity2[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
 
-        // we don't need soil texture, but we need SWC(sat), SWC(field capacity),
+    // we don't need soil texture, but we need SWC(sat), SWC(field capacity),
     // and SWC(wilting point)
     double *swc2 = new double[nlyrs2];
     double *swc_sat2 = new double[nlyrs2];
@@ -570,11 +594,21 @@ namespace {
       //  i, bDensity2[i],  swc_sat2[i], fc2[i], swc2[i], wp2[i] );
     }
 
+    SW_ST_init_run(
+      airTemp,
+      swc2, swc_sat2,
+      bDensity2, width2,
+      oldsTemp3, surfaceTemp,
+      nlyrs2, fc2, wp2,
+      sTconst, deltaX, theMaxDepth,
+      nRgr, &ptr_stError
+    );
+
     // Test surface temp equals surface_temperature_under_snow() because snow > 0
     snowdepth = 5;
 
     soil_temperature(airTemp, pet, aet, biomass, swc2, swc_sat2, bDensity2, width2,
-      oldsTemp3, sTemp3, surfaceTemp, nlyrs2, fc2, wp2, bmLimiter, t1Param1, t1Param2,
+      oldsTemp3, sTemp3, surfaceTemp, nlyrs2, bmLimiter, t1Param1, t1Param2,
       t1Param3, csParam1, csParam2, shParam, snowdepth, sTconst, deltaX, theMaxDepth,
       nRgr, snow, &ptr_stError);
 
@@ -587,7 +621,7 @@ namespace {
     biomass = 100;
 
     soil_temperature(airTemp, pet, aet, biomass, swc2, swc_sat2, bDensity2, width2,
-      oldsTemp3, sTemp3, surfaceTemp, nlyrs2, fc2, wp2, bmLimiter, t1Param1, t1Param2,
+      oldsTemp3, sTemp3, surfaceTemp, nlyrs2, bmLimiter, t1Param1, t1Param2,
       t1Param3, csParam1, csParam2, shParam, snowdepth, sTconst, deltaX, theMaxDepth,
       nRgr, snow, &ptr_stError);
 
@@ -599,7 +633,7 @@ namespace {
     biomass = 305;
 
     soil_temperature(airTemp, pet, aet, biomass, swc2, swc_sat2, bDensity2, width2,
-      oldsTemp3, sTemp3, surfaceTemp, nlyrs2, fc2, wp2, bmLimiter, t1Param1, t1Param2,
+      oldsTemp3, sTemp3, surfaceTemp, nlyrs2, bmLimiter, t1Param1, t1Param2,
       t1Param3, csParam1, csParam2, shParam, snowdepth, sTconst, deltaX, theMaxDepth,
       nRgr, snow, &ptr_stError);
 
@@ -624,12 +658,12 @@ namespace {
       //swprintf("\n k %u, newoldtempR %f", k, stValues.oldsTempR[k]);
       EXPECT_NE(stValues.oldsTempR[k], SW_MISSING);
     }
-    
+
     double *array_list[] = { swc2, swc_sat2, fc2, wp2};
     for (i = 0; i < length(array_list); i++){
       delete[] array_list[i];
     }
-    
+
     // Reset to global state
     Reset_SOILWAT2_after_UnitTest();
   }
@@ -637,48 +671,23 @@ namespace {
   // Test that main soil temperature functions fails when it is supposed to
   TEST(SWFlowTempDeathTest, MainSoilTemperatureFunctionDeathTest) {
 
-    // *****  Test when nlyrs = MAX_LAYERS  ***** //
-
-    // intialize values
-    unsigned int nRgr = 65, i = 0.;
+    unsigned int nlyrs = 1, nRgr = 65;
     double airTemp = 25.0, pet = 5.0, aet = 4.0, biomass = 100., surfaceTemp[] = {20.0, 15. ,14.},
     bmLimiter = 300., t1Param1 = 15., t1Param2 = -4., t1Param3 = 600., csParam1 =0.00070,
     csParam2 = 0.00030, shParam = 0.18, snowdepth = 5, sTconst = 4.15, deltaX = 15,
-    snow = 1;
+    theMaxDepth = 990., snow = 1;
     Bool ptr_stError = swFALSE;
 
-    pcg32_random_t MSTFDT_rng;
-    RandSeed(0, &MSTFDT_rng);
+    double swc[] = {1.0}, swc_sat[] = {1.5}, bDensity[] = {1.8}, width[] = {20},
+    oldsTemp[] = {5.0}, sTemp[] = {4.0};
 
-    unsigned int nlyrs = MAX_LAYERS;
-    double width[] = {5, 5, 5, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 20, 20, 20, 20, 20, 20};
-    double oldsTemp[] = {1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4};
-    double sTemp[] = {1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4};
-    double *swc = new double[nlyrs];
-    double *swc_sat = new double[nlyrs];
-    double *bDensity = new double[nlyrs];
-    double *fc = new double[nlyrs];
-    double *wp = new double[nlyrs];
-
-    for (i = 0; i < nlyrs; i++) {
-      bDensity[i] = fmaxf(RandNorm(1.,0.5, &MSTFDT_rng), 0.1); // greater than 0.1
-      fc[i] = fmaxf(RandNorm(1.5, 0.5, &MSTFDT_rng), 0.1); // greater than 0.1
-      swc_sat[i] = fc[i] + 0.2; //swc_sat > fc2
-      swc[i] =  swc_sat[i] - 0.3; // swc_sat > swc
-      wp[i] = fmaxf(fc[i] - 0.6, 0.1); // wp < fc
-    }
-
-    // Should fail when soil_temperature_init fails - i.e. when theMaxDepth < depth of nlyrs
-
-    double theMaxDepth = 70;
-
+    // Should fail when soil_temperature was not initialized
     EXPECT_DEATH_IF_SUPPORTED(soil_temperature(airTemp, pet, aet, biomass, swc, swc_sat, bDensity, width,
-      oldsTemp, sTemp, surfaceTemp, nlyrs, fc, wp, bmLimiter, t1Param1, t1Param2,
+      oldsTemp, sTemp, surfaceTemp, nlyrs, bmLimiter, t1Param1, t1Param2,
       t1Param3, csParam1, csParam2, shParam, snowdepth, sTconst, deltaX, theMaxDepth,
       nRgr, snow, &ptr_stError), "@ generic.c LogError");
 
     //Reset to global state
     Reset_SOILWAT2_after_UnitTest();
-    delete[] swc; delete[] swc_sat; delete[] bDensity; delete[] fc; delete[] wp;
   }
 }

--- a/test/test_SW_Flow_lib_temp.cc
+++ b/test/test_SW_Flow_lib_temp.cc
@@ -89,7 +89,7 @@ namespace {
     Reset_SOILWAT2_after_UnitTest();
   }
 
-  // Test the soil temperature initialization function 'soil_temperature_init'
+  // Test the soil temperature initialization function 'soil_temperature_setup'
   TEST(SWFlowTempTest, SoilTemperatureInit) {
 
     // declare inputs and output
@@ -108,7 +108,7 @@ namespace {
     wp[0]= fc[0] - 0.6; // wp will always be less than fc
 
     /// test standard conditions
-    soil_temperature_init(bDensity, width, oldsTemp, sTconst, nlyrs,
+    soil_temperature_setup(bDensity, width, oldsTemp, sTconst, nlyrs,
       fc, wp, deltaX, theMaxDepth, nRgr, &ptr_stError);
 
     //Structure Tests
@@ -143,7 +143,7 @@ namespace {
       wp2[i] = fc2[i] - 0.6; // wp will always be less than fc
     }
 
-    soil_temperature_init(bDensity2, width2, oldsTemp2, sTconst, nlyrs,
+    soil_temperature_setup(bDensity2, width2, oldsTemp2, sTconst, nlyrs,
       fc2, wp2, deltaX, theMaxDepth, nRgr, &ptr_stError);
 
     //Structure Tests
@@ -164,7 +164,7 @@ namespace {
     delete[] bDensity2; delete[] fc2; delete[] wp2;
   }
 
-// Death tests for soil_temperature_init function
+// Death tests for soil_temperature_setup function
   TEST(SWFlowTempDeathTest, SoilTemperatureInitDeathTest) {
 
     // *****  Test when nlyrs = MAX_LAYERS (SW_Defines.h)  ***** //
@@ -189,7 +189,7 @@ namespace {
     /// test when theMaxDepth is less than soil layer depth - function should fail
     double theMaxDepth2 = 70.0;
 
-    EXPECT_DEATH_IF_SUPPORTED(soil_temperature_init(bDensity2, width2, oldsTemp2, sTconst, nlyrs,
+    EXPECT_DEATH_IF_SUPPORTED(soil_temperature_setup(bDensity2, width2, oldsTemp2, sTconst, nlyrs,
         fc2, wp2, deltaX, theMaxDepth2, nRgr, &ptr_stError),"@ generic.c LogError"); // We expect death when max depth < last layer
 
     // Reset to previous global state
@@ -199,7 +199,7 @@ namespace {
 
 
   // Test lyrSoil_to_lyrTemp, lyrSoil_to_lyrTemp_temperature via
-  // soil_temperature_init function
+  // soil_temperature_setup function
   TEST(SWFlowTempTest, SoilLayerInterpolationFunctions) {
 
     // declare inputs and output
@@ -220,10 +220,10 @@ namespace {
 
     wp[0]= fmax(fc[0] - 0.6, .1); // wp will always be less than fc
 
-    soil_temperature_init(bDensity, width, oldsTemp, sTconst, nlyrs,
+    soil_temperature_setup(bDensity, width, oldsTemp, sTconst, nlyrs,
       fc, wp, deltaX, theMaxDepth, nRgr, &ptr_stError);
 
-    // lyrSoil_to_lyrTemp tests: This function is used in soil_temperature_init
+    // lyrSoil_to_lyrTemp tests: This function is used in soil_temperature_setup
     // to transfer the soil layer values of bdensity, fc, and wp, to the "temperature layer"
     // which are contained in bdensityR, fcR, and wpR. Thus we check these values.
     for (i = 0; i < nRgr + 1; i++) {  // all Values should be greater than 0
@@ -269,7 +269,7 @@ namespace {
       EXPECT_GT(wp2[i], 0);
     }
 
-    soil_temperature_init(bDensity2, width2, oldsTemp2, sTconst, nlyrs,
+    soil_temperature_setup(bDensity2, width2, oldsTemp2, sTconst, nlyrs,
       fc2, wp2, deltaX, theMaxDepth, nRgr, &ptr_stError);
 
     // lyrSoil_to_lyrTemp tests
@@ -448,7 +448,7 @@ namespace {
     double swc[] = {1.0}, swc_sat[] = {1.5}, bDensity[] = {1.8}, width[] = {20},
     oldsTemp[] = {5.0}, sTemp[] = {4.0}, fc[] = {2.6}, wp[] = {1.0};
 
-    SW_ST_init_run(
+    SW_ST_setup_run(
       airTemp,
       swc, swc_sat,
       bDensity, width,
@@ -523,7 +523,7 @@ namespace {
       oldsTemp2[i] = RandNorm(surfaceTemp[Today], 1, &MSTF_Lyer1_rng);
     }
 
-    SW_ST_init_run(
+    SW_ST_setup_run(
       airTemp,
       swc, swc_sat,
       bDensity, width,
@@ -594,7 +594,7 @@ namespace {
       //  i, bDensity2[i],  swc_sat2[i], fc2[i], swc2[i], wp2[i] );
     }
 
-    SW_ST_init_run(
+    SW_ST_setup_run(
       airTemp,
       swc2, swc_sat2,
       bDensity2, width2,

--- a/test/test_WaterBalance.cc
+++ b/test/test_WaterBalance.cc
@@ -159,4 +159,32 @@ namespace {
   }
 
 
+  TEST(WaterBalance, WithHighGravelVolume) {
+    int i;
+    LyrIndex s;
+
+    // Set high gravel volume in all soil layers
+    ForEachSoilLayer(s)
+    {
+      SW_Site.lyr[s]->fractionVolBulk_gravel = 0.99;
+    }
+
+    // Re-calculate soils
+    SW_SIT_init_run();
+
+    // Run the simulation
+    SW_CTL_main();
+
+    // Collect and output from daily checks
+    for (i = 0; i < N_WBCHECKS; i++) {
+      EXPECT_EQ(0, SW_Soilwat.wbError[i]) <<
+        "Water balance error: " <<
+        SW_Soilwat.wbErrorNames[i];
+    }
+
+    // Reset to previous global state
+    Reset_SOILWAT2_after_UnitTest();
+  }
+
+
 } // namespace

--- a/tools/check_SOILWAT2.sh
+++ b/tools/check_SOILWAT2.sh
@@ -6,9 +6,9 @@
 
 
 #--- List of (builtin and macport) compilers
-declare -a port_compilers=("none" "mp-gcc9" "mp-clang-9.0")
-declare -a ccs=("clang" "gcc" "clang")
-declare -a cxxs=("clang++" "g++" "clang++")
+declare -a port_compilers=("none" "mp-gcc7" "mp-gcc9" "mp-gcc10" "mp-clang-5.0" "mp-clang-9.0" "mp-clang-10")
+declare -a ccs=("clang" "gcc" "gcc" "gcc" "clang" "clang" "clang")
+declare -a cxxs=("clang++" "g++" "g++" "g++" "clang++" "clang++" "clang++")
 
 ncomp=${#ccs[@]}
 

--- a/tools/plot__SW2_PET_Test__petfunc_by_temps.R
+++ b/tools/plot__SW2_PET_Test__petfunc_by_temps.R
@@ -1,0 +1,214 @@
+#--- Create a figure to visualize effects of
+#    temperature, relative humidity, wind speed, and cloud cover
+#    on annual PET
+
+# Run SOILWAT2 unit tests with appropriate flag
+# ```
+#   CPPFLAGS=-DSW2_PET_Test__petfunc_by_temps make test test_run
+# ```
+#
+# Produce plots based on output generated above
+# ```
+#   Rscript tools/plot__SW2_PET_Test__petfunc_by_temps.R
+# ```
+
+#------
+dir_out <- file.path("testing", "Output")
+
+tag_filename <- "SW2_PET_Test__petfunc_by_temps"
+
+file_sw2_test_output <- list.files(
+  dir_out,
+  pattern = paste0("Table__", tag_filename, ".csv"),
+  full.names = TRUE
+)
+
+
+do_plot <- TRUE
+
+
+if (length(file_sw2_test_output) == 0) {
+  stop("No ", shQuote(tag_filename), " output found.")
+}
+
+
+if (!require("ggplot2", quietly = TRUE)) {
+  stop("Package 'ggplot2' is required.")
+}
+
+
+if (do_plot) {
+  data_pet <- utils::read.csv(file_sw2_test_output, row.names = NULL)
+
+  fH <- unique(data_pet[, "fH_gt"])
+  ws <- unique(data_pet[, "windspeed_m_per_s"])
+  cc <- unique(data_pet[, "cloudcover_pct"])
+  rh <- unique(data_pet[, "RH_pct"])
+
+  all_labeller <- ggplot2::labeller(
+    windspeed_m_per_s = setNames(paste0("Wind speed: ", ws, " m/s"), nm = ws),
+    cloudcover_pct = setNames(paste0("Cloud cover: ", round(cc), "%"), nm = cc),
+    RH_pct = setNames(paste0("Rel. humidity: ", round(rh), "%"), nm = rh),
+    fH_gt = setNames(paste0("RSDS scaler: ", fH * 100, "%"), nm = fH)
+  )
+
+
+  #--- Fixed radiation
+  ids_fH <- data_pet[, "fH_gt"] == 1
+
+
+  #--- Layout: x = cc, y = ws, by = rh
+  n_panels <- c(length(ws), length(cc))
+
+  pdf(
+    file = file.path(dir_out, paste0("Fig__", tag_filename, "__by_RH", ".pdf")),
+    height = 2 * n_panels[1],
+    width = 2 * n_panels[2]
+  )
+
+  tmp <- ggplot(
+    data_pet[ids_fH, ],
+    aes(Temperature_C, PET_mm, group = RH_pct, color = RH_pct)
+  ) +
+    xlim(-10, 40) +
+    labs(x = "Temperature (C)", y = "Annual PET (mm)", color = "RH (%)") +
+    geom_line(size = 0.75) +
+    scale_color_viridis_c(direction = -1) +
+    facet_grid(
+      windspeed_m_per_s ~ cloudcover_pct,
+      labeller = all_labeller
+    ) +
+    egg::theme_article() +
+    theme(
+      legend.position = c(
+        0.4 / (n_panels[2] + 1),
+        1 - 0.4 / (n_panels[1] + 1)
+      ),
+      legend.key.size = unit(0.015, units = "npc"),
+      legend.title = element_text(size = 10)
+    )
+
+  plot(tmp)
+  #egg::tag_facet()
+
+
+  dev.off()
+
+
+  #--- Layout: x = ws, y = rh, by = cc
+  n_panels <- c(length(rh), length(ws))
+
+  pdf(
+    file = file.path(dir_out, paste0("Fig__", tag_filename, "__by_CloudCover", ".pdf")),
+    height = 2 * n_panels[1],
+    width = 2 * n_panels[2]
+  )
+
+  tmp <- ggplot(
+    data_pet[ids_fH, ],
+    aes(Temperature_C, PET_mm, group = cloudcover_pct, color = cloudcover_pct)
+  ) +
+    xlim(-10, 40) +
+    labs(x = "Temperature (C)", y = "Annual PET (mm)", color = "Clouds (%)") +
+    geom_line(size = 0.75) +
+    scale_color_viridis_c(direction = -1) +
+    facet_grid(
+      RH_pct ~ windspeed_m_per_s,
+      labeller = all_labeller
+    ) +
+    egg::theme_article() +
+    theme(
+      legend.position = c(
+        0.4 / (n_panels[2] + 1),
+        1 - 0.4 / (n_panels[1] + 1)
+      ),
+      legend.key.size = unit(0.015, units = "npc"),
+      legend.title = element_text(size = 10)
+    )
+
+  plot(tmp)
+  #egg::tag_facet()
+
+  dev.off()
+
+
+
+  #--- Layout: x = cc, y = rh, by = ws
+  n_panels <- c(length(rh), length(cc))
+
+  pdf(
+    file = file.path(dir_out, paste0("Fig__", tag_filename, "__by_WindSpeed", ".pdf")),
+    height = 2 * n_panels[1],
+    width = 2 * n_panels[2]
+  )
+
+  tmp <- ggplot(
+    data_pet[ids_fH, ],
+    aes(Temperature_C, PET_mm, group = windspeed_m_per_s, color = windspeed_m_per_s)
+  ) +
+    xlim(-10, 40) +
+    labs(x = "Temperature (C)", y = "Annual PET (mm)", color = "Wind speed (m/s)") +
+    geom_line(size = 0.75) +
+    scale_color_viridis_c(direction = -1) +
+    facet_grid(
+      RH_pct ~ cloudcover_pct,
+      labeller = all_labeller
+    ) +
+    egg::theme_article() +
+    theme(
+      legend.position = c(
+        0.4 / (n_panels[2] + 1),
+        1 - 0.4 / (n_panels[1] + 1)
+      ),
+      legend.key.size = unit(0.015, units = "npc"),
+      legend.title = element_text(size = 10)
+    )
+
+  plot(tmp)
+  #egg::tag_facet()
+
+  dev.off()
+
+
+
+  #--- Fixed cloud cover
+  ids_cc <- data_pet[, "cloudcover_pct"] == cc[3]
+
+  #--- Layout: x = ws, y = rh, by = fH
+  n_panels <- c(length(rh), length(ws))
+
+  pdf(
+    file = file.path(dir_out, paste0("Fig__", tag_filename, "__by_fRSDS", ".pdf")),
+    height = 2 * n_panels[1],
+    width = 2 * n_panels[2]
+  )
+
+  tmp <- ggplot(
+    data_pet[ids_cc, ],
+    aes(Temperature_C, PET_mm, group = factor(fH_gt), color = factor(fH_gt))
+  ) +
+    xlim(-10, 40) +
+    labs(x = "Temperature (C)", y = "Annual PET (mm)", color = "fRSDS (%)") +
+    geom_line(size = 0.75) +
+    scale_color_viridis_d(direction = -1) +
+    facet_grid(
+      RH_pct ~ windspeed_m_per_s,
+      labeller = all_labeller
+    ) +
+    egg::theme_article() +
+    theme(
+      legend.position = c(
+        0.4 / (n_panels[2] + 1),
+        1 - 0.4 / (n_panels[1] + 1)
+      ),
+      legend.key.size = unit(0.015, units = "npc"),
+      legend.title = element_text(size = 10)
+    )
+
+  plot(tmp)
+  #egg::tag_facet()
+
+  dev.off()
+
+}
+


### PR DESCRIPTION
- Fixed calculation of residual soil moisture if gravel is present (close #282)
- New command line options: `-h` (to print help/usage information); `-v` (to print version and compile time metadata)
- Version and metadata are printed by `main()` unless `-q` (quiet mode)
- Additional unit test output to create plots of PET as function of radiation, relative humidity, wind speed, and cover (optional)