### PR TITLE
Fix declaration of function `nlayers_bsevap()`

### DIFF
--- a/SW_Site.h
+++ b/SW_Site.h
@@ -147,7 +147,7 @@ typedef struct {
 
 void water_eqn(RealD fractionGravel, RealD sand, RealD clay, LyrIndex n);
 RealD calculate_soilBulkDensity(RealD matricDensity, RealD fractionGravel);
-LyrIndex nlayers_bsevap();
+LyrIndex nlayers_bsevap(void);
 void nlayers_vegroots(LyrIndex n_transp_lyrs[]);
 
 void SW_SIT_construct(void);

--- a/makefile
+++ b/makefile
@@ -84,7 +84,11 @@ warning_flags_severe = \
 	-Wmissing-declarations \
 	-Wredundant-decls
 
-warnings_flags_severe_cxx = \
+warning_flags_severe_cc = \
+	$(warning_flags_severe) \
+	-Wstrict-prototypes # '-Wstrict-prototypes' is valid for C/ObjC but not for C++
+
+warning_flags_severe_cxx = \
 	$(warning_flags_severe) \
 	-Wno-error=deprecated
 	# TODO: address underlying problems so that we can eliminate
@@ -190,7 +194,7 @@ $(lib_target_test) :
 		-@$(RM) -f $(objects_lib_test) $(objects_pcg)
 
 $(lib_target_severe) :	# needs CXX because of '*_severe' flags which must match test binary build
-		$(CXX) $(sw_CPPFLAGS) $(sw_CXXFLAGS) $(debug_flags) $(warnings_flags_severe_cxx) \
+		$(CXX) $(sw_CPPFLAGS) $(sw_CXXFLAGS) $(debug_flags) $(warning_flags_severe_cxx) \
 		$(instr_flags_severe) $(use_gnu++11) -c $(sources_lib_test) $(sources_pcg)
 
 		-@$(RM) -f $(lib_target_severe)
@@ -212,14 +216,14 @@ $(target) : $(lib_target)
 		-o $(target) $(sources_bin) $(target_LDLIBS) $(sw_LDFLAGS)
 
 bin_debug_severe :
-		$(CC) $(sw_CPPFLAGS) $(sw_CFLAGS) $(debug_flags) $(warning_flags_severe) \
+		$(CC) $(sw_CPPFLAGS) $(sw_CFLAGS) $(debug_flags) $(warning_flags_severe_cc) \
 		$(instr_flags_severe) $(use_c11) -c $(sources_lib_test) $(sources_pcg)
 
 		-@$(RM) -f $(lib_target_severe)
 		$(AR) -rcs $(lib_target_severe) $(objects_lib_test) $(objects_pcg)
 		-@$(RM) -f $(objects_lib_test) $(objects_pcg)
 
-		$(CC) $(sw_CPPFLAGS) $(sw_CFLAGS) $(debug_flags) $(warning_flags_severe) \
+		$(CC) $(sw_CPPFLAGS) $(sw_CFLAGS) $(debug_flags) $(warning_flags_severe_cc) \
 		$(instr_flags_severe) $(use_c11) \
 		-o $(target) $(sources_bin) $(severe_LDLIBS) $(sw_LDFLAGS)
 
@@ -257,7 +261,7 @@ $(lib_gtest) :
 		@$(AR) -r $(lib_gtest) gtest-all.o
 
 test_severe : $(lib_gtest) $(lib_target_severe)
-		$(CXX) $(sw_CPPFLAGS) $(sw_CXXFLAGS) $(debug_flags) $(warnings_flags_severe_cxx) \
+		$(CXX) $(sw_CPPFLAGS) $(sw_CXXFLAGS) $(debug_flags) $(warning_flags_severe_cxx) \
 		$(instr_flags_severe) $(use_gnu++11) \
 		-isystem ${GTEST_DIR}/include -pthread \
 		test/*.cc -o $(bin_test) $(gtest_LDLIBS) $(severe_LDLIBS) $(sw_LDFLAGS)


### PR DESCRIPTION
- commit 7272805a75a0653862410537a657b5328439669b (Nov 13, 2020) introduced several new functions including `nlayers_bsevap()` -- however, the declaration did not include the `void` argument which the definition later uses
- this commit is fixing this by adding `void` as the argument to the declaration
- to prevent future such cases, the severe tests are now using `-Wstrict-prototypes` (for the C compilations -- as this is not a valid warning under C++)