### PR TITLE
Bugfix rSOILWAT2 issue194

### DIFF
--- a/SW_Output_get_functions.c
+++ b/SW_Output_get_functions.c
@@ -2424,9 +2424,9 @@ void get_soiltemp_mem(OutPeriod pd)
     
 	ForEachSoilLayer(i)
 	{
-        p[iOUT(i, pd)] = vo->maxLyrTemperature[i];
-        p[iOUT(i + nlyrs, pd)] = vo->minLyrTemperature[i];
-        p[iOUT(i + doubleOffset, pd)] = vo->avgLyrTemp[i];
+        p[iOUT((i * 3), pd)] = vo->maxLyrTemperature[i];
+        p[iOUT((i * 3) + 1, pd)] = vo->minLyrTemperature[i];
+        p[iOUT((i * 3) + 2, pd)] = vo->avgLyrTemp[i];
 	}
 }
 

--- a/SW_Output_get_functions.c
+++ b/SW_Output_get_functions.c
@@ -2417,7 +2417,6 @@ void get_soiltemp_mem(OutPeriod pd)
 {
 	LyrIndex i;
 	SW_SOILWAT_OUTPUTS *vo = SW_Soilwat.p_oagg[pd];
-    int nlyrs = SW_Site.n_layers, doubleOffset = 2 * nlyrs;
 
 	RealD *p = p_OUT[eSW_SoilTemp][pd];
 	get_outvalleader(p, pd);


### PR DESCRIPTION
Provides a bug fix for [issue #194](https://github.com/DrylandEcology/rSOILWAT2/issues/194) on rSOILWAT side
- Fixes output order of array that is used when rSOILWAT is defined
- Order is now (of increasing indices): max, min, avg, max, min, avg