### PR TITLE
Specify type of soil density inputs

### DIFF
--- a/SW_Site.h
+++ b/SW_Site.h
@@ -53,6 +53,8 @@
 extern "C" {
 #endif
 
+#define SW_MATRIC 0
+#define SW_BULK 1
 
 typedef unsigned int LyrIndex;
 
@@ -63,7 +65,7 @@ typedef struct {
 	RealD
 		/* Inputs */
 		width, /* width of the soil layer (cm) */
-		soilMatric_density, /* matric soil density of the < 2 mm fraction, i.e., gravel component excluded, (g/cm3) */
+		soilDensityInput, /* soil density [g / cm3]: either of the matric component or bulk soil */
 		evap_coeff, /* prop. of total soil evap from this layer */
 		transp_coeff[NVEGTYPES], /* prop. of total transp from this layer    */
 		fractionVolBulk_gravel, /* gravel content (> 2 mm) as volume-fraction of bulk soil (g/cm3) */
@@ -73,6 +75,7 @@ typedef struct {
 		avgLyrTemp, /* initial soil temperature for each soil layer */
 
 		/* Derived soil characteristics */
+		soilMatric_density, /* matric soil density of the < 2 mm fraction, i.e., gravel component excluded, (g/cm3) */
 		soilBulk_density, /* bulk soil density of the whole soil, i.e., including rock/gravel component, (g/cm3) */
 		swcBulk_fieldcap, /* Soil water content (SWC) corresponding to field capacity (SWP = -0.033 MPa) [cm] */
 		swcBulk_wiltpt, /* SWC corresponding to wilting point (SWP = -1.5 MPa) [cm] */
@@ -104,6 +107,8 @@ typedef struct {
 	Bool reset_yr, /* 1: reset values at start of each year */
 		deepdrain, /* 1: allow drainage into deepest layer  */
 		use_soil_temp; /* whether or not to do soil_temperature calculations */
+
+	unsigned int type_soilDensityInput; /* Encodes whether `soilDensityInput` represent matric density (type = SW_MATRIC = 0) or bulk density (type = SW_BULK = 1) */
 
 	LyrIndex n_layers, /* total number of soil layers */
 		n_transp_rgn, /* soil layers are grouped into n transp. regions */
@@ -166,6 +171,7 @@ extern RealD _SWCInitVal, _SWCWetVal, _SWCMinVal;
 /* --------------------------------------------------- */
 void water_eqn(RealD fractionGravel, RealD sand, RealD clay, LyrIndex n);
 RealD calculate_soilBulkDensity(RealD matricDensity, RealD fractionGravel);
+RealD calculate_soilMatricDensity(RealD bulkDensity, RealD fractionGravel);
 LyrIndex nlayers_bsevap(void);
 void nlayers_vegroots(LyrIndex n_transp_lyrs[]);
 
@@ -181,7 +187,7 @@ void SW_SIT_clear_layers(void);
 LyrIndex _newlayer(void);
 void add_deepdrain_layer(void);
 
-void set_soillayers(LyrIndex nlyrs, RealF *dmax, RealF *matricd, RealF *f_gravel,
+void set_soillayers(LyrIndex nlyrs, RealF *dmax, RealF *bd, RealF *f_gravel,
   RealF *evco, RealF *trco_grass, RealF *trco_shrub, RealF *trco_tree,
   RealF *trco_forb, RealF *psand, RealF *pclay, RealF *imperm, RealF *soiltemp,
   int nRegions, RealD *regionLowerBounds);

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1666,8 +1666,8 @@ MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
 # extension names that should be enabled during MathJax rendering. For example
-# for MathJax version 2 (see https://docs.mathjax.org/en/v2.7-latest/tex.html
-# #tex-and-latex-extensions):
+# for MathJax version 2 (see
+# https://docs.mathjax.org/en/v2.7-latest/tex.html#tex-and-latex-extensions):
 # MATHJAX_EXTENSIONS = TeX/AMSmath TeX/AMSsymbols
 # For example for MathJax version 3 (see
 # http://docs.mathjax.org/en/latest/input/tex/extensions/index.html):

--- a/test/sw_testhelpers.cc
+++ b/test/sw_testhelpers.cc
@@ -68,7 +68,7 @@ void create_test_soillayers(unsigned int nlayers) {
   RealF dmax[MAX_LAYERS] = {
     5, 6, 10, 11, 12, 20, 21, 22, 25, 30, 40, 41, 42, 50, 51, 52, 53, 54, 55,
     60, 70, 80, 90, 110, 150};
-  RealF matricd[MAX_LAYERS] = {
+  RealF bulkd[MAX_LAYERS] = {
     1.430, 1.410, 1.390, 1.390, 1.380, 1.150, 1.130, 1.130, 1.430, 1.410,
     1.390, 1.390, 1.380, 1.150, 1.130, 1.130, 1.430, 1.410, 1.390, 1.390,
     1.380, 1.150, 1.130, 1.130, 1.400};
@@ -111,7 +111,7 @@ void create_test_soillayers(unsigned int nlayers) {
   int nRegions = 3;
   RealD regionLowerBounds[3] = {20., 50., 100.};
 
-  set_soillayers(nlayers, dmax, matricd, f_gravel,
+  set_soillayers(nlayers, dmax, bulkd, f_gravel,
     evco, trco_grass, trco_shrub, trco_tree,
     trco_forb, psand, pclay, imperm, soiltemp,
     nRegions, regionLowerBounds);

--- a/test/test_SW_Site.cc
+++ b/test/test_SW_Site.cc
@@ -200,4 +200,100 @@ namespace {
     Reset_SOILWAT2_after_UnitTest();
   }
 
+
+  // Test bulk and matric soil density functionality
+  TEST(SWSiteTest, SoilDensity) {
+    double
+      soildensity = 1.4,
+      fcoarse = 0.1;
+
+
+    // Check that matric density is zero if coarse fragments is 100%
+    EXPECT_DOUBLE_EQ(
+      calculate_soilMatricDensity(soildensity, 1.),
+      0.
+    );
+
+
+    // Check that bulk and matric soil density are equal if no coarse fragments
+    EXPECT_DOUBLE_EQ(
+      calculate_soilBulkDensity(soildensity, 0.),
+      calculate_soilMatricDensity(soildensity, 0.)
+    );
+
+
+    // Check that bulk and matric density calculations are inverse to each other
+    EXPECT_DOUBLE_EQ(
+      calculate_soilBulkDensity(
+        calculate_soilMatricDensity(soildensity, fcoarse),
+        fcoarse
+      ),
+      soildensity
+    );
+
+    EXPECT_DOUBLE_EQ(
+      calculate_soilMatricDensity(
+        calculate_soilBulkDensity(soildensity, fcoarse),
+        fcoarse
+      ),
+      soildensity
+    );
+
+
+    // Check that bulk density is larger than matric density if coarse fragments
+    EXPECT_GT(
+      calculate_soilBulkDensity(soildensity, fcoarse),
+      soildensity
+    );
+
+
+    // Inputs represent matric density
+    SW_Site.type_soilDensityInput = SW_MATRIC;
+    SW_Site.lyr[0]->fractionVolBulk_gravel = fcoarse;
+    SW_SIT_init_run();
+
+    EXPECT_GT(
+      SW_Site.lyr[0]->soilBulk_density,
+      SW_Site.lyr[0]->soilMatric_density
+    );
+
+
+    // Inputs represent bulk density
+    SW_Site.type_soilDensityInput = SW_BULK;
+    SW_Site.lyr[0]->fractionVolBulk_gravel = fcoarse;
+    SW_SIT_init_run();
+
+    EXPECT_GT(
+      SW_Site.lyr[0]->soilBulk_density,
+      SW_Site.lyr[0]->soilMatric_density
+    );
+
+
+    // Reset to previous global states
+    Reset_SOILWAT2_after_UnitTest();
+  }
+
+
+  // Test that bulk and matric soil density fail
+  TEST(SWSiteDeathTest, SoilDensity) {
+
+    // Check error if bulk density too low for coarse fragments
+    EXPECT_DEATH_IF_SUPPORTED(
+      calculate_soilMatricDensity(1.65, 0.7),
+      "@ generic.c LogError"
+    );
+
+
+    // Check error if type_soilDensityInput not implemented
+    SW_Site.type_soilDensityInput = SW_MISSING;
+
+    EXPECT_DEATH_IF_SUPPORTED(
+      SW_SIT_init_run(),
+      "@ generic.c LogError"
+    );
+
+
+    // Reset to previous global states
+    Reset_SOILWAT2_after_UnitTest();
+  }
 } // namespace

--- a/testing/Input/siteparam.in
+++ b/testing/Input/siteparam.in
@@ -83,6 +83,10 @@ NAN			# aspect = surface azimuth angle (degrees): S=0, E=-90, N=±180, W=90;
 # Name of CO2 scenario: see input file `carbon.in`
 RCP85
 
+# --- Soil characterization ---
+# Are inputs of density representing bulk soil (type 1) or the matric component (type 0)?
+0
+
 #---- Transpiration regions
 # ndx  : 1=shallow, 2=medium, 3=deep, 4=very deep
 # layer: deepest soil layer number of the region.


### PR DESCRIPTION
- close #280 (Soil density: input either for < 2 mm fraction or for whole soil)

* new behavior: user specifies whether input soil density represents matric or bulk density; code then determines both matric and bulk density values from inputs
* previous behavior: input soil density was treated as matric density and converted to bulk density