### PR TITLE
Bugfix too many open files

### DIFF
--- a/.github/workflows/main_nix.yml
+++ b/.github/workflows/main_nix.yml
@@ -32,8 +32,8 @@ jobs:
         make clean bin_run
         make clean bin_debug_severe
 
-    - name: Unit tests
-      run: make clean test_run
+    - name: Unit tests (shuffle and repeat 3x)
+      run: make clean test_rep3rnd
 
     - name: Severe unit tests (without sanitizers)
       if: ${{ runner.os == 'macOS' }}

--- a/.github/workflows/main_win.yml
+++ b/.github/workflows/main_win.yml
@@ -42,5 +42,5 @@ jobs:
     - name: Run binary
       run: make clean bin_run
 
-    - name: Unit tests
-      run: make clean test_run
+    - name: Unit tests (shuffle and repeat 3x)
+      run: make clean test_rep3rnd

--- a/include/SW_Main_lib.h
+++ b/include/SW_Main_lib.h
@@ -17,7 +17,7 @@ extern "C" {
 /* --------------------------------------------------- */
 void sw_init_args(int argc, char **argv);
 void sw_print_version(void);
-
+void sw_check_log(void);
 
 #ifdef __cplusplus
 }

--- a/makefile
+++ b/makefile
@@ -33,6 +33,8 @@
 #                  artifacts beforehand, e.g., `make clean_test`
 # make test_reprnd similar to `make test_run`, i.e., execute the test binary
 #                  repeatedly while randomly shuffling tests
+# make test_rep3rnd   similar to `make test_run`, i.e., execute the test binary
+#                  three times while randomly shuffling tests
 #
 # make bin_debug   similar to `make bin_run` with debug settings;
 #                  consider cleaning previous build artifacts beforehand,
@@ -356,6 +358,10 @@ test_leaks :
 .PHONY : test_reprnd
 test_reprnd : test
 		$(bin_test) --gtest_shuffle --gtest_repeat=-1
+
+.PHONY : test_rep3rnd
+test_rep3rnd : test
+		$(bin_test) --gtest_shuffle --gtest_repeat=3
 
 .PHONY : bin_debug
 bin_debug :

--- a/src/SW_Main.c
+++ b/src/SW_Main.c
@@ -39,19 +39,6 @@
 /*             Local Function Definitions              */
 /* --------------------------------------------------- */
 
-static void check_log(void) {
-	/* =================================================== */
-	/* function to be called by atexit() so it's the last
-	 * to execute before termination.  This is the place to
-	 * do any cleanup or progress reporting.
-	 */
-	if (logfp != stdout && logfp != stderr) {
-		if (logged && !QuietMode)
-			sw_error(0, "\nCheck logfile for error or status messages.\n");
-		CloseFile(&logfp);
-	}
-
-}
 
 
 /* =================================================== */
@@ -67,7 +54,7 @@ int main(int argc, char **argv) {
 	/* =================================================== */
 
 	logged = swFALSE;
-	atexit(check_log);
+	atexit(sw_check_log);
 	logfp = stdout;
 
 	sw_init_args(argc, argv);

--- a/src/SW_Main_lib.c
+++ b/src/SW_Main_lib.c
@@ -207,3 +207,19 @@ void sw_init_args(int argc, char **argv) {
 	} /* end for(i) */
 
 }
+
+
+void sw_check_log(void) {
+	/* =================================================== */
+	/* function to be called by atexit() so it's the last
+	 * to execute before termination.  This is the place to
+	 * do any cleanup or progress reporting.
+	 */
+	if (logfp != stdout && logfp != stderr) {
+		CloseFile(&logfp);
+		if (logged && !QuietMode) {
+			sw_error(0, "\nCheck logfile for error or status messages.\n");
+		}
+	}
+
+}

--- a/tests/gtests/sw_maintest.cc
+++ b/tests/gtests/sw_maintest.cc
@@ -15,25 +15,9 @@
 #include <time.h>
 #include <unistd.h>
 
-#include "include/myMemory.h"
 // externs `*logfp`, `errstr`, `logged`, `QuietMode`, `EchoInits`
 #include "include/generic.h"
 #include "include/filefuncs.h" // externs `_firstfile`, `inbuf`
-#include "include/rands.h"
-#include "include/Times.h"
-#include "include/SW_Defines.h"
-#include "include/SW_Times.h"
-#include "include/SW_Files.h"
-#include "include/SW_Carbon.h"
-#include "include/SW_Site.h"
-#include "include/SW_VegProd.h"
-#include "include/SW_VegEstab.h"
-#include "include/SW_Model.h"
-#include "include/SW_SoilWater.h"
-#include "include/SW_Weather.h"
-#include "include/SW_Markov.h"
-#include "include/SW_Sky.h"
-
 #include "include/SW_Control.h"
 
 #include "tests/gtests/sw_testhelpers.h"
@@ -66,16 +50,13 @@ int main(int argc, char **argv) {
     because SOILWAT2 uses (global) states.
     This is otherwise not comptable with the c++ approach used by googletest.
   */
-  logged = swFALSE;
-  logfp = stdout;
 
   // Emulate 'sw_init_args()'
   if (!ChDir(dir_test)) {
     swprintf("Invalid project directory (%s)", dir_test);
   }
   strcpy(_firstfile, masterfile_test);
-  QuietMode = swTRUE;
-  EchoInits = swFALSE;
+
 
   // Initialize SOILWAT2 variables and read values from example input file
   Reset_SOILWAT2_after_UnitTest();

--- a/tests/gtests/sw_testhelpers.cc
+++ b/tests/gtests/sw_testhelpers.cc
@@ -15,25 +15,14 @@
 #include <time.h>
 #include <unistd.h>
 
-#include "include/myMemory.h"
 // externs `*logfp`, `errstr`, `logged`, `QuietMode`, `EchoInits`
 #include "include/generic.h"
 #include "include/filefuncs.h" // externs `_firstfile`, `inbuf`
-#include "include/rands.h"
-#include "include/Times.h"
-#include "include/SW_Defines.h"
-#include "include/SW_Times.h"
-#include "include/SW_Files.h"
-#include "include/SW_Carbon.h"
 #include "include/SW_Site.h"
-#include "include/SW_VegProd.h"
-#include "include/SW_VegEstab.h"
-#include "include/SW_Model.h"
 #include "include/SW_SoilWater.h"
 #include "include/SW_Weather.h"
-#include "include/SW_Markov.h"
-#include "include/SW_Sky.h"
 #include "include/SW_Control.h"
+#include "include/SW_Main_lib.h" // for `sw_check_log()`
 
 #include "tests/gtests/sw_testhelpers.h"
 
@@ -42,18 +31,41 @@
 /** Initialize SOILWAT2 variables and read values from example input file
  */
 void Reset_SOILWAT2_after_UnitTest(void) {
+  /*--- Imitate 'SW_Main.c/main()':
+    we need to initialize and take down SOILWAT2 variables
+    because SOILWAT2 uses (global) states.
+    This is otherwise not comptable with the c++ approach used by googletest.
+  */
+  logged = swFALSE;
+  logfp = NULL;
+
+  QuietMode = swTRUE;
+  EchoInits = swFALSE;
+
   SW_CTL_clear_model(swFALSE);
 
-  SW_CTL_setup_model(_firstfile);
+  SW_CTL_setup_model(_firstfile); // `_firstfile` is here "files.in"
   SW_CTL_read_inputs_from_disk();
+
+  /* Notes on messages during tests
+    - `SW_F_read()`, via SW_CTL_read_inputs_from_disk(), writes the file
+      "example/Output/logfile.log" to disk (based on content of "files.in")
+    - we close "Output/logfile.log"
+    - we set `logfp` to NULL to silence all non-error messages during tests
+    - error messages go directly to stderr (which DeathTests use to match against)
+  */
+  sw_check_log();
+  logfp = NULL;
+
   SW_WTH_finalize_all_weather();
   SW_CTL_init_run();
 
 
-  // Next two function calls will require SW_Output.c
+  // Next functions calls from `main()` require SW_Output.c
   //   (see issue #85 'Make SW_Output.c comptabile with c++ to include in unit testing code')
   // SW_OUT_set_ncol();
   // SW_OUT_set_colnames();
+  // ...
 }
 
 

--- a/tests/gtests/test_SW_Flow_lib_temp.cc
+++ b/tests/gtests/test_SW_Flow_lib_temp.cc
@@ -192,7 +192,7 @@ namespace {
         fc2, wp2, deltaX, theMaxDepth2, nRgr,
         &ptr_stError
       ),
-      "@ generic.c LogError"
+      "SOIL_TEMP FUNCTION ERROR: soil temperature max depth"
     );
 
     // Reset to previous global state
@@ -709,7 +709,7 @@ namespace {
         &ptr_stError, max_air_temp, min_air_temp, H_gt, min_temp, max_temp,
         &surface_max, &surface_min
       ),
-      "@ generic.c LogError"
+      "SOILWAT2 ERROR soil temperature module was not initialized"
     );
 
     //Reset to global state

--- a/tests/gtests/test_SW_Markov.cc
+++ b/tests/gtests/test_SW_Markov.cc
@@ -182,7 +182,7 @@ namespace {
     // Case: (wT_covar ^ 2 / wTmax_var) > wTmin_var --> LOGFATAL
     EXPECT_DEATH_IF_SUPPORTED(
       (test_mvnorm)(&tmax, &tmin, 0., 0., 1., 1., 2.),
-      "@ generic.c LogError"
+      "Bad covariance matrix"
     );
 
     // Reset to previous global state

--- a/tests/gtests/test_SW_Site.cc
+++ b/tests/gtests/test_SW_Site.cc
@@ -144,7 +144,7 @@ namespace {
         gravel,
         bdensity
       ),
-      "@ generic.c LogError"
+      "PTF is not implemented in SOILWAT2"
     );
   }
 
@@ -239,7 +239,7 @@ namespace {
 
     EXPECT_DEATH_IF_SUPPORTED(
       SWRC_check_parameters(swrc_type, swrcp),
-      "@ generic.c LogError"
+      "is not implemented"
     );
   }
 
@@ -444,12 +444,18 @@ namespace {
     // Check error for bad bare-soil evaporation coefficient (should be [0-1])
     help = SW_Site.lyr[n1]->evap_coeff;
     SW_Site.lyr[n1]->evap_coeff = -0.5;
-    EXPECT_DEATH_IF_SUPPORTED(SW_SIT_init_run(), "@ generic.c LogError");
+    EXPECT_DEATH_IF_SUPPORTED(
+      SW_SIT_init_run(),
+      "'bare-soil evaporation coefficient' has an invalid value"
+    );
     SW_Site.lyr[n1]->evap_coeff = help;
 
     // Check error for bad transpiration coefficient (should be [0-1])
     SW_Site.lyr[n2]->transp_coeff[k] = 1.5;
-    EXPECT_DEATH_IF_SUPPORTED(SW_SIT_init_run(), "@ generic.c LogError");
+    EXPECT_DEATH_IF_SUPPORTED(
+      SW_SIT_init_run(),
+      "'transpiration coefficient' has an invalid value"
+    );
 
     // Reset to previous global states
     Reset_SOILWAT2_after_UnitTest();
@@ -617,7 +623,7 @@ namespace {
     // Check error if bulk density too low for coarse fragments
     EXPECT_DEATH_IF_SUPPORTED(
       calculate_soilMatricDensity(1.65, 0.7),
-      "@ generic.c LogError"
+      "is lower than expected"
     );
 
 
@@ -626,7 +632,7 @@ namespace {
 
     EXPECT_DEATH_IF_SUPPORTED(
       SW_SIT_init_run(),
-      "@ generic.c LogError"
+      "Soil density type not recognized"
     );
 
 

--- a/tests/gtests/test_SW_SoilWater.cc
+++ b/tests/gtests/test_SW_SoilWater.cc
@@ -275,7 +275,7 @@ namespace{
     swrc_type = N_SWRCs + 1;
     EXPECT_DEATH_IF_SUPPORTED(
       SWRC_SWCtoSWP(1., swrc_type, swrcp, gravel, width, LOGFATAL),
-      "@ generic.c LogError"
+      "is not implemented"
     );
     EXPECT_DOUBLE_EQ(
       SWRC_SWCtoSWP(1., swrc_type, swrcp, gravel, width, LOGWARN),
@@ -287,7 +287,7 @@ namespace{
     for (swrc_type = 0; swrc_type < N_SWRCs; swrc_type++) {
       EXPECT_DEATH_IF_SUPPORTED(
         SWRC_SWCtoSWP(-1., swrc_type, swrcp, gravel, width, LOGFATAL),
-        "@ generic.c LogError"
+        "invalid SWC"
       );
       EXPECT_DOUBLE_EQ(
         SWRC_SWCtoSWP(-1., swrc_type, swrcp, gravel, width, LOGWARN),
@@ -296,7 +296,7 @@ namespace{
 
       EXPECT_DEATH_IF_SUPPORTED(
         SWRC_SWCtoSWP(1., swrc_type, swrcp, 1., width, LOGFATAL),
-        "@ generic.c LogError"
+        "invalid SWC"
       );
       EXPECT_DOUBLE_EQ(
         SWRC_SWCtoSWP(1., swrc_type, swrcp, 1., width, LOGWARN),
@@ -305,7 +305,7 @@ namespace{
 
       EXPECT_DEATH_IF_SUPPORTED(
         SWRC_SWCtoSWP(1., swrc_type, swrcp, gravel, 0., LOGFATAL),
-        "@ generic.c LogError"
+        "invalid SWC"
       );
       EXPECT_DOUBLE_EQ(
         SWRC_SWCtoSWP(1., swrc_type, swrcp, gravel, 0., LOGWARN),
@@ -325,7 +325,7 @@ namespace{
 
     EXPECT_DEATH_IF_SUPPORTED(
       SWRC_SWCtoSWP(0.99 * swrcp[0], swrc_type, swrcp, gravel, width, LOGFATAL),
-      "@ generic.c LogError"
+      "invalid value"
     );
     EXPECT_DOUBLE_EQ(
       SWRC_SWCtoSWP(0.99 * swrcp[0], swrc_type, swrcp, gravel, width, LOGWARN),
@@ -352,7 +352,7 @@ namespace{
     swrc_type = N_SWRCs + 1;
     EXPECT_DEATH_IF_SUPPORTED(
       SWRC_SWPtoSWC(15., swrc_type, swrcp, gravel, width, LOGFATAL),
-      "@ generic.c LogError"
+      "is not implemented"
     );
     EXPECT_DOUBLE_EQ(
       SWRC_SWPtoSWC(15., swrc_type, swrcp, gravel, width, LOGWARN),
@@ -363,7 +363,7 @@ namespace{
     for (swrc_type = 0; swrc_type < N_SWRCs; swrc_type++) {
       EXPECT_DEATH_IF_SUPPORTED(
         SWRC_SWPtoSWC(-1., swrc_type, swrcp, gravel, width, LOGFATAL),
-        "@ generic.c LogError"
+        "invalid SWP"
       );
       EXPECT_DOUBLE_EQ(
         SWRC_SWPtoSWC(-1., swrc_type, swrcp, gravel, width, LOGWARN),

--- a/tests/gtests/test_SW_VegProd.cc
+++ b/tests/gtests/test_SW_VegProd.cc
@@ -1193,7 +1193,7 @@ namespace {
                     climateAverages.meanTempMon_C, climateAverages.PPTMon_cm, inputValues, shrubLimit,
                     SumGrassesFraction, C4Variables, fillEmptyWithBareGround, inNorthHem, warnExtrapolation,
                     fixBareGround, grassOutput, RelAbundanceL0, RelAbundanceL1);,
-          ""
+          "User defined relative abundance values sum to more than 1 = full land cover"
         );
 
         /*  ===============================================================

--- a/tests/gtests/test_SW_Weather.cc
+++ b/tests/gtests/test_SW_Weather.cc
@@ -154,7 +154,7 @@ namespace {
         // Error: too many missing values and weather generator turned off
         EXPECT_DEATH_IF_SUPPORTED(
           SW_WTH_finalize_all_weather(),
-          ""
+          "more than 3 days missing in year 1981 and weather generator turned off"
         );
 
         Reset_SOILWAT2_after_UnitTest();


### PR DESCRIPTION
- close https://github.com/DrylandEcology/SOILWAT2/issues/342

* #342 is a bug for SOILWAT2 tests but not for other setups

- new approach for SOILWAT2 tests to close log files
* immediately close the `logfp` file connection that was created by `SW_F_read()`
* set `logfp` to NULL to silence non-error messages during tests
* update `LogError()` to behave as it already does for rSOILWAT2, i.e., if silenced, write only if error (message is sent to stderr) and otherwise write all message to `logfp` as previously
* DeathTests now expect a specific error message