### PR TITLE
Feature soil temperature initialization

### DIFF
--- a/include/SW_Flow_lib.h
+++ b/include/SW_Flow_lib.h
@@ -175,8 +175,8 @@ void SW_ST_setup_run(
 	Bool *soil_temp_init,
 	double airTemp,
 	double swc[],
-	double oldavgLyrTemp[],
 	double *surfaceAvg,
+	double avgLyrTemp[],
 	double* lyrFrozen,
 	LOG_INFO* LogInfo
 );

--- a/include/SW_SoilWater.h
+++ b/include/SW_SoilWater.h
@@ -65,9 +65,12 @@ void SW_SWC_construct(SW_SOILWAT* SW_SoilWat, LOG_INFO* LogInfo);
 void SW_SWC_deconstruct(SW_SOILWAT* SW_SoilWat);
 void SW_SWC_new_year(SW_SOILWAT* SW_SoilWat, SW_SITE* SW_Site, TimeInt year,
 					 LOG_INFO* LogInfo);
-void SW_SWC_read(SW_SOILWAT* SW_SoilWat, RealD site_avgLyrTemp[],
-	TimeInt endyr, LyrIndex n_layers, char *InFiles[],
-	LOG_INFO* LogInfo);
+void SW_SWC_read(
+	SW_SOILWAT* SW_SoilWat,
+	TimeInt endyr,
+	char *InFiles[],
+	LOG_INFO* LogInfo
+);
 void SW_SWC_init_run(SW_SOILWAT* SW_SoilWat, SW_SITE* SW_Site,
 					 RealD* temp_snow);
 void _read_swc_hist(SW_SOILWAT_HIST* SoilWat_hist, TimeInt year, LOG_INFO* LogInfo);

--- a/include/SW_datastructs.h
+++ b/include/SW_datastructs.h
@@ -56,12 +56,12 @@ typedef struct {
 typedef struct {
 
 	double depths[MAX_LAYERS],  //soil layer depths of SoilWat soil
-	       depthsR[MAX_ST_RGR],//evenly spaced soil layer depths for soil temperature calculations
-		   	 fcR[MAX_ST_RGR],//field capacity of soil layers for soil temperature calculations
-		   	 wpR[MAX_ST_RGR], //wilting point of soil layers for soil temperature calculations
-		   	 bDensityR[MAX_ST_RGR],//bulk density of the whole soil per soil layer for soil temperature calculations
+	       depthsR[MAX_ST_RGR],//evenly spaced depths of soil temperature layer profile
+		   	 fcR[MAX_ST_RGR],//field capacity of soil temperature layer profile, i.e., at `depthsR[]`
+		   	 wpR[MAX_ST_RGR], //wilting point of soil temperature layer profile, i.e., at `depthsR[]`
+		   	 bDensityR[MAX_ST_RGR],//bulk density of the whole soil of soil temperature layer profile, i.e., at `depthsR[]`
 		   	 oldsFusionPool_actual[MAX_LAYERS],
-             oldavgLyrTempR[MAX_ST_RGR];//yesterdays soil temperature of soil layers for soil temperature calculations; index 0 is surface temperature
+             oldavgLyrTempR[MAX_ST_RGR];//yesterdays soil temperature of soil temperature layer profile, i.e., at `depthsR[]`; Note: index 0 is surface temperature
 
 	double tlyrs_by_slyrs[MAX_ST_RGR][MAX_LAYERS + 1]; // array of soil depth correspondance between soil profile layers and soil temperature layers; last column has negative values and indicates use of deepest soil layer values copied for deeper soil temperature layers
 
@@ -241,7 +241,7 @@ typedef struct {
 		fractionWeightMatric_sand[MAX_LAYERS], /* sand content (< 2 mm & > . mm) as weight-fraction of matric soil (g/g) */
 		fractionWeightMatric_clay[MAX_LAYERS], /* clay content (< . mm & > . mm) as weight-fraction of matric soil (g/g) */
 		impermeability[MAX_LAYERS], /* fraction of how impermeable a layer is (0=permeable, 1=impermeable)    */
-		avgLyrTemp[MAX_LAYERS], /* initial soil temperature for each soil layer */
+		avgLyrTempInit[MAX_LAYERS], /* initial soil temperature for each soil layer */
 
 		/* Derived soil characteristics */
 		soilMatric_density[MAX_LAYERS], /* matric soil density of the < 2 mm fraction, i.e., gravel component excluded, (g/cm3) */

--- a/src/SW_Control.c
+++ b/src/SW_Control.c
@@ -362,8 +362,12 @@ void SW_CTL_read_inputs_from_disk(SW_ALL* sw, PATH_INFO* PathInfo,
   if (debug) swprintf(" > 'CO2'");
   #endif
 
-  SW_SWC_read(&sw->SoilWat, sw->Site.avgLyrTemp, sw->Model.endyr,
-              sw->Site.n_layers, PathInfo->InFiles, LogInfo);
+  SW_SWC_read(
+    &sw->SoilWat,
+    sw->Model.endyr,
+    PathInfo->InFiles,
+    LogInfo
+  );
   #ifdef SWDEBUG
   if (debug) swprintf(" > 'swc'");
   if (debug) swprintf(" completed.\n");

--- a/src/SW_Flow.c
+++ b/src/SW_Flow.c
@@ -151,6 +151,8 @@ void SW_FLW_init_run(SW_SOILWAT* SW_SoilWat) {
 
 		SW_SoilWat->swcBulk[Today][i] = 0.;
 		SW_SoilWat->drain[i] = 0.;
+
+		SW_SoilWat->avgLyrTemp[i] = 0.;
 	}
 
 	//When running as a library make sure these are set to zero.
@@ -217,18 +219,13 @@ void SW_Water_Flow(SW_ALL* sw, LOG_INFO* LogInfo) {
 			&sw->StRegValues.soil_temp_init,
 			sw->Weather.now.temp_avg,
 			sw->SoilWat.swcBulk[Today],
-			sw->SoilWat.avgLyrTemp, // yesterday's soil temperature values
-			&sw->Weather.surfaceAvg, // yesterday's soil surface temperature
+			&sw->Weather.surfaceAvg,
+			sw->SoilWat.avgLyrTemp,
 			sw->SoilWat.lyrFrozen,
 			LogInfo
 		);
 	}
 
-	ForEachSoilLayer(i, n_layers) {
-		/* Default average layer temperature to zero in case values are
-		   not updated otherwise */
-		sw->SoilWat.avgLyrTemp[i] = 0.;
-	}
 
 	/* Solar radiation and PET */
 	x = sw->VegProd.bare_cov.albedo * sw->VegProd.bare_cov.fCover;

--- a/src/SW_Site.c
+++ b/src/SW_Site.c
@@ -1650,7 +1650,7 @@ void SW_LYR_read(SW_SITE* SW_Site, char *InFiles[], LOG_INFO* LogInfo) {
 		SW_Site->fractionWeightMatric_sand[lyrno] = psand;
 		SW_Site->fractionWeightMatric_clay[lyrno] = pclay;
 		SW_Site->impermeability[lyrno] = imperm;
-		SW_Site->avgLyrTemp[lyrno] = soiltemp;
+		SW_Site->avgLyrTempInit[lyrno] = soiltemp;
 
 		if (lyrno >= MAX_LAYERS) {
 			CloseFile(&f, LogInfo);
@@ -1768,7 +1768,7 @@ void set_soillayers(SW_VEGPROD* SW_VegProd, SW_SITE* SW_Site,
     SW_Site->fractionWeightMatric_sand[lyrno] = psand[i];
     SW_Site->fractionWeightMatric_clay[lyrno] = pclay[i];
     SW_Site->impermeability[lyrno] = imperm[i];
-    SW_Site->avgLyrTemp[lyrno] = soiltemp[i];
+    SW_Site->avgLyrTempInit[lyrno] = soiltemp[i];
   }
 
 
@@ -2537,7 +2537,7 @@ void _echo_inputs(SW_SITE* SW_Site, char *InFiles[], LOG_INFO* LogInfo) {
 		LogError(LogInfo, LOGNOTE, "  %3d %5.1f %9.5f %6.2f %8.5f %8.5f %6.2f %6.2f %7.4f %7.4f %7.4f %7.4f %7.4f %7.4f %8.4f %7.4f %5.4f\n", i + 1, SW_Site->width[i],
 				SW_Site->soilBulk_density[i], SW_Site->fractionVolBulk_gravel[i], SW_Site->swcBulk_fieldcap[i], SW_Site->swcBulk_wiltpt[i], SW_Site->fractionWeightMatric_sand[i],
 				SW_Site->fractionWeightMatric_clay[i], SW_Site->swcBulk_atSWPcrit[i][SW_FORBS], SW_Site->swcBulk_atSWPcrit[i][SW_TREES], SW_Site->swcBulk_atSWPcrit[i][SW_SHRUB],
-				SW_Site->swcBulk_atSWPcrit[i][SW_GRASS], SW_Site->swcBulk_wet[i], SW_Site->swcBulk_min[i], SW_Site->swcBulk_init[i], SW_Site->swcBulk_saturated[i], SW_Site->avgLyrTemp[i]);
+				SW_Site->swcBulk_atSWPcrit[i][SW_GRASS], SW_Site->swcBulk_wet[i], SW_Site->swcBulk_min[i], SW_Site->swcBulk_init[i], SW_Site->swcBulk_saturated[i], SW_Site->avgLyrTempInit[i]);
 	}
 
 	LogError(LogInfo, LOGNOTE, "\n  Water Potential values:\n");

--- a/src/SW_SoilWater.c
+++ b/src/SW_SoilWater.c
@@ -961,15 +961,16 @@ void SW_SWC_new_year(SW_SOILWAT* SW_SoilWat, SW_SITE* SW_Site, TimeInt year,
 
 @param[in,out] SW_SoilWat Struct of type SW_SOILWAT containing
 	soil water related values
-@param[in] site_avgLyrTemp Initial soil temperature for each soil layer
 @param[in] endyr Ending year for model run
-@param[in] n_layers Number of layers of soil within the simulation run
 @param[in] InFiles Array of program in/output files
 @param[in] LogInfo Holds information dealing with logfile output
 */
-void SW_SWC_read(SW_SOILWAT* SW_SoilWat, RealD site_avgLyrTemp[],
-	TimeInt endyr, LyrIndex n_layers, char *InFiles[],
-	LOG_INFO* LogInfo) {
+void SW_SWC_read(
+	SW_SOILWAT* SW_SoilWat,
+	TimeInt endyr,
+	char *InFiles[],
+	LOG_INFO* LogInfo
+) {
 	/* =================================================== */
 	/* HISTORY
 	 *  1/25/02 - cwb - removed unused records of logfile and
@@ -979,11 +980,6 @@ void SW_SWC_read(SW_SOILWAT* SW_SoilWat, RealD site_avgLyrTemp[],
 	FILE *f;
 	int lineno = 0, nitems = 4;
 	char inbuf[MAX_FILENAMESIZE];
-// gets the soil temperatures from where they are read in the SW_Site struct for use later
-// SW_Site.c must call it's read function before this, or it won't work
-	LyrIndex i;
-	ForEachSoilLayer(i, n_layers)
-		SW_SoilWat->avgLyrTemp[i] = site_avgLyrTemp[i];
 
 	char *MyFileName = InFiles[eSoilwat];
 	f = OpenFile(MyFileName, "r", LogInfo);

--- a/tests/gtests/test_SW_Flow_lib_temp.cc
+++ b/tests/gtests/test_SW_Flow_lib_temp.cc
@@ -96,13 +96,13 @@ namespace {
     // *****  Test when nlyrs = 1  ***** //
     unsigned int i =0.;
     nlyrs = 1;
-    double width[] = {20}, oldsTemp[] = {1};
+    double width[] = {20}, sTempInit[] = {1};
     double bDensity[] = {RandNorm(1.,0.5,&STInit_rng)}, fc[] = {RandNorm(1.5, 0.5,&STInit_rng)};
     double wp[1];
     wp[0]= fc[0] - 0.6; // wp will always be less than fc
 
     /// test standard conditions
-    soil_temperature_setup(&SW_All.StRegValues, bDensity, width, oldsTemp,
+    soil_temperature_setup(&SW_All.StRegValues, bDensity, width, sTempInit,
       sTconst, nlyrs, fc, wp, deltaX, theMaxDepth, nRgr, &ptr_stError,
       &SW_All.StRegValues.soil_temp_init, &LogInfo);
 
@@ -123,7 +123,7 @@ namespace {
     /// generate inputs using a for loop
     nlyrs = MAX_LAYERS;
     double width2[] = {5, 5, 5, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 20, 20, 20, 20, 20, 20};
-    double oldsTemp2[] = {1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4};
+    double sTempInit2[] = {1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4};
     double *bDensity2 = new double[nlyrs];
     double *fc2 = new double[nlyrs];
     double *wp2 = new double[nlyrs];
@@ -134,7 +134,7 @@ namespace {
       wp2[i] = fc2[i] - 0.6; // wp will always be less than fc
     }
 
-    soil_temperature_setup(&SW_All.StRegValues, bDensity2, width2, oldsTemp2,
+    soil_temperature_setup(&SW_All.StRegValues, bDensity2, width2, sTempInit2,
       sTconst, nlyrs, fc2, wp2, deltaX, theMaxDepth, nRgr, &ptr_stError,
       &SW_All.StRegValues.soil_temp_init, &LogInfo);
 
@@ -163,7 +163,7 @@ namespace {
     Bool ptr_stError = swFALSE;
     nlyrs = MAX_LAYERS;
     double width2[] = {5, 5, 5, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 20, 20, 20, 20, 20, 20};
-    double oldsTemp2[] = {1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4};
+    double sTempInit2[] = {1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4};
     double *bDensity2 = new double[nlyrs];
     double *fc2 = new double[nlyrs];
     double *wp2 = new double[nlyrs];
@@ -182,7 +182,7 @@ namespace {
     // We expect death when max depth < last layer
     EXPECT_DEATH_IF_SUPPORTED(
       soil_temperature_setup(
-        &SW_All.StRegValues, bDensity2, width2, oldsTemp2, sTconst, nlyrs,
+        &SW_All.StRegValues, bDensity2, width2, sTempInit2, sTconst, nlyrs,
         fc2, wp2, deltaX, theMaxDepth2, nRgr, &ptr_stError,
         &SW_All.StRegValues.soil_temp_init, &LogInfo
       ),
@@ -208,14 +208,14 @@ namespace {
     // *****  Test when nlyrs = 1  ***** //
     unsigned int i = 0.;
     nlyrs = 1;
-    double width[] = {20}, oldsTemp[] = {1};
+    double width[] = {20}, sTempInit[] = {1};
     double bDensity[] = {fmaxf(RandNorm(1.5,0.5,&SLIF_rng), 0.1)},
       fc[] = {fmaxf(RandNorm(1.5, 0.5,&SLIF_rng), 0.1)};
     double wp[1];
 
     wp[0]= fmax(fc[0] - 0.6, .1); // wp will always be less than fc
 
-    soil_temperature_setup(&SW_All.StRegValues, bDensity, width, oldsTemp,
+    soil_temperature_setup(&SW_All.StRegValues, bDensity, width, sTempInit,
       sTconst, nlyrs, fc, wp, deltaX, theMaxDepth, nRgr, &ptr_stError,
       &SW_All.StRegValues.soil_temp_init, &LogInfo);
 
@@ -236,22 +236,23 @@ namespace {
     }
 
     // lyrSoil_to_lyrTemp_temperature tests
+    EXPECT_TRUE(missing(SW_All.StRegValues.oldavgLyrTempR[0])); // surface temperature is initialized to missing because not used
     double maxvalR = 0.;
-    for (i = 0; i < nRgr + 1; i++) {
-      EXPECT_GT(SW_All.StRegValues.oldavgLyrTempR[i], -100); //Values interpolated into oldsTempR should be realistic
-      EXPECT_LT(SW_All.StRegValues.oldavgLyrTempR[i], 100); //Values interpolated into oldsTempR should be realistic
+    for (i = 1; i < nRgr + 1; i++) {
+      EXPECT_GT(SW_All.StRegValues.oldavgLyrTempR[i], -100); //Values interpolated into sTempInitR should be realistic
+      EXPECT_LT(SW_All.StRegValues.oldavgLyrTempR[i], 100); //Values interpolated into sTempInitR should be realistic
       if(GT(SW_All.StRegValues.oldavgLyrTempR[i], maxvalR)) {
         maxvalR = SW_All.StRegValues.oldavgLyrTempR[i];
       }
     }
-    EXPECT_LE(maxvalR, sTconst);//Maximum interpolated oldsTempR value should be less than or equal to maximum in oldsTemp2 (sTconst = last layer)
+    EXPECT_LE(maxvalR, sTconst);//Maximum interpolated sTempInitR value should be less than or equal to maximum in sTempInit2 (sTconst = last layer)
     EXPECT_EQ(SW_All.StRegValues.oldavgLyrTempR[nRgr + 1], sTconst); //Temperature in last interpolated layer should equal sTconst
 
     // *****  Test when nlyrs = MAX_LAYERS (SW_Defines.h)  ***** //
     /// generate inputs using a for loop
     nlyrs = MAX_LAYERS;
     double width2[] = {5, 5, 5, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 20, 20, 20, 20, 20, 20};
-    double oldsTemp2[] = {1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4};
+    double sTempInit2[] = {1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4};
     double *bDensity2 = new double[nlyrs];
     double *fc2 = new double[nlyrs];
     double *wp2 = new double[nlyrs];
@@ -265,7 +266,7 @@ namespace {
       EXPECT_GT(wp2[i], 0);
     }
 
-    soil_temperature_setup(&SW_All.StRegValues, bDensity2, width2, oldsTemp2,
+    soil_temperature_setup(&SW_All.StRegValues, bDensity2, width2, sTempInit2,
       sTconst, nlyrs, fc2, wp2, deltaX, theMaxDepth, nRgr, &ptr_stError,
       &SW_All.StRegValues.soil_temp_init, &LogInfo);
 
@@ -284,15 +285,16 @@ namespace {
     }
 
     // lyrSoil_to_lyrTemp_temperature tests
+    EXPECT_TRUE(missing(SW_All.StRegValues.oldavgLyrTempR[0])); // surface temperature is initialized to missing because not used
     maxvalR = 0.;
-    for (i = 0; i <= nRgr + 1; i++) {
-      EXPECT_GT(SW_All.StRegValues.oldavgLyrTempR[i], -200); //Values interpolated into oldsTempR should be realistic
-      EXPECT_LT(SW_All.StRegValues.oldavgLyrTempR[i], 200); //Values interpolated into oldsTempR should be realistic
+    for (i = 1; i <= nRgr + 1; i++) {
+      EXPECT_GT(SW_All.StRegValues.oldavgLyrTempR[i], -200); //Values interpolated into sTempInitR should be realistic
+      EXPECT_LT(SW_All.StRegValues.oldavgLyrTempR[i], 200); //Values interpolated into sTempInitR should be realistic
       if(GT(SW_All.StRegValues.oldavgLyrTempR[i], maxvalR)) {
         maxvalR = SW_All.StRegValues.oldavgLyrTempR[i];
       }
     }
-    EXPECT_LE(maxvalR, sTconst);//Maximum interpolated oldsTempR value should be less than or equal to maximum in oldsTemp2 (sTconst = last layer)
+    EXPECT_LE(maxvalR, sTconst);//Maximum interpolated sTempInitR value should be less than or equal to maximum in sTempInit2 (sTconst = last layer)
     EXPECT_EQ(SW_All.StRegValues.oldavgLyrTempR[nRgr + 1], sTconst); //Temperature in last interpolated layer should equal sTconst
 
     delete[] bDensity2; delete[] fc2; delete[] wp2;
@@ -363,7 +365,7 @@ namespace {
     /// error causing condtions
 
     double *sTempR = new double[nRgr + 2];
-    double *oldsTempR = new double[nRgr + 2];
+    double *sTempInitR = new double[nRgr + 2];
     double *wpR = new double[nRgr + 2];
     double *fcR = new double[nRgr + 2];
     double *vwcR = new double[nRgr + 2];
@@ -373,14 +375,14 @@ namespace {
     unsigned int i = 0.;
     for (i = 0; i <= nRgr + 1; i++) {
       sTempR[i] = RandNorm(1.5, 1,&STTF_rng);
-      oldsTempR[i] = RandNorm(1.5, 1,&STTF_rng);
+      sTempInitR[i] = RandNorm(1.5, 1,&STTF_rng);
       fcR[i] = 2.1;
       wpR[i] = 1.5; // wp will always be less than fc
       vwcR[i] = 1.6;
       bDensityR[i] = 1.5;
     }
 
-    soil_temperature_today(&delta_time, deltaX, T1, sTconst, nRgr, sTempR, oldsTempR,
+    soil_temperature_today(&delta_time, deltaX, T1, sTconst, nRgr, sTempR, sTempInitR,
       vwcR, wpR, fcR, bDensityR, csParam1, csParam2, shParam, &ptr_stError, surface_range,
       temperatureRangeR, depthsR, SW_All.Model.year, SW_All.Model.doy);
 
@@ -400,21 +402,21 @@ namespace {
 
     // test that the ptr_stError is FALSE when it is supposed to
     double *sTempR2 = new double[nRgr + 2];
-    double *oldsTempR3 = new double[nRgr + 2];
+    double *sTempInitR3 = new double[nRgr + 2];
 
     for (i = 0; i <= nRgr + 1; i++)
     {
       sTempR2[i] = RandNorm(150, 1,&STTF_rng);
-      oldsTempR3[i] = RandNorm(150, 1,&STTF_rng);
+      sTempInitR3[i] = RandNorm(150, 1,&STTF_rng);
     }
 
-    soil_temperature_today(&delta_time, deltaX, T1, sTconst, nRgr, sTempR2, oldsTempR3,
+    soil_temperature_today(&delta_time, deltaX, T1, sTconst, nRgr, sTempR2, sTempInitR3,
         vwcR, wpR, fcR, bDensityR, csParam1, csParam2, shParam, &ptr_stError, surface_range,
         temperatureRangeR, depthsR, SW_All.Model.year, SW_All.Model.doy);
 
     //Check that ptr_stError is TRUE
     EXPECT_EQ(ptr_stError, 1);
-    double *array_list[] = {sTempR2, oldsTempR3, sTempR, oldsTempR, wpR, fcR, vwcR, bDensityR, temperatureRangeR, depthsR};
+    double *array_list[] = {sTempR2, sTempInitR3, sTempR, sTempInitR, wpR, fcR, vwcR, bDensityR, temperatureRangeR, depthsR};
     for (i = 0; i < length(array_list); i++){
       delete[] array_list[i];
     }
@@ -425,10 +427,7 @@ namespace {
   // is only called in the soil_temperature function
   TEST_F(AllTest, SWFlowTempMainSoilTemperatureFunction_Lyr01) {
 
-    unsigned int k, i;
-
-    pcg32_random_t MSTF_Lyer1_rng;
-    RandSeed(0u, 0u, &MSTF_Lyer1_rng);
+    unsigned int k;
 
     // *****  Test when nlyrs = 1  ***** //
     unsigned int nlyrs = 1, nRgr = 65;
@@ -440,8 +439,9 @@ namespace {
     Bool ptr_stError = swFALSE;
 
     double swc[] = {1.0}, swc_sat[] = {1.5}, bDensity[] = {1.8}, width[] = {20},
-    oldsTemp[] = {5.0}, sTemp[1], min_temp[] = {10.0}, max_temp[] = {1.0};
+    sTemp[1], min_temp[] = {10.0}, max_temp[] = {1.0};
 
+    SW_All.Site.avgLyrTempInit[0] = 5.0;
     SW_All.Site.soilBulk_density[0] = 1.8;
     SW_All.Site.width[0] = 20;
     SW_All.Site.n_layers = 1;
@@ -455,14 +455,17 @@ namespace {
 
 
     SW_ST_setup_run(
-      &SW_All.StRegValues, &SW_All.Site, &ptr_stError,
-      &SW_All.StRegValues.soil_temp_init, airTemp, swc,
-      oldsTemp, &surfaceTemp, SW_All.SoilWat.lyrFrozen, &LogInfo
+      &SW_All.StRegValues,
+      &SW_All.Site,
+      &ptr_stError,
+      &SW_All.StRegValues.soil_temp_init,
+      airTemp,
+      swc,
+      &surfaceTemp,
+      sTemp,
+      SW_All.SoilWat.lyrFrozen,
+      &LogInfo
     );
-
-    for (k = 0; k < nlyrs; k++) {
-      sTemp[k] = oldsTemp[k];
-    }
 
     soil_temperature(&SW_All.StRegValues,
       &surface_max, &surface_min, SW_All.SoilWat.lyrFrozen,
@@ -481,7 +484,7 @@ namespace {
     snowdepth = 0;
 
     for (k = 0; k < nlyrs; k++) {
-      sTemp[k] = oldsTemp[k];
+      sTemp[k] = SW_All.Site.avgLyrTempInit[k];
     }
 
     soil_temperature(&SW_All.StRegValues,
@@ -500,7 +503,7 @@ namespace {
     biomass = 305;
 
     for (k = 0; k < nlyrs; k++) {
-      sTemp[k] = oldsTemp[k];
+      sTemp[k] = SW_All.Site.avgLyrTempInit[k];
     }
 
     soil_temperature(&SW_All.StRegValues,
@@ -522,7 +525,7 @@ namespace {
     EXPECT_LT(sTemp[0], 100); // Sense check
     EXPECT_EQ(0, ptr_stError); // ptr_stError should be FALSE
 
-    // Expect that oldsTempR is updated to sTempR for the next day
+    // Expect that sTempInitR is updated to sTempR for the next day
     for (k = 0; k <= nRgr + 1; k++)
     {
       //swprintf("\n k %u, newoldtempR %f", k, SW_All.StRegValues.oldavgLyrTempR[k]);
@@ -530,21 +533,20 @@ namespace {
     }
 
     // ptr_stError should be set to TRUE if soil_temperature_today fails (i.e. unrealistic temp values)
-    double *sTemp2 = new double[nlyrs];
-    double *oldsTemp2 = new double[nlyrs];
 
-    surfaceTemp = airTemp = 1500.;
-
-    for (i = 0; i < nlyrs; i++)
-    {
-      sTemp2[i] = RandNorm(surfaceTemp, 1, &MSTF_Lyer1_rng);
-      oldsTemp2[i] = RandNorm(surfaceTemp, 1, &MSTF_Lyer1_rng);
-    }
+    airTemp = 1500.;
 
     SW_ST_setup_run(
-      &SW_All.StRegValues, &SW_All.Site, &ptr_stError,
-      &SW_All.StRegValues.soil_temp_init, airTemp, swc, oldsTemp,
-      &surfaceTemp, SW_All.SoilWat.lyrFrozen, &LogInfo
+      &SW_All.StRegValues,
+      &SW_All.Site,
+      &ptr_stError,
+      &SW_All.StRegValues.soil_temp_init,
+      airTemp,
+      swc,
+      &surfaceTemp,
+      sTemp,
+      SW_All.SoilWat.lyrFrozen,
+      &LogInfo
     );
 
     EXPECT_EQ(ptr_stError, swFALSE);
@@ -552,15 +554,13 @@ namespace {
     soil_temperature(&SW_All.StRegValues,
       &surface_max, &surface_max, SW_All.SoilWat.lyrFrozen,
       airTemp, pet, aet, biomass, swc, swc_sat, bDensity, width,
-      sTemp2, &surfaceTemp, nlyrs, bmLimiter, t1Param1, t1Param2, t1Param3,
+      sTemp, &surfaceTemp, nlyrs, bmLimiter, t1Param1, t1Param2, t1Param3,
       csParam1, csParam2, shParam, snowdepth, sTconst, deltaX, theMaxDepth,
       nRgr, snow, max_air_temp, min_air_temp, H_gt, SW_All.Model.year,
       SW_All.Model.doy, min_temp, max_temp, &ptr_stError, &LogInfo);
 
     // Check that error has occurred as indicated by ptr_stError
     EXPECT_EQ(ptr_stError, swTRUE);
-
-    delete[] oldsTemp2; delete[] sTemp2;
   }
 
   // Test main soil temperature function 'soil_temperature'
@@ -585,7 +585,7 @@ namespace {
 
     unsigned int nlyrs2 = MAX_LAYERS;
     double width2[] = {5, 5, 5, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 20, 20, 20, 20, 20, 20};
-    double oldsTemp3[] = {1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4};
+    double sTempInit3[] = {1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4};
     double sTemp3[MAX_LAYERS];
     double bDensity2[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
 
@@ -596,6 +596,7 @@ namespace {
     double *min_temp = new double[nlyrs2];
     double *max_temp = new double[nlyrs2];
     for (i = 0; i < nlyrs2; i++) {
+      SW_All.Site.avgLyrTempInit[i] = sTempInit3[i];
       // SWC(wilting point): width > swc_wp > 0
       SW_All.Site.swcBulk_wiltpt[i] = 0.1 * width2[i];
       // SWC(field capacity): width > swc_fc > swc_wp
@@ -621,17 +622,21 @@ namespace {
     SW_All.Site.n_layers = nlyrs2;
 
     SW_ST_setup_run(
-      &SW_All.StRegValues, &SW_All.Site, &ptr_stError,
-      &SW_All.StRegValues.soil_temp_init, airTemp, swc2,
-      oldsTemp3, &surfaceTemp, SW_All.SoilWat.lyrFrozen, &LogInfo
+      &SW_All.StRegValues,
+      &SW_All.Site,
+      &ptr_stError,
+      &SW_All.StRegValues.soil_temp_init,
+      airTemp,
+      swc2,
+      &surfaceTemp,
+      sTemp3,
+      SW_All.SoilWat.lyrFrozen,
+      &LogInfo
     );
+
 
     // Test surface temp equals surface_temperature_under_snow() because snow > 0
     snowdepth = 5;
-
-    for (k = 0; k < nlyrs2; k++) {
-      sTemp3[k] = oldsTemp3[k];
-    }
 
     soil_temperature(&SW_All.StRegValues, &surface_max, &surface_min,
       SW_All.SoilWat.lyrFrozen, airTemp, pet, aet, biomass, swc2, swc_sat2,
@@ -649,7 +654,7 @@ namespace {
     snowdepth = 0;
     biomass = 100;
     for (k = 0; k < nlyrs2; k++) {
-      sTemp3[k] = oldsTemp3[k];
+      sTemp3[k] = sTempInit3[k];
     }
 
     soil_temperature(&SW_All.StRegValues, &surface_max, &surface_min,
@@ -667,7 +672,7 @@ namespace {
     //Test surface temp equals equation when biomass < blimititer & snow = 0
     biomass = 305;
     for (k = 0; k < nlyrs2; k++) {
-      sTemp3[k] = oldsTemp3[k];
+      sTemp3[k] = SW_All.Site.avgLyrTempInit[k];
     }
 
     soil_temperature(&SW_All.StRegValues, &surface_max, &surface_min,
@@ -693,7 +698,7 @@ namespace {
       EXPECT_LT(sTemp3[k], 100); // Sense check&
     }
 
-    // Expect that oldsTempR is updated to sTempR for the next day
+    // Expect that sTempInitR is updated to sTempR for the next day
     for (k = 0; k <= nRgr + 1; k++)
     {
       //swprintf("\n k %u, newoldtempR %f", k, SW_All.StRegValues.oldavgLyrTempR[k]);


### PR DESCRIPTION
re-organized initialization of soil temperature values: `SW_ST_setup_run()` now sets all soil temperature to initial values (which is only called if the soil temperature module is activated), i.e., both `SW_SoilWater.avgLyrTemp[]` and `SW_StRegValues.oldavgLyrTempR[]` are derived from `SW_Site.avgLyrTempInit[]`