### PR TITLE
Feature memory fixes

### DIFF
--- a/.LSAN_suppr.txt
+++ b/.LSAN_suppr.txt
@@ -3,8 +3,5 @@
 
 # These are known leaks that await fixing
 
-# https://github.com/DrylandEcology/SOILWAT2/issues/205
-leak:SW_VPD_construct
-
 # on Apple arm64: https://github.com/google/sanitizers/issues/1501
 leak:realizeClassWithoutSwift

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Bugfixes
     * Fix an error where a pointer was freed even though it was not allocated
       (issue #356; @dschlaep).
+    * Fix memory leak in test of `SW_VPD_construct()` (issue #205; @dschlaep).
 
 # SOILWAT2 v7.0.0
 * This version produces nearly identical simulation output

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 # NEWS
 
 # SOILWAT2 v7.1.0-9000
+* Bugfixes
+    * Fix an error where a pointer was freed even though it was not allocated
+      (issue #356; @dschlaep).
 
 # SOILWAT2 v7.0.0
 * This version produces nearly identical simulation output

--- a/include/SW_Control.h
+++ b/include/SW_Control.h
@@ -31,7 +31,7 @@ extern "C" {
 void SW_CTL_setup_model(SW_ALL* sw, SW_OUTPUT_POINTERS* SW_OutputPtrs,
                         PATH_INFO* PathInfo, LOG_INFO* LogInfo);
 void SW_CTL_clear_model(Bool full_reset, SW_ALL* sw, PATH_INFO* PathInfo);
-void SW_CTL_init_run(SW_ALL* sw, PATH_INFO* PathInfo, LOG_INFO* LogInfo);
+void SW_CTL_init_run(SW_ALL* sw, LOG_INFO* LogInfo);
 void SW_CTL_read_inputs_from_disk(SW_ALL* sw, PATH_INFO* PathInfo,
                                   LOG_INFO* LogInfo);
 void SW_CTL_main(SW_ALL* sw, SW_OUTPUT_POINTERS* SW_OutputPtrs,

--- a/include/SW_Site.h
+++ b/include/SW_Site.h
@@ -239,7 +239,7 @@ void SW_SIT_init_counts(SW_SITE* SW_Site);
 void SW_SIT_read(SW_SITE* SW_Site, char *InFiles[],
 				 SW_CARBON* SW_Carbon, LOG_INFO* LogInfo);
 void SW_SIT_init_run(SW_VEGPROD* SW_VegProd, SW_SITE* SW_Site,
-					 char *InFiles[], LOG_INFO* LogInfo);
+					LOG_INFO* LogInfo);
 void _echo_inputs(SW_SITE* SW_Site, char *InFiles[], LOG_INFO* LogInfo);
 
 /* these used to be in Layers */
@@ -251,7 +251,7 @@ void set_soillayers(SW_VEGPROD* SW_VegProd, SW_SITE* SW_Site,
 	LyrIndex nlyrs, RealF *dmax, RealF *bd, RealF *f_gravel, RealF *evco,
 	RealF *trco_grass, RealF *trco_shrub, RealF *trco_tree, RealF *trco_forb,
 	RealF *psand, RealF *pclay, RealF *imperm, RealF *soiltemp, int nRegions,
-	RealD *regionLowerBounds, char *InFiles[], LOG_INFO* LogInfo);
+	RealD *regionLowerBounds, LOG_INFO* LogInfo);
 void derive_soilRegions(SW_SITE* SW_Site, int nRegions,
 						RealD *regionLowerBounds, LOG_INFO* LogInfo);
 

--- a/src/SW_Control.c
+++ b/src/SW_Control.c
@@ -179,10 +179,9 @@ void SW_CTL_clear_model(Bool full_reset, SW_ALL* sw, PATH_INFO* PathInfo) {
 
   @param[in,out] sw Comprehensive structure holding all information
     dealt with in SOILWAT2
-  @param[in] PathInfo Struct holding all information about the programs path/files
   @param[in] LogInfo Holds information dealing with logfile output
 */
-void SW_CTL_init_run(SW_ALL* sw, PATH_INFO* PathInfo, LOG_INFO* LogInfo) {
+void SW_CTL_init_run(SW_ALL* sw, LOG_INFO* LogInfo) {
 
 	// SW_F_init_run() not needed
 	// SW_MDL_init_run() not needed
@@ -190,7 +189,7 @@ void SW_CTL_init_run(SW_ALL* sw, PATH_INFO* PathInfo, LOG_INFO* LogInfo) {
 	// SW_MKV_init_run() not needed
 	SW_PET_init_run(&sw->AtmDemand);
 	// SW_SKY_init_run() not needed
-	SW_SIT_init_run(&sw->VegProd, &sw->Site, PathInfo->InFiles, LogInfo);
+	SW_SIT_init_run(&sw->VegProd, &sw->Site, LogInfo);
 	SW_VES_init_run(sw->VegEstab.parms, &sw->Site, sw->Site.n_transp_lyrs,
                   sw->VegEstab.count, LogInfo); // must run after `SW_SIT_init_run()`
 	SW_VPD_init_run(&sw->VegProd, &sw->Weather, &sw->Model,

--- a/src/SW_Main.c
+++ b/src/SW_Main.c
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
 								sw.Model.days_in_month, &LogInfo);
 
 	// initialize simulation run (based on user inputs)
-	SW_CTL_init_run(&sw, &PathInfo, &LogInfo);
+	SW_CTL_init_run(&sw, &LogInfo);
 
   // initialize output
 	SW_OUT_set_ncol(sw.Site.n_layers, sw.Site.n_evap_lyrs, sw.VegEstab.count,

--- a/src/SW_Site.c
+++ b/src/SW_Site.c
@@ -1704,7 +1704,6 @@ void SW_LYR_read(SW_SITE* SW_Site, char *InFiles[], LOG_INFO* LogInfo) {
     depth [cm] of each region in ascending (in value) order. If you think about
     this from the perspective of soil, it would mean the shallowest bound is at
     `lowerBounds[0]`.
-  @param[in] InFiles Array of program in/output files
   @param[in] LogInfo Holds information dealing with logfile output
 
   @sideeffect After deleting any previous data in the soil layer array
@@ -1721,7 +1720,8 @@ void set_soillayers(SW_VEGPROD* SW_VegProd, SW_SITE* SW_Site,
 	LyrIndex nlyrs, RealF *dmax, RealF *bd, RealF *f_gravel, RealF *evco,
 	RealF *trco_grass, RealF *trco_shrub, RealF *trco_tree, RealF *trco_forb,
 	RealF *psand, RealF *pclay, RealF *imperm, RealF *soiltemp, int nRegions,
-	RealD *regionLowerBounds, char *InFiles[], LOG_INFO* LogInfo)
+	RealD *regionLowerBounds,
+	LOG_INFO* LogInfo)
 {
 
   RealF dmin = 0.0;
@@ -1775,7 +1775,7 @@ void set_soillayers(SW_VEGPROD* SW_VegProd, SW_SITE* SW_Site,
   derive_soilRegions(SW_Site, nRegions, regionLowerBounds, LogInfo);
 
   // Re-initialize site parameters based on new soil layers
-  SW_SIT_init_run(SW_VegProd, SW_Site, InFiles, LogInfo);
+  SW_SIT_init_run(SW_VegProd, SW_Site, LogInfo);
 }
 
 
@@ -1949,13 +1949,11 @@ void SW_SWRC_read(SW_SITE* SW_Site, char *InFiles[], LOG_INFO* LogInfo) {
 	@param[in,out] SW_VegProd Struct of type SW_VEGPROD describing surface
 		cover conditions in the simulation
 	@param[in,out] SW_Site Struct of type SW_SITE describing the simulated site
-	@param[in] InFiles Array of program in/output files
 	@param[in] LogInfo Holds information dealing with logfile output
 
 	@sideeffect Values stored in global variable `SW_Site`.
 */
-void SW_SIT_init_run(SW_VEGPROD* SW_VegProd, SW_SITE* SW_Site,
-					 char *InFiles[], LOG_INFO* LogInfo) {
+void SW_SIT_init_run(SW_VEGPROD* SW_VegProd, SW_SITE* SW_Site, LOG_INFO* LogInfo) {
 	/* =================================================== */
 	/* potentially this routine can be called whether the
 	 * layer data came from a file or a function call which
@@ -2271,15 +2269,15 @@ void SW_SIT_init_run(SW_VEGPROD* SW_VegProd, SW_SITE* SW_Site,
 				SW_Site->n_transp_lyrs[k] = max(SW_Site->n_transp_lyrs[k], s);
 
 			} else if (s == 0) {
-				LogError(LogInfo, LOGFATAL, "%s : Top soil layer must be included\n"
-						"  in %s tranpiration regions.\n", InFiles[eSite], key2veg[k]);
+				LogError(LogInfo, LOGFATAL, ": Top soil layer must be included\n"
+						"  in %s tranpiration regions.\n", key2veg[k]);
 			} else if (r < SW_Site->n_transp_rgn) {
-				LogError(LogInfo, LOGFATAL, "%s : Transpiration region %d \n"
+				LogError(LogInfo, LOGFATAL, ": Transpiration region %d \n"
 						"  is deeper than the deepest layer with a\n"
-						"  %s transpiration coefficient > 0 (%d) in '%s'.\n"
+						"  %s transpiration coefficient > 0 (%d).\n"
 						"  Please fix the discrepancy and try again.\n",
-						InFiles[eSite], r + 1, key2veg[k], s,
-								  InFiles[eLayers]);
+						r + 1, key2veg[k], s
+				);
 			} else {
 				SW_Site->my_transp_rgn[k][s] = 0;
 			}

--- a/src/SW_SoilWater.c
+++ b/src/SW_SoilWater.c
@@ -572,11 +572,9 @@ void SW_SWC_construct(SW_SOILWAT* SW_SoilWat, LOG_INFO* LogInfo) {
 	/* =================================================== */
 	OutPeriod pd;
 
-	// Clear memory before setting it
-	if (!isnull(SW_SoilWat->hist.file_prefix)) {
-		Mem_Free(SW_SoilWat->hist.file_prefix);
-		SW_SoilWat->hist.file_prefix = NULL;
-	}
+	/* initialize pointer */
+	SW_SoilWat->hist.file_prefix = NULL;
+
 
 	// Clear the module structure:
 	memset(SW_SoilWat, 0, sizeof(SW_SOILWAT));

--- a/src/Times.c
+++ b/src/Times.c
@@ -191,7 +191,9 @@ Bool isleapyear(const TimeInt year) {
  @param[in] interpAsBase1 Boolean value specifying if "dailyValues" should be base1 or base0
  @param[in] cum_monthdays Monthly cumulative number of days for "current" year
  @param[in] days_in_month Number of days per month for "current" year
- @param[out] dailyValues Array with linearly interpolated values for each day
+ @param[out] dailyValues Array with linearly interpolated values for each day;
+   `dailyValues` must be at least of length `MAX_DAYS` if `interpAsBase1` is
+   FALSE , and length `MAX_DAYS + 1` if `interpAsBase1` is TRUE.
 
  @note If `interpAsBase1` is TRUE, then `dailyValues[0]` is ignored (with a value of 0) because a `base1`
  index for "day of year" (doy) is used, i.e., the value on the first day of year (`doy = 1`) is located in `dailyValues[1]`.

--- a/tests/gtests/sw_maintest.cc
+++ b/tests/gtests/sw_maintest.cc
@@ -46,11 +46,7 @@ const char * dir_test = "./tests/example";
 
 int main(int argc, char **argv) {
   int res;
-  /*--- Imitate 'SW_Main.c/main()':
-    we need to initialize and take down SOILWAT2 variables
-    because SOILWAT2 uses (global) states.
-    This is otherwise not comptable with the c++ approach used by googletest.
-  */
+  /*--- Imitate 'SW_Main.c/main()' */
 
   // Emulate 'sw_init_args()'
   if (!ChDir(dir_test)) {
@@ -60,13 +56,17 @@ int main(int argc, char **argv) {
   //--- Setup unit tests
   ::testing::InitGoogleTest(&argc, argv);
 
-  // set death tests to be "threadsafe" instead of "fast"
+  // Set death tests to be "threadsafe" instead of "fast", i.e.,
+  // "re-executes the binary to cause just the single death test under consideration to be run"
+  // (https://google.github.io/googletest/reference/assertions.html#death)
+  // See code example in header for `AllTestStruct`
   GTEST_FLAG_SET(death_test_style, "threadsafe");
 
   // Run unit tests
   res = RUN_ALL_TESTS();
 
-  //--- Return output of 'RUN_ALL_TESTS()', see https://github.com/google/googletest/blob/master/googletest/docs/FAQ.md#my-compiler-complains-about-ignoring-return-value-when-i-call-run_all_tests-why
+  //--- Return output of 'RUN_ALL_TESTS()'
+  // (https://google.github.io/googletest/primer.html#writing-the-main-function)
   return res;
 }
 

--- a/tests/gtests/sw_testhelpers.cc
+++ b/tests/gtests/sw_testhelpers.cc
@@ -38,7 +38,7 @@
       simulation after this function has set soil layers, e.g.,
       SW_SWC_init_run()
 */
-void create_test_soillayers(unsigned int nlayers, char *InFiles[],
+void create_test_soillayers(unsigned int nlayers,
       SW_VEGPROD *SW_VegProd, SW_SITE *SW_Site, LOG_INFO *LogInfo) {
 
   if (nlayers <= 0 || nlayers > MAX_LAYERS) {
@@ -95,5 +95,5 @@ void create_test_soillayers(unsigned int nlayers, char *InFiles[],
   set_soillayers(SW_VegProd, SW_Site, nlayers, dmax,
     bulkd, f_gravel, evco, trco_grass, trco_shrub, trco_tree,
     trco_forb, psand, pclay, imperm, soiltemp, nRegions,
-    regionLowerBounds, InFiles, LogInfo);
+    regionLowerBounds, LogInfo);
 }

--- a/tests/gtests/sw_testhelpers.cc
+++ b/tests/gtests/sw_testhelpers.cc
@@ -24,8 +24,17 @@
 #include "include/SW_Files.h"
 #include "include/myMemory.h"
 
+#include "include/SW_Weather.h"
+#include "include/SW_Main_lib.h"
+
+
 #include "tests/gtests/sw_testhelpers.h"
 
+
+void silent_tests(LOG_INFO* LogInfo) {
+  LogInfo->logged = swFALSE;
+  LogInfo->logfp = NULL;
+}
 
 /**
   @brief Creates soil layers based on function arguments (instead of reading
@@ -96,4 +105,69 @@ void create_test_soillayers(unsigned int nlayers,
     bulkd, f_gravel, evco, trco_grass, trco_shrub, trco_tree,
     trco_forb, psand, pclay, imperm, soiltemp, nRegions,
     regionLowerBounds, LogInfo);
+}
+
+
+
+void setup_SW_Site_for_tests(SW_SITE *SW_Site) {
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
+
+    SW_Site->deepdrain = swTRUE;
+
+    SW_Site->_SWCMinVal = 100;
+    SW_Site->_SWCWetVal = 15;
+    SW_Site->_SWCInitVal = 15;
+
+    SW_Site->stMaxDepth = 990;
+    SW_Site->stDeltaX = 15;
+
+    SW_Site->slow_drain_coeff = 0.02;
+
+    SW_Site->site_has_swrcp = swFALSE;
+    strcpy(SW_Site->site_swrc_name, (char *) "Campbell1974");
+    SW_Site->site_swrc_type = encode_str2swrc(SW_Site->site_swrc_name, &LogInfo);
+    strcpy(SW_Site->site_ptf_name, (char *) "Cosby1984AndOthers");
+    SW_Site->site_ptf_type = encode_str2ptf(SW_Site->site_ptf_name);
+}
+
+
+// `memcpy()` does not work for copying an initialized `SW_ALL`
+// because it does not copy dynamically allocated memory to which
+// members of `SW_ALL` point to
+void setup_AllTest_for_tests(
+  SW_ALL *SW_All,
+  PATH_INFO *PathInfo,
+  LOG_INFO *LogInfo,
+  SW_OUTPUT_POINTERS *SW_OutputPtrs
+) {
+      Bool QuietMode = swFALSE;
+
+      // Initialize SOILWAT2 variables and read values from example input file
+      silent_tests(LogInfo);
+
+      PathInfo->InFiles[eFirst] = Str_Dup(DFLT_FIRSTFILE, LogInfo);
+
+      SW_CTL_setup_model(SW_All, SW_OutputPtrs, PathInfo, LogInfo);
+      SW_CTL_read_inputs_from_disk(SW_All, PathInfo, LogInfo);
+
+      /* Notes on messages during tests
+        - `SW_F_read()`, via SW_CTL_read_inputs_from_disk(), writes the file
+          "example/Output/logfile.log" to disk (based on content of "files.in")
+        - we close "Output/logfile.log"
+        - we set `logfp` to NULL to silence all non-error messages during tests
+        - error messages go directly to stderr (which DeathTests use to match against)
+      */
+      sw_check_log(QuietMode, LogInfo);
+      silent_tests(LogInfo);
+
+      SW_WTH_finalize_all_weather(
+        &SW_All->Markov,
+        &SW_All->Weather,
+        SW_All->Model.cum_monthdays,
+        SW_All->Model.days_in_month,
+        LogInfo
+      );
+
+      SW_CTL_init_run(SW_All, LogInfo);
 }

--- a/tests/gtests/sw_testhelpers.h
+++ b/tests/gtests/sw_testhelpers.h
@@ -24,6 +24,12 @@ static const double
 #define missing(x)  ( EQ( fabs( (x) ), SW_MISSING ) || !std::isfinite( (x) ) )
 
 
+/* Functions for tests */
+
+void create_test_soillayers(unsigned int nlayers,
+      SW_VEGPROD *SW_VegProd, SW_SITE *SW_Site, LOG_INFO *LogInfo);
+
+
 class AllTest : public::testing::Test {
   protected:
 
@@ -59,7 +65,7 @@ class AllTest : public::testing::Test {
 
       SW_WTH_finalize_all_weather(&SW_All.Markov, &SW_All.Weather,
             SW_All.Model.cum_monthdays, SW_All.Model.days_in_month, &LogInfo);
-      SW_CTL_init_run(&SW_All, &PathInfo, &LogInfo);
+      SW_CTL_init_run(&SW_All, &LogInfo);
     }
 
     void TearDown() override {
@@ -69,9 +75,5 @@ class AllTest : public::testing::Test {
 
 using AllDeathTest = AllTest;
 
-/* Functions for unit tests */
 
-void Reset_SOILWAT2_after_UnitTest(void);
 
-void create_test_soillayers(unsigned int nlayers, char *InFiles[],
-      SW_VEGPROD *SW_VegProd, SW_SITE *SW_Site, LOG_INFO *LogInfo);

--- a/tests/gtests/sw_testhelpers.h
+++ b/tests/gtests/sw_testhelpers.h
@@ -1,11 +1,9 @@
 #include <cmath>
 #include "gtest/gtest.h"
 #include "include/SW_datastructs.h"
+#include "include/SW_Defines.h"
 #include "include/SW_Control.h"
-#include "include/SW_Weather.h"
-#include "include/myMemory.h"
-#include "include/SW_Files.h"
-#include "include/SW_Main_lib.h"
+
 
 
 #define length(array) (sizeof(array) / sizeof(*(array))) //get length of an array
@@ -26,11 +24,30 @@ static const double
 
 /* Functions for tests */
 
+void silent_tests(LOG_INFO* LogInfo);
+
 void create_test_soillayers(unsigned int nlayers,
       SW_VEGPROD *SW_VegProd, SW_SITE *SW_Site, LOG_INFO *LogInfo);
 
+void setup_SW_Site_for_tests(SW_SITE *SW_Site);
 
-class AllTest : public::testing::Test {
+void setup_AllTest_for_tests(
+  SW_ALL *SW_All,
+  PATH_INFO *PathInfo,
+  LOG_INFO *LogInfo,
+  SW_OUTPUT_POINTERS *SW_OutputPtrs
+);
+
+
+/* AllTestFixture is our base test fixture class inheriting from `::testing::Test` */
+/* Note: don't use text fixtures with death tests in thread-safe mode,
+   use class `AllTestStruct` (inside the death assertion) instead (see below).
+   This is because each thread-safe death assertion is run from scratch and
+   any code inside the death test and before the `EXPECT_DEATH` assertion is
+   run twice (including setting up of a test fixture).
+   See https://google.github.io/googletest/reference/assertions.html#death
+*/
+class AllTestFixture : public ::testing::Test {
   protected:
 
     SW_ALL SW_All;
@@ -39,33 +56,7 @@ class AllTest : public::testing::Test {
     SW_OUTPUT_POINTERS SW_OutputPtrs;
 
     void SetUp() override {
-      // `memcpy()` does not work to copy from a global to local attributes
-      // since the function does not copy dynamically allocated memory
-
-      Bool QuietMode = swFALSE;
-
-      // Initialize SOILWAT2 variables and read values from example input file
-      LogInfo.logged = swFALSE;
-      LogInfo.logfp = NULL;
-
-      PathInfo.InFiles[eFirst] = Str_Dup(DFLT_FIRSTFILE, &LogInfo);
-
-      SW_CTL_setup_model(&SW_All, &SW_OutputPtrs, &PathInfo, &LogInfo);
-      SW_CTL_read_inputs_from_disk(&SW_All, &PathInfo, &LogInfo);
-
-      /* Notes on messages during tests
-        - `SW_F_read()`, via SW_CTL_read_inputs_from_disk(), writes the file
-          "example/Output/logfile.log" to disk (based on content of "files.in")
-        - we close "Output/logfile.log"
-        - we set `logfp` to NULL to silence all non-error messages during tests
-        - error messages go directly to stderr (which DeathTests use to match against)
-      */
-      sw_check_log(QuietMode, &LogInfo);
-      LogInfo.logfp = NULL;
-
-      SW_WTH_finalize_all_weather(&SW_All.Markov, &SW_All.Weather,
-            SW_All.Model.cum_monthdays, SW_All.Model.days_in_month, &LogInfo);
-      SW_CTL_init_run(&SW_All, &LogInfo);
+      setup_AllTest_for_tests(&SW_All, &PathInfo, &LogInfo, &SW_OutputPtrs);
     }
 
     void TearDown() override {
@@ -73,7 +64,56 @@ class AllTest : public::testing::Test {
     }
 };
 
-using AllDeathTest = AllTest;
+
+using CarbonFixtureTest = AllTestFixture;
+
+using SiteFixtureTest = AllTestFixture;
+
+using VegEstabFixtureTest = AllTestFixture;
+
+using VegProdFixtureTest = AllTestFixture;
+
+using WeatherFixtureTest = AllTestFixture;
+
+using WaterBalanceFixtureTest = AllTestFixture;
 
 
 
+/* AllTestStruct is like AllTestFixture but does not inherit from `::testing::Test` */
+
+/* Note: Use class `AllTestStruct` for thread-safe death tests inside the
+   assertion itself -- otherwise, multiple instances will be created
+   see https://google.github.io/googletest/reference/assertions.html#death
+
+   Example code that avoids the creation of multiple instances:
+   ```
+   TEST(SomeDeathTest, TestName) {
+       ...; // code here will be run twice
+
+       EXPECT_DEATH_IF_SUPPORTED({
+               // code inside `EXPECT_DEATH` is run once
+               AllTestStruct sw = AllTestStruct();
+               ...
+               function_that_should_fail(...);
+           },
+           "Expected failure message."
+       )
+   }
+   ```
+*/
+class AllTestStruct {
+  public:
+
+    SW_ALL SW_All;
+    PATH_INFO PathInfo;
+    LOG_INFO LogInfo;
+    SW_OUTPUT_POINTERS SW_OutputPtrs;
+
+    AllTestStruct() {
+      setup_AllTest_for_tests(&SW_All, &PathInfo, &LogInfo, &SW_OutputPtrs);
+    }
+
+    ~AllTestStruct() {
+      SW_CTL_clear_model(swTRUE, &SW_All, &PathInfo);
+    }
+};

--- a/tests/gtests/test_SW_Carbon.cc
+++ b/tests/gtests/test_SW_Carbon.cc
@@ -41,19 +41,20 @@
 
 namespace {
   // Test the SW_Carbon constructor 'SW_CBN_construct'
-  TEST_F(AllTest, CarbonConstructor) {
+  TEST(CarbonTest, CarbonConstructor) {
     int x;
+    SW_CARBON SW_Carbon;
 
-    SW_CBN_construct(&SW_All.Carbon);
+    SW_CBN_construct(&SW_Carbon); // does not allocate memory
 
     // Test type (and existence)
-    EXPECT_EQ(typeid(x), typeid(SW_All.Carbon.use_wue_mult));
-    EXPECT_EQ(typeid(x), typeid(SW_All.Carbon.use_bio_mult));
+    EXPECT_EQ(typeid(x), typeid(SW_Carbon.use_wue_mult));
+    EXPECT_EQ(typeid(x), typeid(SW_Carbon.use_bio_mult));
   }
 
 
   // Test reading yearly CO2 data from disk file
-  TEST_F(AllTest, ReadCarbonInputFile) {
+  TEST_F(CarbonFixtureTest, CarbonReadInputFile) {
     TimeInt year, simendyr = SW_All.Model.endyr + SW_All.Model.addtl_yr;
     double sum_CO2;
 
@@ -86,7 +87,7 @@ namespace {
 
 
   // Test the calculation of CO2-effect multipliers
-  TEST_F(AllTest, CarbonCO2multipliers) {
+  TEST_F(CarbonFixtureTest, CarbonCO2multipliers) {
     TimeInt year, simendyr = SW_All.Model.endyr + SW_All.Model.addtl_yr;
     int k;
 

--- a/tests/gtests/test_SW_Defines.cc
+++ b/tests/gtests/test_SW_Defines.cc
@@ -23,7 +23,7 @@
 
 namespace {
 
-  TEST_F(AllTest, SWDefinesMissingValues) {
+  TEST(SWDefines, SWDefinesMissingValues) {
     // SOILWAT2 missing value
     EXPECT_TRUE(missing(SW_MISSING));
 

--- a/tests/gtests/test_SW_Flow_Lib.cc
+++ b/tests/gtests/test_SW_Flow_Lib.cc
@@ -49,8 +49,14 @@ namespace
 {
 
   // Test the veg interception function 'veg_intercepted_water'
-  TEST_F(AllTest, SWFlowVegInterceptedWater)
+  TEST(SWFlowTest, SWFlowVegInterceptedWater)
   {
+    VegType veg[NVEGTYPES];
+    short k;
+
+    ForEachVegType(k) {
+      veg[k].veg_kSmax = 2.;
+    }
 
     ForEachVegType(k)
     {
@@ -61,8 +67,9 @@ namespace
       // Test expectation when there is no leaf-area
       bLAI = 0.0, ppt = 5.0, pptleft = ppt, store = 0.0;
 
-      veg_intercepted_water(&pptleft, &wintveg, &store,
-        m, SW_All.VegProd.veg[k].veg_kSmax, bLAI, scale);
+      veg_intercepted_water(
+        &pptleft, &wintveg, &store, m, veg[k].veg_kSmax, bLAI, scale
+      );
 
       EXPECT_EQ(0, wintveg); // When there is no veg, interception should be 0
       EXPECT_EQ(0, store); // When there is no veg, stored interception should be 0
@@ -72,8 +79,9 @@ namespace
       // Test expectations when there is no rain, but there is leaf-area
       bLAI = 1.5, ppt = 0.0, pptleft = ppt, store = 0.0;
 
-      veg_intercepted_water(&pptleft, &wintveg, &store,
-        m, SW_All.VegProd.veg[k].veg_kSmax, bLAI, scale);
+      veg_intercepted_water(
+        &pptleft, &wintveg, &store, m, veg[k].veg_kSmax, bLAI, scale
+      );
 
       EXPECT_EQ(0, wintveg);  // When there is no ppt, interception should be 0
       EXPECT_EQ(0, store);  // When there is no ppt, stored interception should be 0
@@ -83,8 +91,9 @@ namespace
       // Test expectations when there is both veg cover and precipitation
       bLAI = 1.5, ppt = 5.0, pptleft = ppt, store = 0.0;
 
-      veg_intercepted_water(&pptleft, &wintveg, &store,
-        m, SW_All.VegProd.veg[k].veg_kSmax, bLAI, scale);
+      veg_intercepted_water(
+        &pptleft, &wintveg, &store, m, veg[k].veg_kSmax, bLAI, scale
+      );
 
       EXPECT_GT(wintveg, 0); // interception by veg should be greater than 0
       EXPECT_LE(wintveg, ppt); // interception by veg should be less than or equal to ppt
@@ -94,8 +103,14 @@ namespace
   }
 
   // Test the litter interception function 'litter_intercepted_water'
-  TEST_F(AllTest, SWFlowLitterInterceptedWater)
+  TEST(SWFlowTest, SWFlowLitterInterceptedWater)
   {
+    VegType veg[NVEGTYPES];
+    short k;
+
+    ForEachVegType(k) {
+      veg[k].lit_kSmax = 2.;
+    }
 
     ForEachVegType(k)
     {
@@ -106,8 +121,9 @@ namespace
       // Test expectation when there is no litter
       blitter = 0.0, ppt = 5.0, pptleft = ppt, wintlit = 0.0, store = 0.0;
 
-      litter_intercepted_water(&pptleft, &wintlit, &store,
-        m, SW_All.VegProd.veg[k].lit_kSmax, blitter, scale);
+      litter_intercepted_water(
+        &pptleft, &wintlit, &store, m, veg[k].lit_kSmax, blitter, scale
+      );
 
       EXPECT_EQ(0, wintlit); // When litter is 0, interception should be 0
       EXPECT_EQ(0, store); // When litter is 0, stored interception should be 0
@@ -121,8 +137,9 @@ namespace
       // Test expectations when there is no throughfall
       blitter = 200.0, ppt = 0.0, pptleft = ppt, wintlit = 0.0, store = 0.0;
 
-      litter_intercepted_water(&pptleft, &wintlit, &store,
-        m, SW_All.VegProd.veg[k].lit_kSmax, blitter, scale);
+      litter_intercepted_water(
+        &pptleft, &wintlit, &store, m, veg[k].lit_kSmax, blitter, scale
+      );
 
       EXPECT_EQ(0, pptleft); // When there is no ppt, pptleft should be 0
       EXPECT_EQ(0, wintlit); // When there is no ppt, interception should be 0
@@ -133,8 +150,9 @@ namespace
       // Test expectations when pptleft, scale, and blitter are greater than 0
       blitter = 200.0, ppt = 5.0, pptleft = ppt, wintlit = 0.0, store = 0.0;
 
-      litter_intercepted_water(&pptleft, &wintlit, &store,
-        m, SW_All.VegProd.veg[k].lit_kSmax, blitter, scale);
+      litter_intercepted_water(
+        &pptleft, &wintlit, &store, m, veg[k].lit_kSmax, blitter, scale
+      );
 
       EXPECT_GT(wintlit, 0); // interception by litter should be greater than 0
       EXPECT_LE(wintlit, pptleft); // interception by lit should be less than or equal to ppt
@@ -144,8 +162,9 @@ namespace
   }
 
   // Test infiltration under high water function, 'infiltrate_water_high'
-  TEST_F(AllTest, SWFlowSaturatedPercolation)
+  TEST(SWFlowTest, SWFlowSaturatedPercolation)
   {
+    RealD lyrFrozen[MAX_LAYERS] = {0};
 
     // declare inputs
     double pptleft = 5.0, standingWater, drainout;
@@ -156,8 +175,10 @@ namespace
     double swc[1] = {0.8}, swcfc[1] = {1.1}, swcsat[1] = {1.6},
       impermeability[1] = {0.}, drain[1] = {0.};
 
-    infiltrate_water_high(swc, drain, &drainout, pptleft, nlyrs, swcfc, swcsat,
-      impermeability, &standingWater, SW_All.SoilWat.lyrFrozen);
+    infiltrate_water_high(
+      swc, drain, &drainout, pptleft, nlyrs, swcfc, swcsat, impermeability,
+      &standingWater, lyrFrozen
+    );
 
     EXPECT_GE(drain[0], 0); // drainage should be greater than or equal to 0 when soil layers are 1 and ppt > 1
     EXPECT_LE(swc[0], swcsat[0]); // swc should be less than or equal to swcsat
@@ -167,8 +188,10 @@ namespace
     pptleft = 0.0, standingWater = 0.0, drain[0] = 0., swc[0] = 0.8,
     swcfc[0] = 1.1, swcsat[0] = 1.6;
 
-    infiltrate_water_high(swc, drain, &drainout, pptleft, nlyrs, swcfc, swcsat,
-      impermeability, &standingWater, SW_All.SoilWat.lyrFrozen);
+    infiltrate_water_high(
+      swc, drain, &drainout, pptleft, nlyrs, swcfc, swcsat, impermeability,
+      &standingWater, lyrFrozen
+    );
 
     EXPECT_DOUBLE_EQ(0, drain[0]); // drainage should be 0
 
@@ -178,8 +201,10 @@ namespace
     impermeability[0] = 1.;
     swc[0] = 0.8, drain[0] = 0.;
 
-    infiltrate_water_high(swc, drain, &drainout, pptleft, nlyrs, swcfc, swcsat,
-      impermeability, &standingWater, SW_All.SoilWat.lyrFrozen);
+    infiltrate_water_high(
+      swc, drain, &drainout, pptleft, nlyrs, swcfc, swcsat, impermeability,
+      &standingWater, lyrFrozen
+    );
 
     EXPECT_DOUBLE_EQ(0., drain[0]); //When impermeability is 1, drainage should be 0
     EXPECT_DOUBLE_EQ(standingWater, (pptleft + 0.8) - swcsat[0]); /* When impermeability is 1,
@@ -206,8 +231,10 @@ namespace
       impermeability2[i] = 0.0;
     }
 
-    infiltrate_water_high(swc2, drain2, &drainout, pptleft, nlyrs, swcfc2,
-      swcsat2, impermeability2, &standingWater, SW_All.SoilWat.lyrFrozen);
+    infiltrate_water_high(
+      swc2, drain2, &drainout, pptleft, nlyrs, swcfc2, swcsat2, impermeability2,
+      &standingWater, lyrFrozen
+    );
 
     EXPECT_EQ(drainout, drain2[MAX_LAYERS - 1]); /* drainout and drain should be
       equal in the last layer */
@@ -234,8 +261,10 @@ namespace
       drain3[i] = 0.;// swcsat will always be greater than swcfc in each layer
     }
 
-    infiltrate_water_high(swc3, drain3, &drainout, pptleft, nlyrs, swcfc3,
-      swcsat3, impermeability2, &standingWater, SW_All.SoilWat.lyrFrozen);
+    infiltrate_water_high(
+      swc3, drain3, &drainout, pptleft, nlyrs, swcfc3, swcsat3, impermeability2,
+      &standingWater, lyrFrozen
+    );
 
     for (i = 0; i < MAX_LAYERS; i++)
     {
@@ -261,8 +290,10 @@ namespace
 
     swc4[0] = 0.8; // Need to hard code this value because swc4 is altered by function
 
-    infiltrate_water_high(swc4, drain4, &drainout, pptleft, nlyrs, swcfc4,
-      swcsat4, impermeability4, &standingWater, SW_All.SoilWat.lyrFrozen);
+    infiltrate_water_high(
+      swc4, drain4, &drainout, pptleft, nlyrs, swcfc4, swcsat4, impermeability4,
+      &standingWater, lyrFrozen
+    );
 
     EXPECT_DOUBLE_EQ(standingWater, (pptleft + 0.8) - swcsat4[0]); /* When impermeability is 1,
       standingWater should be equivalent to  pptLeft + swc[0] - swcsat[0]) */
@@ -289,8 +320,10 @@ namespace
       drain5[i] = 0.0;
     }
 
-    infiltrate_water_high(swc5, drain5, &drainout, pptleft, nlyrs, swcfc5,
-      swcsat5, impermeability5, &standingWater, SW_All.SoilWat.lyrFrozen);
+    infiltrate_water_high(
+      swc5, drain5, &drainout, pptleft, nlyrs, swcfc5, swcsat5, impermeability5,
+      &standingWater, lyrFrozen
+    );
 
     for (i = 0; i < MAX_LAYERS; i++)
     {
@@ -313,9 +346,23 @@ namespace
 
 
   //Test transp_weighted_avg function.
-  TEST_F(AllTest, SWFlowTranspWeightedAvg)
+  TEST(SWFlowTest, SWFlowTranspWeightedAvg)
   {
-    //--- TEST_F when n_layers is 1 ------
+    unsigned int k;
+
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
+
+    SW_SITE SW_Site;
+    setup_SW_Site_for_tests(&SW_Site);
+
+    SW_VEGPROD SW_VegProd;
+    ForEachVegType(k) {
+      SW_VegProd.veg[k].SWPcrit = 20;
+    }
+
+
+    //--- Test when n_layers is 1 ------
     //INPUTS
     double swp_avg = 10;
     unsigned int i;
@@ -327,24 +374,22 @@ namespace
     double swp_avgExpected1 = 1.5992088;
 
     // Setup soil layers
-    create_test_soillayers(n_layers, &SW_All.VegProd, &SW_All.Site, &LogInfo);
+    create_test_soillayers(n_layers, &SW_VegProd, &SW_Site, &LogInfo);
 
     ForEachSoilLayer(i, n_layers)
     {
-
       // example: swc as mean of wilting point and field capacity
-      swc[i] = (SW_All.Site.swcBulk_fieldcap[i] +
-                          SW_All.Site.swcBulk_wiltpt[i]) / 2.;
+      swc[i] = (SW_Site.swcBulk_fieldcap[i] + SW_Site.swcBulk_wiltpt[i]) / 2.;
     }
 
-    //Begin TEST_F when n_layers is one
-    transp_weighted_avg(&swp_avg, &SW_All.Site, n_tr_rgns, n_layers,
+    //Begin Test when n_layers is one
+    transp_weighted_avg(&swp_avg, &SW_Site, n_tr_rgns, n_layers,
                         tr_regions, swc, SW_SHRUB, &LogInfo);
 
     EXPECT_GE(swp_avg, 0); //Must always be non negative.
     EXPECT_NEAR(swp_avg, swp_avgExpected1, tol6);
 
-    //--- TEST_F when n_layers is at "max" ------
+    //--- Test when n_layers is at "max" ------
     //INPUTS
     swp_avg = 10, n_tr_rgns = 4, n_layers = 25;
     unsigned int tr_regions2[25] = {1,1,1,2,2,3,3,3,4,4,4,4,4,4,4,4,4,4,4,4,
@@ -355,18 +400,16 @@ namespace
     double swp_avgExpectedM = 1.7389131503001496;
 
     // Setup soil layers
-    create_test_soillayers(n_layers, &SW_All.VegProd, &SW_All.Site, &LogInfo);
+    create_test_soillayers(n_layers, &SW_VegProd, &SW_Site, &LogInfo);
 
     ForEachSoilLayer(i, n_layers)
     {
-
       // example: swc as mean of wilting point and field capacity
-      swc2[i] = (SW_All.Site.swcBulk_fieldcap[i] +
-                                      SW_All.Site.swcBulk_wiltpt[i]) / 2.;
+      swc2[i] = (SW_Site.swcBulk_fieldcap[i] + SW_Site.swcBulk_wiltpt[i]) / 2.;
     }
 
 
-    transp_weighted_avg(&swp_avg, &SW_All.Site, n_tr_rgns, n_layers,
+    transp_weighted_avg(&swp_avg, &SW_Site, n_tr_rgns, n_layers,
                         tr_regions2, swc2, SW_SHRUB, &LogInfo);
 
     EXPECT_GE(swp_avg, 0); //Must always be non negative.
@@ -376,12 +419,12 @@ namespace
 
 
   //Test EsT_partitioning by manipulating fbse and fbst variables.
-  TEST_F(AllTest, SWFlowEsTPartitioning)
+  TEST(SWFlowTest, SWFlowEsTPartitioning)
   {
     //INPUTS
     double fbse = 0, fbst = 0, blivelai = 0.002, lai_param = 2;
 
-    //TEST_F when fbse > bsemax
+    //Test when fbse > bsemax
     double fbseExpected = 0.995, fbstExpected = 0.005;
     EsT_partitioning(&fbse, &fbst, blivelai, lai_param);
 
@@ -393,7 +436,7 @@ namespace
     EXPECT_LT(fbst, 1); //fbse and fbst must be between zero and one
     EXPECT_DOUBLE_EQ(fbst + fbse, 1); //Must add up to one.
 
-    //TEST_F when fbse < bsemax
+    //Test when fbse < bsemax
     blivelai = 0.0012, lai_param = 5, fbseExpected = 0.994018,
       fbstExpected = 0.005982036;
     EsT_partitioning(&fbse, &fbst, blivelai, lai_param);
@@ -408,10 +451,25 @@ namespace
     EXPECT_DOUBLE_EQ(fbst + fbse, 1);  //Must add up to one.
   }
 
+
   // TEST pot_soil_evap
-  TEST_F(AllTest, SWFlowPotentialSoilEvaporation)
+  TEST(SWFlowTest, SWFlowPotentialSoilEvaporation)
   {
-    unsigned int i, k, nelyrs;
+    unsigned int k;
+
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
+
+    SW_SITE SW_Site;
+    setup_SW_Site_for_tests(&SW_Site);
+
+    SW_VEGPROD SW_VegProd;
+    ForEachVegType(k) {
+      SW_VegProd.veg[k].SWPcrit = 20;
+    }
+
+
+    unsigned int i, nelyrs;
     double bserate = 0, totagb, Es_param_limit = 999.,
       fbse = 0.813, fbse0 = 0., petday = 0.1, petday0 = 0.,
       shift = 45, shape = 0.1, inflec = 0.25, range = 0.5;
@@ -431,19 +489,17 @@ namespace
       }
 
       // Setup soil layers
-      create_test_soillayers(nelyrs, &SW_All.VegProd, &SW_All.Site, &LogInfo);
+      create_test_soillayers(nelyrs, &SW_VegProd, &SW_Site, &LogInfo);
 
-      ForEachSoilLayer(i, SW_All.Site.n_layers)
+      ForEachSoilLayer(i, SW_Site.n_layers)
       {
-
         // example: swc as mean of wilting point and field capacity
-        swc[i] = (SW_All.Site.swcBulk_fieldcap[i] +
-                                    SW_All.Site.swcBulk_wiltpt[i]) / 2.;
+        swc[i] = (SW_Site.swcBulk_fieldcap[i] + SW_Site.swcBulk_wiltpt[i]) / 2.;
       }
 
-      // Begin TEST_F if (totagb >= Es_param_limit)
+      // Begin Test if (totagb >= Es_param_limit)
       totagb = Es_param_limit + 1.;
-      pot_soil_evap(&SW_All.Site, nelyrs, totagb, fbse,
+      pot_soil_evap(&SW_Site, nelyrs, totagb, fbse,
         petday, shift, shape, inflec, range, swc, Es_param_limit,
         &bserate, &LogInfo);
 
@@ -455,8 +511,8 @@ namespace
       // Begin TESTs if (totagb < Es_param_limit)
       totagb = Es_param_limit / 2;
 
-      // Begin TEST_F if (PET = 0)
-      pot_soil_evap(&SW_All.Site, nelyrs, totagb, fbse, petday0, shift,
+      // Begin Test if (PET = 0)
+      pot_soil_evap(&SW_Site, nelyrs, totagb, fbse, petday0, shift,
         shape, inflec, range, swc, Es_param_limit, &bserate, &LogInfo);
 
       // expect baresoil evaporation rate = 0 if PET = 0
@@ -464,8 +520,8 @@ namespace
         "pot_soil_evap != 0 if PET = 0 for " << nelyrs << " soil layers";
 
 
-      // Begin TEST_F if (potential baresoil rate = 0)
-      pot_soil_evap(&SW_All.Site, nelyrs, totagb, fbse0, petday, shift,
+      // Begin Test if (potential baresoil rate = 0)
+      pot_soil_evap(&SW_Site, nelyrs, totagb, fbse0, petday, shift,
         shape, inflec, range, swc, Es_param_limit, &bserate, &LogInfo);
 
       // expect baresoil evaporation rate = 0 if fbse = 0
@@ -473,8 +529,8 @@ namespace
         "pot_soil_evap != 0 if fbse = 0 for " << nelyrs << " soil layers";
 
 
-      // Begin TEST_F if (totagb < Es_param_limit)
-      pot_soil_evap(&SW_All.Site, nelyrs, totagb, fbse, petday, shift,
+      // Begin Test if (totagb < Es_param_limit)
+      pot_soil_evap(&SW_Site, nelyrs, totagb, fbse, petday, shift,
         shape, inflec, range, swc, Es_param_limit, &bserate, &LogInfo);
 
       // expect baresoil evaporation rate > 0
@@ -493,9 +549,22 @@ namespace
   }
 
 
-  //TEST_F pot_soil_evap_bs for when nelyrs = 1 and nelyrs = MAX
-  TEST_F(AllTest, SWFlowPotentialSoilEvaporation2)
+  //Test pot_soil_evap_bs for when nelyrs = 1 and nelyrs = MAX
+  TEST(SWFlowTest, SWFlowPotentialSoilEvaporation2)
   {
+    unsigned int k;
+
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
+
+    SW_SITE SW_Site;
+    setup_SW_Site_for_tests(&SW_Site);
+
+    SW_VEGPROD SW_VegProd;
+    ForEachVegType(k) {
+      SW_VegProd.veg[k].SWPcrit = 20;
+    }
+
     //INPUTS
     unsigned int nelyrs,i;
     double bserate = 0, petday = 0.1, shift = 45, shape = 0.1, inflec = 0.25,
@@ -515,17 +584,16 @@ namespace
       }
 
       // Setup soil layers
-      create_test_soillayers(nelyrs, &SW_All.VegProd, &SW_All.Site, &LogInfo);
+      create_test_soillayers(nelyrs, &SW_VegProd, &SW_Site, &LogInfo);
 
-      ForEachSoilLayer(i, SW_All.Site.n_layers)
+      ForEachSoilLayer(i, SW_Site.n_layers)
       {
         // example: swc as mean of wilting point and field capacity
-        swc[i] = (SW_All.Site.swcBulk_fieldcap[i] +
-                                      SW_All.Site.swcBulk_wiltpt[i]) / 2.;
+        swc[i] = (SW_Site.swcBulk_fieldcap[i] + SW_Site.swcBulk_wiltpt[i]) / 2.;
       }
 
-      //Begin TEST_F for bserate when nelyrs = 1
-      pot_soil_evap_bs(&bserate, &SW_All.Site, nelyrs, petday, shift, shape,
+      //Begin Test for bserate when nelyrs = 1
+      pot_soil_evap_bs(&bserate, &SW_Site, nelyrs, petday, shift, shape,
                        inflec, range, swc, &LogInfo);
       if (nelyrs == 1)
       {
@@ -542,7 +610,7 @@ namespace
 
 
   //Test pot_transp by manipulating biolive and biodead input variables
-  TEST_F(AllTest, SWFlowPotentialTranspiration)
+  TEST(SWFlowTest, SWFlowPotentialTranspiration)
   {
     //INPUTS
     double bstrate = 0, swpavg = 0.8, biolive = -0.8, biodead = 0.2, fbst = 0.8, petday = 0.1,
@@ -550,7 +618,7 @@ namespace
         shade_deadmax = 0.9, shade_xinflex = 0.4, shade_slope = 0.9, shade_yinflex = 0.3,
           shade_range = 0.8, co2_wue_multiplier = 2.1;
 
-    //Begin TEST_F for if biolive < 0
+    //Begin Test for if biolive < 0
     pot_transp(&bstrate, swpavg, biolive, biodead, fbst, petday, swp_shift, swp_shape,
       swp_inflec, swp_range, shade_scale, shade_deadmax, shade_xinflex, shade_slope,
         shade_yinflex, shade_range, co2_wue_multiplier);
@@ -560,7 +628,7 @@ namespace
 
     EXPECT_DOUBLE_EQ(bstrate, 0); //bstrate = 0 if biolove < 0
 
-    //Begin TEST_F for if biolive > 0
+    //Begin Test for if biolive > 0
     biolive = 0.8;
     pot_transp(&bstrate, swpavg, biolive, biodead, fbst, petday, swp_shift, swp_shape,
       swp_inflec, swp_range, shade_scale, shade_deadmax, shade_xinflex, shade_slope,
@@ -569,7 +637,7 @@ namespace
     EXPECT_NEAR(bstrate, bstrateExpected, tol6); //For this test local variable shadeaf = 1, affecting bstrate
                                    //bstrate is expected to be 0.06596299
 
-    //Begin TEST_F for if biodead > shade_deadmax
+    //Begin Test for if biodead > shade_deadmax
     biodead = 0.95, bstrateExpected = 0.0659629;
     pot_transp(&bstrate, swpavg, biolive, biodead, fbst, petday, swp_shift, swp_shape,
       swp_inflec, swp_range, shade_scale, shade_deadmax, shade_xinflex, shade_slope,
@@ -577,7 +645,7 @@ namespace
 
     EXPECT_NEAR(bstrate, bstrateExpected, tol6); //bstrate is expected to be 0.06564905
 
-    //Begin TEST_F for if biodead < shade_deadmax
+    //Begin Test for if biodead < shade_deadmax
     biodead = 0.2, bstrateExpected = 0.0659629;
     pot_transp(&bstrate, swpavg, biolive, biodead, fbst, petday, swp_shift, swp_shape,
       swp_inflec, swp_range, shade_scale, shade_deadmax, shade_xinflex, shade_slope,
@@ -588,12 +656,12 @@ namespace
   }
 
   //Test result for watrate by manipulating variable petday
-  TEST_F(AllTest, SWFlowWatrate)
+  TEST(SWFlowTest, SWFlowWatrate)
   {
     //INPUTS
     double swp = 0.8, petday = 0.1, shift = 45, shape = 0.1, inflec = 0.25, range = 0.8;
 
-    //Begin TEST_F for if petday < .2
+    //Begin Test for if petday < .2
     double watExpected = 0.630365;
     double wat = watrate(swp, petday, shift, shape, inflec, range);
 
@@ -601,7 +669,7 @@ namespace
     EXPECT_LE(wat, 1); //watrate must be between 0 & 1
     EXPECT_GE(wat, 0); //watrate must be between 0 & 1
 
-    //Begin TEST_F for if 0.2 < petday < .4
+    //Begin Test for if 0.2 < petday < .4
     petday = 0.3, watExpected = 0.6298786;
     wat = watrate(swp, petday, shift, shape, inflec, range);
 
@@ -609,7 +677,7 @@ namespace
     EXPECT_LE(wat, 1); //watrate must be between 0 & 1
     EXPECT_GE(wat, 0); //watrate must be between 0 & 1
 
-    //Begin TEST_F for if 0.4 < petday < .6
+    //Begin Test for if 0.4 < petday < .6
     petday = 0.5, watExpected = 0.6285504;
     wat = watrate(swp, petday, shift, shape, inflec, range);
 
@@ -617,7 +685,7 @@ namespace
     EXPECT_LE(wat, 1); //watrate must be between 0 & 1
     EXPECT_GE(wat, 0); //watrate must be between 0 & 1
 
-    //Begin TEST_F for if 0.6 < petday < 1
+    //Begin Test for if 0.6 < petday < 1
     petday = 0.8, watExpected = 0.627666;
     wat = watrate(swp, petday, shift, shape, inflec, range);
 
@@ -627,12 +695,12 @@ namespace
   }
 
   //Test evap_fromSurface by manipulating water_pool and evap_rate variables
-  TEST_F(AllTest, SWFlowSurfaceEvaporation)
+  TEST(SWFlowTest, SWFlowSurfaceEvaporation)
   {
     //INPUTS
     double water_pool = 1, evap_rate = 0.33, aet = 0.53;
 
-    //Begin TEST_F for when water_pool > evap_rate
+    //Begin Test for when water_pool > evap_rate
     double aetExpected = 0.86, evapExpected = 0.33, waterExpected = 0.67;
     evap_fromSurface(&water_pool, &evap_rate, &aet);
 
@@ -645,7 +713,7 @@ namespace
     EXPECT_NEAR(water_pool, waterExpected, tol6); //Variable water_pool is expected to be 0.67 with current inputs
     EXPECT_GE(water_pool, 0); //water_pool is never negative
 
-    //Begin TEST_F for when water_pool < evap_rate
+    //Begin Test for when water_pool < evap_rate
     water_pool = 0.1, evap_rate = 0.67, aet = 0.78, aetExpected = 0.88, evapExpected = 0.1;
     evap_fromSurface(&water_pool, &evap_rate, &aet);
 
@@ -660,8 +728,22 @@ namespace
   }
 
   //Test remove_from_soil when nlyrs = 1 and when nlyrs = MAX
-  TEST_F(AllTest, SWFlowRemoveFromSoil)
+  TEST(SWFlowTest, SWFlowRemoveFromSoil)
   {
+    unsigned int k;
+
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
+
+    SW_SITE SW_Site;
+    setup_SW_Site_for_tests(&SW_Site);
+
+    SW_VEGPROD SW_VegProd;
+    ForEachVegType(k) {
+      SW_VegProd.veg[k].SWPcrit = 20;
+    }
+
+
     // INPUTS
     unsigned int nlyrs, i;
     double aet_init = 0.33, aet, rate = 0.62;
@@ -669,6 +751,8 @@ namespace
     double swcmin[MAX_LAYERS] = {0.};
     double qty[MAX_LAYERS] = {0.}, qty_sum = 0.;
     double coeff[MAX_LAYERS], coeffZero[MAX_LAYERS] = {0.};
+
+    RealD lyrFrozen[MAX_LAYERS] = {0};
 
 
     // Loop over tests with varying number of soil layers
@@ -684,17 +768,17 @@ namespace
       }
 
       // Setup: soil layers
-      create_test_soillayers(nlyrs, &SW_All.VegProd, &SW_All.Site, &LogInfo);
+      create_test_soillayers(nlyrs, &SW_VegProd, &SW_Site, &LogInfo);
 
       ForEachSoilLayer(i, nlyrs)
       {
         // Setup: initial swc to some example value, here SWC at 20% VWC
-        swc_init[i] = 0.2 * SW_All.Site.width[i];
+        swc_init[i] = 0.2 * SW_Site.width[i];
         // Setup: water extraction coefficient, some example value, here 0.5
         coeff[i] = 0.5;
       }
 
-      //------ 1) TEST_F: if coeff[i] == 0, then expectation: no water extracted
+      //------ 1) Test: if coeff[i] == 0, then expectation: no water extracted
       // Re-set inputs
       aet = aet_init;
       ForEachSoilLayer(i, nlyrs)
@@ -704,8 +788,8 @@ namespace
       }
 
       // Call function to test: use coeffZero instead of coeff
-      remove_from_soil(swc, qty, &SW_All.Site, &aet, nlyrs, coeffZero,
-          rate, swcmin, SW_All.SoilWat.lyrFrozen, &LogInfo);
+      remove_from_soil(swc, qty, &SW_Site, &aet, nlyrs, coeffZero,
+          rate, swcmin, lyrFrozen, &LogInfo);
 
       // Check expectation of no change from original values
       qty_sum = 0.;
@@ -726,19 +810,19 @@ namespace
           "remove_from_soil: sum(qty) != 0 for " << nlyrs << " soil layers";
 
 
-      //------ 2) TEST_F: if frozen[i], then expectation: no water extracted
+      //------ 2) Test: if frozen[i], then expectation: no water extracted
       // Re-set inputs and set soil layers as frozen
       aet = aet_init;
       ForEachSoilLayer(i, nlyrs)
       {
-        SW_All.SoilWat.lyrFrozen[i] = swTRUE;
+        lyrFrozen[i] = swTRUE;
         qty[i] = 0.;
         swc[i] = swc_init[i];
       }
 
       // Call function to test
-      remove_from_soil(swc, qty, &SW_All.Site, &aet, nlyrs, coeff,
-          rate, swcmin, SW_All.SoilWat.lyrFrozen, &LogInfo);
+      remove_from_soil(swc, qty, &SW_Site, &aet, nlyrs, coeff,
+          rate, swcmin, lyrFrozen, &LogInfo);
 
       // Check expectation of no change from original values
       qty_sum = 0.;
@@ -759,19 +843,19 @@ namespace
           "remove_from_soil: sum(qty) != 0 for " << nlyrs << " soil layers";
 
 
-      //------ 3) TEST_F: if coeff[i] > 0 && !frozen[i], then water is extracted
+      //------ 3) Test: if coeff[i] > 0 && !frozen[i], then water is extracted
       // Re-set inputs
       aet = aet_init;
       ForEachSoilLayer(i, nlyrs)
       {
-        SW_All.SoilWat.lyrFrozen[i] = swFALSE;
+        lyrFrozen[i] = swFALSE;
         qty[i] = 0.;
         swc[i] = swc_init[i];
       }
 
       // Call function to test
-      remove_from_soil(swc, qty, &SW_All.Site, &aet, nlyrs, coeff,
-          rate, swcmin, SW_All.SoilWat.lyrFrozen, &LogInfo);
+      remove_from_soil(swc, qty, &SW_Site, &aet, nlyrs, coeff,
+          rate, swcmin, lyrFrozen, &LogInfo);
 
       // Check values of qty[] and swc[]
       qty_sum = 0.;
@@ -823,14 +907,30 @@ namespace
 
 
   //Test when nlyrs = 1 and 25 for outputs; swc, drain, drainout, standing water
-  TEST_F(AllTest, SWFlowPercolateUnsaturated)
+  TEST(SWFlowTest, SWFlowPercolateUnsaturated)
   {
+    unsigned int k;
+
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
+
+    SW_SITE SW_Site;
+    setup_SW_Site_for_tests(&SW_Site);
+
+    SW_VEGPROD SW_VegProd;
+    ForEachVegType(k) {
+      SW_VegProd.veg[k].SWPcrit = 20;
+    }
+
+
     //INPUTS
-    unsigned int nlyrs, i, k;
+    unsigned int nlyrs, i;
     double
       sum_delta_swc, small, drainout, standingWater;
     double swc[MAX_LAYERS];
     double drain[MAX_LAYERS];
+
+    RealD lyrFrozen[MAX_LAYERS] = {0};
 
 
     // Loop over tests with varying number of soil layers
@@ -846,18 +946,18 @@ namespace
       }
 
       // Setup soil layers
-      create_test_soillayers(nlyrs, &SW_All.VegProd, &SW_All.Site, &LogInfo);
+      create_test_soillayers(nlyrs, &SW_VegProd, &SW_Site, &LogInfo);
 
       // Initialize soil arrays to be independent of soil texture...
       ForEachSoilLayer(i, nlyrs)
       {
-        SW_All.Site.swcBulk_fieldcap[i] = 0.25 * SW_All.Site.width[i];
-        SW_All.Site.swcBulk_min[i] = 0.05 * SW_All.Site.width[i];
-        SW_All.Site.swcBulk_saturated[i] = 0.35 * SW_All.Site.width[i];
+        SW_Site.swcBulk_fieldcap[i] = 0.25 * SW_Site.width[i];
+        SW_Site.swcBulk_min[i] = 0.05 * SW_Site.width[i];
+        SW_Site.swcBulk_saturated[i] = 0.35 * SW_Site.width[i];
       }
 
 
-      //--- (1) TEST_F:
+      //--- (1) Test:
       //        if swc[i] <= swcmin[i],
       //        then expect drain = 0
 
@@ -867,16 +967,16 @@ namespace
 
       ForEachSoilLayer(i, nlyrs)
       {
-        SW_All.Site.swcBulk_init[i] = 0.5 * SW_All.Site.swcBulk_min[i];
-        swc[i] = SW_All.Site.swcBulk_init[i];
+        SW_Site.swcBulk_init[i] = 0.5 * SW_Site.swcBulk_min[i];
+        swc[i] = SW_Site.swcBulk_init[i];
         drain[i] = 0.;
       }
 
       // Call function to test
       percolate_unsaturated(
         swc, drain, &drainout, &standingWater,
-        nlyrs, SW_All.SoilWat.lyrFrozen, &SW_All.Site,
-        SW_All.Site.slow_drain_coeff, SLOW_DRAIN_DEPTH
+        nlyrs, lyrFrozen, &SW_Site,
+        SW_Site.slow_drain_coeff, SLOW_DRAIN_DEPTH
       );
 
       // Expectation: drainout = 0
@@ -890,12 +990,12 @@ namespace
       {
         EXPECT_NEAR(drain[i], 0., tol6) <<
           "percolate_unsaturated: drain != 0 for layer " << 1 + i;
-        EXPECT_NEAR(swc[i], SW_All.Site.swcBulk_init[i], tol6) <<
+        EXPECT_NEAR(swc[i], SW_Site.swcBulk_init[i], tol6) <<
           "percolate_unsaturated: swc != swc_init for layer " << 1 + i;
       }
 
 
-      //--- (2) TEST_F:
+      //--- (2) Test:
       //        if swc_fc > swc[i] > swcmin[i],
       //        then expect drain > 0
 
@@ -905,16 +1005,16 @@ namespace
 
       ForEachSoilLayer(i, nlyrs)
       {
-        SW_All.Site.swcBulk_init[i] = 0.9 * SW_All.Site.swcBulk_fieldcap[i];
-        swc[i] = SW_All.Site.swcBulk_init[i];
+        SW_Site.swcBulk_init[i] = 0.9 * SW_Site.swcBulk_fieldcap[i];
+        swc[i] = SW_Site.swcBulk_init[i];
         drain[i] = 0.;
       }
 
       // Call function to test
       percolate_unsaturated(
         swc, drain, &drainout, &standingWater,
-        nlyrs, SW_All.SoilWat.lyrFrozen, &SW_All.Site,
-        SW_All.Site.slow_drain_coeff, SLOW_DRAIN_DEPTH
+        nlyrs, lyrFrozen, &SW_Site,
+        SW_Site.slow_drain_coeff, SLOW_DRAIN_DEPTH
       );
 
       // Expectation: drainout > 0
@@ -929,13 +1029,13 @@ namespace
       {
         EXPECT_GT(drain[i], 0.) <<
           "percolate_unsaturated: drain !> 0 for layer " << 1 + i;
-        sum_delta_swc += swc[i] - SW_All.Site.swcBulk_init[i];
+        sum_delta_swc += swc[i] - SW_Site.swcBulk_init[i];
       }
       EXPECT_LT(sum_delta_swc, 0.) <<
         "percolate_unsaturated: sum(delta(swc[i])) !< 0 for layer " << 1 + i;
 
 
-      //--- (3) TEST_F:
+      //--- (3) Test:
       //        if swc_sat ~ swc[i] > swc_fc[i],
       //        then expect drain < 0 && ponded > 0
 
@@ -945,16 +1045,16 @@ namespace
 
       ForEachSoilLayer(i, nlyrs)
       {
-        SW_All.Site.swcBulk_init[i] = 1.1 * SW_All.Site.swcBulk_saturated[i];
-        swc[i] = SW_All.Site.swcBulk_init[i];
+        SW_Site.swcBulk_init[i] = 1.1 * SW_Site.swcBulk_saturated[i];
+        swc[i] = SW_Site.swcBulk_init[i];
         drain[i] = 0.;
       }
 
       // Call function to test
       percolate_unsaturated(
         swc, drain, &drainout, &standingWater,
-        nlyrs, SW_All.SoilWat.lyrFrozen, &SW_All.Site,
-        SW_All.Site.slow_drain_coeff, SLOW_DRAIN_DEPTH
+        nlyrs, lyrFrozen, &SW_Site,
+        SW_Site.slow_drain_coeff, SLOW_DRAIN_DEPTH
       );
 
       // Expectation: drainout > 0
@@ -971,16 +1071,16 @@ namespace
           EXPECT_LT(drain[i], 0.) <<
             "percolate_unsaturated: drain !< 0 for layer " << 1 + i;
         } else {
-          EXPECT_NEAR(drain[i], SW_All.Site.slow_drain_coeff, tol6) <<
+          EXPECT_NEAR(drain[i], SW_Site.slow_drain_coeff, tol6) <<
             "percolate_unsaturated: drain != sdrainpar in last layer " << 1 + i;
         }
-        sum_delta_swc += swc[i] - SW_All.Site.swcBulk_init[i];
+        sum_delta_swc += swc[i] - SW_Site.swcBulk_init[i];
       }
       EXPECT_LT(sum_delta_swc, 0.) <<
         "percolate_unsaturated: sum(delta(swc[i])) !< 0 for layer " << 1 + i;
 
 
-      //--- (4) TEST_F:
+      //--- (4) Test:
       //        if lyrFrozen[i],
       //        then expect drain[i] to be small
       small = tol3;
@@ -991,17 +1091,17 @@ namespace
 
       ForEachSoilLayer(i, nlyrs)
       {
-        SW_All.Site.swcBulk_init[i] = 0.9 * SW_All.Site.swcBulk_fieldcap[i];
-        swc[i] = SW_All.Site.swcBulk_init[i];
+        SW_Site.swcBulk_init[i] = 0.9 * SW_Site.swcBulk_fieldcap[i];
+        swc[i] = SW_Site.swcBulk_init[i];
         drain[i] = 0.;
-        SW_All.SoilWat.lyrFrozen[i] = swTRUE;
+        lyrFrozen[i] = swTRUE;
       }
 
       // Call function to test
       percolate_unsaturated(
         swc, drain, &drainout, &standingWater,
-        nlyrs, SW_All.SoilWat.lyrFrozen, &SW_All.Site,
-        SW_All.Site.slow_drain_coeff, SLOW_DRAIN_DEPTH
+        nlyrs, lyrFrozen, &SW_Site,
+        SW_Site.slow_drain_coeff, SLOW_DRAIN_DEPTH
       );
 
 
@@ -1019,29 +1119,44 @@ namespace
           "percolate_unsaturated: drain !> 0 for layer " << 1 + i;
         EXPECT_LT(drain[i], small) <<
           "percolate_unsaturated: small !> drain for layer " << 1 + i;
-        EXPECT_NEAR(swc[i], SW_All.Site.swcBulk_init[i], small) <<
+        EXPECT_NEAR(swc[i], SW_Site.swcBulk_init[i], small) <<
           "percolate_unsaturated: swc !~ swc_init for layer " << 1 + i;
       }
 
       // Reset frozen status
       ForEachSoilLayer(i, nlyrs)
       {
-        SW_All.SoilWat.lyrFrozen[i] = swFALSE;
+        lyrFrozen[i] = swFALSE;
       }
     }
   }
 
 
-  //TEST_F for hydraulic_redistribution when nlyrs = MAX_LAYERS and nlyrs = 1
-  TEST_F(AllTest, SWFlowHydraulicRedistribution)
+  //Test for hydraulic_redistribution when nlyrs = MAX_LAYERS and nlyrs = 1
+  TEST(SWFlowTest, SWFlowHydraulicRedistribution)
   {
+    unsigned int k;
+
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
+
+    SW_SITE SW_Site;
+    setup_SW_Site_for_tests(&SW_Site);
+
+    SW_VEGPROD SW_VegProd;
+    ForEachVegType(k) {
+      SW_VegProd.veg[k].SWPcrit = 20;
+    }
+
     // INPUTS
-    unsigned int nlyrs, i, k;
+    unsigned int nlyrs, i, year = 1980, doy = 1;
     double maxCondroot = -0.2328, swp50 = 1.2e12, shapeCond = 1, scale = 0.3;
     double
       swc[MAX_LAYERS],
       hydred[MAX_LAYERS] = {0.};
     double swcExpected = 0., hydredExpected = 0.;
+
+    RealD lyrFrozen[MAX_LAYERS] = {0};
 
     // INPUTS for expected outcomes
     double swcExpected_1L[1] = {0.8258887};
@@ -1073,26 +1188,25 @@ namespace
       }
 
       // Setup soil layers
-      create_test_soillayers(nlyrs, &SW_All.VegProd, &SW_All.Site, &LogInfo);
+      create_test_soillayers(nlyrs, &SW_VegProd, &SW_Site, &LogInfo);
 
       ForEachSoilLayer(i, nlyrs)
       {
         // example data based on soil:
-        swc[i] = (SW_All.Site.swcBulk_fieldcap[i] +
-                                      SW_All.Site.swcBulk_wiltpt[i]) / 2.;
-        SW_All.SoilWat.lyrFrozen[i] = swFALSE;
+        swc[i] = (SW_Site.swcBulk_fieldcap[i] + SW_Site.swcBulk_wiltpt[i]) / 2.;
+        lyrFrozen[i] = swFALSE;
       }
 
       // Call function to be tested
       hydraulic_redistribution(
         swc,
         hydred,
-        &SW_All.Site,
+        &SW_Site,
         SW_SHRUB,
         nlyrs,
-        SW_All.SoilWat.lyrFrozen,
+        lyrFrozen,
         maxCondroot, swp50, shapeCond, scale,
-        SW_All.Model.year, SW_All.Model.doy,
+        year, doy,
         &LogInfo
       );
 

--- a/tests/gtests/test_SW_Flow_Lib.cc
+++ b/tests/gtests/test_SW_Flow_Lib.cc
@@ -327,8 +327,7 @@ namespace
     double swp_avgExpected1 = 1.5992088;
 
     // Setup soil layers
-    create_test_soillayers(n_layers, PathInfo.InFiles, &SW_All.VegProd,
-                           &SW_All.Site, &LogInfo);
+    create_test_soillayers(n_layers, &SW_All.VegProd, &SW_All.Site, &LogInfo);
 
     ForEachSoilLayer(i, n_layers)
     {
@@ -356,8 +355,7 @@ namespace
     double swp_avgExpectedM = 1.7389131503001496;
 
     // Setup soil layers
-    create_test_soillayers(n_layers, PathInfo.InFiles, &SW_All.VegProd,
-                           &SW_All.Site, &LogInfo);
+    create_test_soillayers(n_layers, &SW_All.VegProd, &SW_All.Site, &LogInfo);
 
     ForEachSoilLayer(i, n_layers)
     {
@@ -433,8 +431,7 @@ namespace
       }
 
       // Setup soil layers
-      create_test_soillayers(nelyrs, PathInfo.InFiles, &SW_All.VegProd,
-                             &SW_All.Site, &LogInfo);
+      create_test_soillayers(nelyrs, &SW_All.VegProd, &SW_All.Site, &LogInfo);
 
       ForEachSoilLayer(i, SW_All.Site.n_layers)
       {
@@ -518,8 +515,7 @@ namespace
       }
 
       // Setup soil layers
-      create_test_soillayers(nelyrs, PathInfo.InFiles, &SW_All.VegProd,
-                             &SW_All.Site, &LogInfo);
+      create_test_soillayers(nelyrs, &SW_All.VegProd, &SW_All.Site, &LogInfo);
 
       ForEachSoilLayer(i, SW_All.Site.n_layers)
       {
@@ -688,8 +684,7 @@ namespace
       }
 
       // Setup: soil layers
-      create_test_soillayers(nlyrs, PathInfo.InFiles, &SW_All.VegProd,
-                             &SW_All.Site, &LogInfo);
+      create_test_soillayers(nlyrs, &SW_All.VegProd, &SW_All.Site, &LogInfo);
 
       ForEachSoilLayer(i, nlyrs)
       {
@@ -851,8 +846,7 @@ namespace
       }
 
       // Setup soil layers
-      create_test_soillayers(nlyrs, PathInfo.InFiles, &SW_All.VegProd,
-                             &SW_All.Site, &LogInfo);
+      create_test_soillayers(nlyrs, &SW_All.VegProd, &SW_All.Site, &LogInfo);
 
       // Initialize soil arrays to be independent of soil texture...
       ForEachSoilLayer(i, nlyrs)
@@ -1079,8 +1073,8 @@ namespace
       }
 
       // Setup soil layers
-      create_test_soillayers(nlyrs, PathInfo.InFiles, &SW_All.VegProd,
-                             &SW_All.Site, &LogInfo);
+      create_test_soillayers(nlyrs, &SW_All.VegProd, &SW_All.Site, &LogInfo);
+
       ForEachSoilLayer(i, nlyrs)
       {
         // example data based on soil:

--- a/tests/gtests/test_SW_Flow_Lib_PET.cc
+++ b/tests/gtests/test_SW_Flow_Lib_PET.cc
@@ -47,7 +47,7 @@
 namespace
 {
   // Test solar position
-  TEST_F(AllTest, SolarPosSolarPosition)
+  TEST(AtmDemandTest, SolarPosSolarPosition)
   {
     double declin, reldist, lat,
       six_hours = 6. * swPI / 12.,
@@ -141,7 +141,7 @@ namespace
 
 
   // Test sun hour angles for horizontal and tilted surfaces
-  TEST_F(AllTest, SolarPosSW_HourAnglesSymmetries)
+  TEST(AtmDemandTest, SolarPosSW_HourAnglesSymmetries)
   {
     //------ Check expectations on some symmetries
     //  - Expectation 1: Horizontal sunset/sunrise:
@@ -164,6 +164,8 @@ namespace
     // (particularly near equinoxes and near "edges" of shading):
     //    --> not unit tested here, but see
     //        `SW2_SolarPosition_Test__hourangles_by_lat_and_doy`
+
+    SW_ATMD SW_AtmDemand;
 
     int
       k, k2, ilat, itime, isl, iasp,
@@ -237,9 +239,11 @@ namespace
                   );
               }
 
+              SW_PET_init_run(&SW_AtmDemand); // Init radiation memoization
+
               // Calculate sun hour angles
               sun_hourangles(
-                &SW_All.AtmDemand,
+                &SW_AtmDemand,
                 doy_used[k][itime],
                 latitude_used[k][itime],
                 slope,
@@ -264,8 +268,6 @@ namespace
 
               daylength[k][itime] *= rad_to_hours;
             }
-
-            SW_PET_init_run(&SW_All.AtmDemand); // Re-init radiation memoization
           }
 
 
@@ -351,7 +353,7 @@ namespace
   // ```
   //   Rscript tools/plot__SW2_SolarPosition_Test__hourangles_by_lat_and_doy.R
   // ```
-  TEST_F(AllTest, SolarPosHourAnglesByLatAndDoy)
+  TEST(AtmDemandTest, SolarPosHourAnglesByLatAndDoy)
   {
     int k, ilat, idoy, isl, iasp, length_strnum;
     double
@@ -498,7 +500,7 @@ namespace
   // ```
   //   Rscript tools/plot__SW2_SolarPosition_Test__hourangles_by_lats.R
   // ```
-  TEST_F(AllTest, SolarPosHourAnglesByLats)
+  TEST(AtmDemandTest, SolarPosHourAnglesByLats)
   {
     int k, ilat, idoy, isl, iasp, iasp2,
       // day of nonleap year Mar 18 (one day before equinox), Jun 21 (solstice),
@@ -589,8 +591,10 @@ namespace
   //   Comparison against examples by Duffie & Beckman 2013 are expected to
   //   deviate in value, but show similar patterns, because equations for
   //   (i) sun-earth distance equation and (ii) solar declination differ
-  TEST_F(AllTest, SolarRadiationExtraterrestrial)
+  TEST(AtmDemandTest, SolarRadiationExtraterrestrial)
   {
+    SW_ATMD SW_AtmDemand;
+
     unsigned int k1, k2, doy;
     double
       lat,
@@ -626,15 +630,18 @@ namespace
       lat = lats_Table1_10_1[k1] * deg_to_rad;
 
       for (k2 = 0; k2 < 12; k2++) {
+
+        SW_PET_init_run(&SW_AtmDemand); // Init radiation memoization (for new location)
+
         if (std::isfinite(H_oh_Table1_10_1[k1][k2])) {
           doy = doys_Table1_6_1[k2];
 
           sun_hourangles(
-            &SW_All.AtmDemand,
+            &SW_AtmDemand,
             doy, lat, 0., 0.,
             sun_angles, int_cos_theta, int_sin_beta
           );
-          solar_radiation_extraterrestrial(SW_All.AtmDemand.memoized_G_o, doy,
+          solar_radiation_extraterrestrial(SW_AtmDemand.memoized_G_o, doy,
                                            int_cos_theta, H_o);
 
           if (ZRO(H_oh_Table1_10_1[k1][k2])) {
@@ -657,47 +664,47 @@ namespace
           }
         }
       }
-
-      SW_PET_init_run(&SW_All.AtmDemand); // Re-init radiation memoization (for next location)
     }
 
 
     // Duffie & Beckman 2013: Example 1.10.1
+    SW_PET_init_run(&SW_AtmDemand); // Re-init radiation memoization
     doy = 105;
     sun_hourangles(
-      &SW_All.AtmDemand,
+      &SW_AtmDemand,
       doy, lat_Madison_WI, 0., 0.,
       sun_angles, int_cos_theta, int_sin_beta
     );
-    solar_radiation_extraterrestrial(SW_All.AtmDemand.memoized_G_o, doy,
+    solar_radiation_extraterrestrial(SW_AtmDemand.memoized_G_o, doy,
                                      int_cos_theta, H_o);
     EXPECT_NEAR(H_o[0], 33.8, 2. * tol1)
       << "Duffie & Beckman 2013: Example 1.10.1\n";
-    SW_PET_init_run(&SW_All.AtmDemand); // Re-init radiation memoization
+
 
     // Duffie & Beckman 2013: Example 2.11.1
+    SW_PET_init_run(&SW_AtmDemand); // Re-init radiation memoization
     doy = 246;
     sun_hourangles(
-      &SW_All.AtmDemand,
+      &SW_AtmDemand,
       doy, lat_StLouis_MO, 0., 0.,
       sun_angles, int_cos_theta, int_sin_beta
     );
-    solar_radiation_extraterrestrial(SW_All.AtmDemand.memoized_G_o, doy, int_cos_theta, H_o);
+    solar_radiation_extraterrestrial(SW_AtmDemand.memoized_G_o, doy, int_cos_theta, H_o);
     EXPECT_NEAR(H_o[0], 33.0, 7. * tol1)
       << "Duffie & Beckman 2013: Example 2.11.1\n";
-    SW_PET_init_run(&SW_All.AtmDemand); // Re-init radiation memoization
+
 
     // Duffie & Beckman 2013: Example 2.12.1
+    SW_PET_init_run(&SW_AtmDemand); // Re-init radiation memoization
     doy = 162;
     sun_hourangles(
-      &SW_All.AtmDemand,
+      &SW_AtmDemand,
       doy, lat_Madison_WI, 0., 0.,
       sun_angles, int_cos_theta, int_sin_beta
     );
-    solar_radiation_extraterrestrial(SW_All.AtmDemand.memoized_G_o, doy, int_cos_theta, H_o);
+    solar_radiation_extraterrestrial(SW_AtmDemand.memoized_G_o, doy, int_cos_theta, H_o);
     EXPECT_NEAR(H_o[0], 41.8, tol1)
       << "Duffie & Beckman 2013: Example 2.12.1\n";
-    SW_PET_init_run(&SW_All.AtmDemand); // Re-init radiation memoization
   }
 
 
@@ -708,8 +715,14 @@ namespace
   //       (see `SW2_SolarRadiationiation_Test.extraterrestrial`),
   //   (ii) we calculate H_gh while they use measured H_gh values, and
   //   (iii) separation models differ, etc.
-  TEST_F(AllTest, SolarRadiationGlobal)
+  TEST(AtmDemandTest, SolarRadiationGlobal)
   {
+    SW_ATMD SW_AtmDemand;
+    SW_PET_init_run(&SW_AtmDemand); // Init radiation memoization
+
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
+
     unsigned int k;
 
     // Duffie & Beckman 2013: Table 1.6.1
@@ -767,7 +780,7 @@ namespace
       rsds = SW_MISSING;
 
       H_gt = solar_radiation(
-        &SW_All.AtmDemand,
+        &SW_AtmDemand,
         doys_Table1_6_1[k],
         43. * deg_to_rad, // latitude
         226., // elevation
@@ -801,7 +814,7 @@ namespace
       rsds = H_gh; // calculated using `cloud_cover1[]`
 
       H_gt = solar_radiation(
-        &SW_All.AtmDemand,
+        &SW_AtmDemand,
         doys_Table1_6_1[k],
         43. * deg_to_rad, // latitude
         226., // elevation
@@ -830,7 +843,7 @@ namespace
       rsds = H_Ex2_19_1[1][k];
 
       H_gt = solar_radiation(
-        &SW_All.AtmDemand,
+        &SW_AtmDemand,
         doys_Table1_6_1[k],
         43. * deg_to_rad, // latitude
         226., // elevation
@@ -863,15 +876,13 @@ namespace
         << "Duffie & Beckman 2013: Example 2.19.1 (observed rsds), cloud cover: "
         << "month = " << k + 1 << "\n";
     }
-
-    SW_PET_init_run(&SW_All.AtmDemand); // Re-init radiation memoization
   }
 
 
 
 
   // Test saturation vapor pressure functions
-  TEST_F(AllTest, SW2PETsvp)
+  TEST(AtmDemandTest, PETsvp)
   {
     int i;
     double
@@ -905,8 +916,14 @@ namespace
 
 
   // Test `petfunc()`
-  TEST_F(AllTest, SW2PETpetfunc)
+  TEST(AtmDemandTest, PETpetfunc)
   {
+    SW_ATMD SW_AtmDemand;
+
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
+
+
     int i;
     unsigned int
       doy = 2,
@@ -938,12 +955,14 @@ namespace
         0.0896, 0.1290, 0.1867, 0.2736, 0.4027, 0.5890
       };
 
+    SW_PET_init_run(&SW_AtmDemand); // Init radiation memoization
+
     for (i = 0; i < 10; i++)
     {
       actual_vap_pressure = actualVaporPressure1(RH, avgtemps[i]);
 
       H_gt = solar_radiation(
-        &SW_All.AtmDemand, doy,
+        &SW_AtmDemand, doy,
         lat, elev, slope0, aspect, reflec,
         &cloudcov, actual_vap_pressure,
         rsds, desc_rsds,
@@ -962,14 +981,16 @@ namespace
       // Inputs
       lats[] = {-90., -45., 0., 45., 90.},
       // Expected PET
-      expected_pet_lats[] = {0.1550, 0.4360, 0.3597, 0.1216, 0.0421};
+      expected_pet_lats[] = {0.416576, 0.435964, 0.359670, 0.121564, 0.042131};
 
     double e_a = actualVaporPressure1(RH, temp);
 
     for (i = 0; i < 5; i++)
     {
+      SW_PET_init_run(&SW_AtmDemand); // Re-init radiation memoization
+
       H_gt = solar_radiation(
-        &SW_All.AtmDemand, doy,
+        &SW_AtmDemand, doy,
         lats[i] * deg_to_rad, elev, slope0, aspect, reflec,
         &cloudcov, e_a,
         rsds, desc_rsds,
@@ -979,9 +1000,7 @@ namespace
       check_pet = petfunc(H_gt, temp, elev, reflec, RH, windsp,
                           cloudcov, &LogInfo);
 
-      EXPECT_NEAR(check_pet, expected_pet_lats[i], tol3);
-
-      SW_PET_init_run(&SW_All.AtmDemand); // Re-init radiation memoization
+      EXPECT_NEAR(check_pet, expected_pet_lats[i], tol6);
    }
 
 
@@ -995,8 +1014,10 @@ namespace
 
     for (i = 0; i < 5; i++)
     {
+      SW_PET_init_run(&SW_AtmDemand); // Re-init radiation memoization
+
       H_gt = solar_radiation(
-        &SW_All.AtmDemand, doy,
+        &SW_AtmDemand, doy,
         lat, elevs[i], slope0, aspect, reflec,
         &cloudcov, e_a,
         rsds, desc_rsds,
@@ -1019,8 +1040,10 @@ namespace
 
     for (i = 0; i < 5; i++)
     {
+      SW_PET_init_run(&SW_AtmDemand); // Re-init radiation memoization
+
       H_gt = solar_radiation(
-        &SW_All.AtmDemand, doy,
+        &SW_AtmDemand, doy,
         lat, elev, slopes[i] * deg_to_rad, aspect, reflec,
         &cloudcov, e_a,
         rsds, desc_rsds,
@@ -1031,8 +1054,6 @@ namespace
                           cloudcov, &LogInfo);
 
       EXPECT_NEAR(check_pet, expected_pet_slopes[i], tol3);
-
-      SW_PET_init_run(&SW_All.AtmDemand); // Re-init radiation memoization
     }
 
 
@@ -1048,8 +1069,10 @@ namespace
 
     for (i = 0; i < 7; i++)
     {
+      SW_PET_init_run(&SW_AtmDemand); // Re-init radiation memoization
+
       H_gt = solar_radiation(
-        &SW_All.AtmDemand, doy,
+        &SW_AtmDemand, doy,
         lat, elev, sloped, aspects[i] * deg_to_rad, reflec,
         &cloudcov, e_a,
         rsds, desc_rsds,
@@ -1060,8 +1083,6 @@ namespace
                           cloudcov, &LogInfo);
 
       EXPECT_NEAR(check_pet, expected_pet_aspects[i], tol3);
-
-      SW_PET_init_run(&SW_All.AtmDemand); // Re-init radiation memoization
     }
 
 
@@ -1074,8 +1095,10 @@ namespace
 
     for (i = 0; i < 5; i++)
     {
+      SW_PET_init_run(&SW_AtmDemand); // Re-init radiation memoization
+
       H_gt = solar_radiation(
-        &SW_All.AtmDemand, doy,
+        &SW_AtmDemand, doy,
         lat, elev, sloped, aspect, reflecs[i],
         &cloudcov, e_a,
         rsds, desc_rsds,
@@ -1098,10 +1121,12 @@ namespace
 
     for (i = 0; i < 5; i++)
     {
+      SW_PET_init_run(&SW_AtmDemand); // Re-init radiation memoization
+
       actual_vap_pressure = actualVaporPressure1(RHs[i], temp);
 
       H_gt = solar_radiation(
-        &SW_All.AtmDemand, doy,
+        &SW_AtmDemand, doy,
         lat, elev, slope0, aspect, reflec,
         &cloudcov, actual_vap_pressure,
         rsds, desc_rsds,
@@ -1122,8 +1147,10 @@ namespace
       // Expected PET
       expected_pet_windsps[] = {0.1016, 0.1426, 0.3070, 0.5124, 0.9232};
 
+    SW_PET_init_run(&SW_AtmDemand); // Re-init radiation memoization
+
     H_gt = solar_radiation(
-      &SW_All.AtmDemand, doy,
+      &SW_AtmDemand, doy,
       lat, elev, slope0, aspect, reflec,
       &cloudcov, e_a,
       rsds, desc_rsds,
@@ -1149,8 +1176,10 @@ namespace
 
     for (i = 0; i < 5; i++)
     {
+      SW_PET_init_run(&SW_AtmDemand); // Re-init radiation memoization
+
       H_gt = solar_radiation(
-        &SW_All.AtmDemand, doy,
+        &SW_AtmDemand, doy,
         lat, elev, slope0, aspect, reflec,
         &cloudcovs[i], e_a,
         rsds, desc_rsds,
@@ -1162,8 +1191,6 @@ namespace
 
       EXPECT_NEAR(check_pet, expected_pet_cloudcovs[i], tol3);
     }
-
-    SW_PET_init_run(&SW_All.AtmDemand); // Re-init radiation memoization
   }
 
 
@@ -1178,8 +1205,15 @@ namespace
   // ```
   //   Rscript tools/plot__SW2_PET_Test__petfunc_by_temps.R
   // ```
-  TEST_F(AllTest, SW2PETPetfuncByTemps)
+  TEST(AtmDemandTest, PETPetfuncByTemps)
   {
+    SW_ATMD SW_AtmDemand;
+    SW_PET_init_run(&SW_AtmDemand); // Init radiation memoization
+
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
+
+
     int doy, k1, k2, k3, k4, k5;
 
     unsigned int desc_rsds = 0;
@@ -1235,7 +1269,7 @@ namespace
               {
 
                 H_gt = fH_gt * solar_radiation(
-                  &SW_All.AtmDemand, doy,
+                  &SW_AtmDemand, doy,
                   lat, elev, slope, aspect, reflec,
                   &cloudcover, RH, temp,
                   rsds, desc_rsds,

--- a/tests/gtests/test_SW_Flow_lib_temp.cc
+++ b/tests/gtests/test_SW_Flow_lib_temp.cc
@@ -46,7 +46,7 @@ pcg32_random_t flowTemp_rng;
 namespace {
 
   // Test the function 'surface_temperature_under_snow'
-  TEST_F(AllTest, SWFlowTempSurfaceTemperatureUnderSnow) {
+  TEST(SWFlowTempTest, SWFlowTempSurfaceTemperatureUnderSnow) {
 
     // declare inputs and output
     double snow, airTempAvg;
@@ -84,7 +84,12 @@ namespace {
   }
 
   // Test the soil temperature initialization function 'soil_temperature_setup'
-  TEST_F(AllTest, SWFlowTempSoilTemperatureInit) {
+  TEST(SWFlowTempTest, SWFlowTempSoilTemperatureInit) {
+    ST_RGR_VALUES SW_StRegValues;
+    SW_ST_init_run(&SW_StRegValues);
+
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
 
     // declare inputs and output
     double deltaX = 15.0, theMaxDepth = 990.0, sTconst = 4.15;
@@ -102,22 +107,24 @@ namespace {
     wp[0]= fc[0] - 0.6; // wp will always be less than fc
 
     /// test standard conditions
-    soil_temperature_setup(&SW_All.StRegValues, bDensity, width, sTempInit,
+    soil_temperature_setup(&SW_StRegValues, bDensity, width, sTempInit,
       sTconst, nlyrs, fc, wp, deltaX, theMaxDepth, nRgr, &ptr_stError,
-      &SW_All.StRegValues.soil_temp_init, &LogInfo);
+      &SW_StRegValues.soil_temp_init, &LogInfo);
 
     //Structure Tests
-    EXPECT_EQ(sizeof(SW_All.StRegValues.tlyrs_by_slyrs),
-      sizeof(double) * MAX_ST_RGR * (MAX_LAYERS + 1));
+    EXPECT_EQ(
+      sizeof(SW_StRegValues.tlyrs_by_slyrs),
+      sizeof(double) * MAX_ST_RGR * (MAX_LAYERS + 1)
+    );
 
-    for(unsigned int i = ceil(SW_All.StRegValues.depths[nlyrs - 1]/deltaX); i < nRgr + 1; i++){
-        EXPECT_EQ(SW_All.StRegValues.tlyrs_by_slyrs[i][nlyrs], -deltaX);
+    for(unsigned int i = ceil(SW_StRegValues.depths[nlyrs - 1]/deltaX); i < nRgr + 1; i++){
+        EXPECT_EQ(SW_StRegValues.tlyrs_by_slyrs[i][nlyrs], -deltaX);
         //Values should be equal to -deltaX when i > the depth of the soil profile/deltaX and j is == nlyrs
     }
 
     // Other init test
-    EXPECT_EQ(SW_All.StRegValues.depths[nlyrs - 1], 20); // sum of inputs width = maximum depth; in my example 20
-    EXPECT_EQ((SW_All.StRegValues.depthsR[nRgr]/deltaX) - 1, nRgr); // nRgr = (MaxDepth/deltaX) - 1
+    EXPECT_EQ(SW_StRegValues.depths[nlyrs - 1], 20); // sum of inputs width = maximum depth; in my example 20
+    EXPECT_EQ((SW_StRegValues.depthsR[nRgr]/deltaX) - 1, nRgr); // nRgr = (MaxDepth/deltaX) - 1
 
     // *****  Test when nlyrs = MAX_LAYERS (SW_Defines.h)  ***** //
     /// generate inputs using a for loop
@@ -134,28 +141,35 @@ namespace {
       wp2[i] = fc2[i] - 0.6; // wp will always be less than fc
     }
 
-    soil_temperature_setup(&SW_All.StRegValues, bDensity2, width2, sTempInit2,
+    soil_temperature_setup(&SW_StRegValues, bDensity2, width2, sTempInit2,
       sTconst, nlyrs, fc2, wp2, deltaX, theMaxDepth, nRgr, &ptr_stError,
-      &SW_All.StRegValues.soil_temp_init, &LogInfo);
+      &SW_StRegValues.soil_temp_init, &LogInfo);
 
     //Structure Tests
-    EXPECT_EQ(sizeof(SW_All.StRegValues.tlyrs_by_slyrs),
-      sizeof(double) * MAX_ST_RGR * (MAX_LAYERS + 1));
+    EXPECT_EQ(
+      sizeof(SW_StRegValues.tlyrs_by_slyrs),
+      sizeof(double) * MAX_ST_RGR * (MAX_LAYERS + 1)
+    );
 
-    for(unsigned int i = ceil(SW_All.StRegValues.depths[nlyrs - 1]/deltaX); i < nRgr + 1; i++){
-        EXPECT_EQ(SW_All.StRegValues.tlyrs_by_slyrs[i][nlyrs], -deltaX);
+    for(unsigned int i = ceil(SW_StRegValues.depths[nlyrs - 1]/deltaX); i < nRgr + 1; i++){
+        EXPECT_EQ(SW_StRegValues.tlyrs_by_slyrs[i][nlyrs], -deltaX);
         //Values should be equal to -deltaX when i > the depth of the soil profile/deltaX and j is == nlyrs
     }
 
     // Other init test
-    EXPECT_EQ(SW_All.StRegValues.depths[nlyrs - 1], 295); // sum of inputs width = maximum depth; in my example 295
-    EXPECT_EQ((SW_All.StRegValues.depthsR[nRgr]/deltaX) - 1, nRgr); // nRgr = (MaxDepth/deltaX) - 1
+    EXPECT_EQ(SW_StRegValues.depths[nlyrs - 1], 295); // sum of inputs width = maximum depth; in my example 295
+    EXPECT_EQ((SW_StRegValues.depthsR[nRgr]/deltaX) - 1, nRgr); // nRgr = (MaxDepth/deltaX) - 1
 
     delete[] bDensity2; delete[] fc2; delete[] wp2;
   }
 
   // Death tests for soil_temperature_setup function
-  TEST_F(AllDeathTest, SWFlowTempSoilTemperatureInitDeathTest) {
+  TEST(SWFlowTempDeathTest, SWFlowTempSoilTemperatureInitDeathTest) {
+    ST_RGR_VALUES SW_StRegValues;
+    SW_ST_init_run(&SW_StRegValues);
+
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
 
     // *****  Test when nlyrs = MAX_LAYERS (SW_Defines.h)  ***** //
     double deltaX = 15.0, sTconst = 4.15;
@@ -182,9 +196,9 @@ namespace {
     // We expect death when max depth < last layer
     EXPECT_DEATH_IF_SUPPORTED(
       soil_temperature_setup(
-        &SW_All.StRegValues, bDensity2, width2, sTempInit2, sTconst, nlyrs,
+        &SW_StRegValues, bDensity2, width2, sTempInit2, sTconst, nlyrs,
         fc2, wp2, deltaX, theMaxDepth2, nRgr, &ptr_stError,
-        &SW_All.StRegValues.soil_temp_init, &LogInfo
+        &SW_StRegValues.soil_temp_init, &LogInfo
       ),
       "SOIL_TEMP FUNCTION ERROR: soil temperature max depth"
     );
@@ -195,7 +209,12 @@ namespace {
 
   // Test lyrSoil_to_lyrTemp, lyrSoil_to_lyrTemp_temperature via
   // soil_temperature_setup function
-  TEST_F(AllTest, SWFlowTempSoilLayerInterpolationFunctions) {
+  TEST(SWFlowTempTest, SWFlowTempSoilLayerInterpolationFunctions) {
+    ST_RGR_VALUES SW_StRegValues;
+    SW_ST_init_run(&SW_StRegValues);
+
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
 
     // declare inputs and output
     double deltaX = 15.0, theMaxDepth = 990.0, sTconst = 4.15;
@@ -215,38 +234,38 @@ namespace {
 
     wp[0]= fmax(fc[0] - 0.6, .1); // wp will always be less than fc
 
-    soil_temperature_setup(&SW_All.StRegValues, bDensity, width, sTempInit,
+    soil_temperature_setup(&SW_StRegValues, bDensity, width, sTempInit,
       sTconst, nlyrs, fc, wp, deltaX, theMaxDepth, nRgr, &ptr_stError,
-      &SW_All.StRegValues.soil_temp_init, &LogInfo);
+      &SW_StRegValues.soil_temp_init, &LogInfo);
 
     // lyrSoil_to_lyrTemp tests: This function is used in soil_temperature_setup
     // to transfer the soil layer values of bdensity, fc, and wp, to the "temperature layer"
     // which are contained in bdensityR, fcR, and wpR. Thus we check these values.
     for (i = 0; i < nRgr + 1; i++) {  // all Values should be greater than 0
-      EXPECT_GT(SW_All.StRegValues.bDensityR[i], 0);
-      EXPECT_GT(SW_All.StRegValues.fcR[i], 0);
-      EXPECT_GT(SW_All.StRegValues.wpR[i], 0);
+      EXPECT_GT(SW_StRegValues.bDensityR[i], 0);
+      EXPECT_GT(SW_StRegValues.fcR[i], 0);
+      EXPECT_GT(SW_StRegValues.wpR[i], 0);
     }
 
-    for (i = ceil(SW_All.StRegValues.depths[nlyrs - 1]/deltaX) + 1; i < nRgr + 1; i++) {
+    for (i = ceil(SW_StRegValues.depths[nlyrs - 1]/deltaX) + 1; i < nRgr + 1; i++) {
       //The TempLayer values that are at depths greater than the max SoilLayer depth should be uniform
-      EXPECT_EQ(SW_All.StRegValues.bDensityR[i], SW_All.StRegValues.bDensityR[i - 1]);
-      EXPECT_EQ(SW_All.StRegValues.fcR[i], SW_All.StRegValues.fcR[i - 1]);
-      EXPECT_EQ(SW_All.StRegValues.wpR[i], SW_All.StRegValues.wpR[i - 1]);
+      EXPECT_EQ(SW_StRegValues.bDensityR[i], SW_StRegValues.bDensityR[i - 1]);
+      EXPECT_EQ(SW_StRegValues.fcR[i], SW_StRegValues.fcR[i - 1]);
+      EXPECT_EQ(SW_StRegValues.wpR[i], SW_StRegValues.wpR[i - 1]);
     }
 
     // lyrSoil_to_lyrTemp_temperature tests
-    EXPECT_TRUE(missing(SW_All.StRegValues.oldavgLyrTempR[0])); // surface temperature is initialized to missing because not used
+    EXPECT_TRUE(missing(SW_StRegValues.oldavgLyrTempR[0])); // surface temperature is initialized to missing because not used
     double maxvalR = 0.;
     for (i = 1; i < nRgr + 1; i++) {
-      EXPECT_GT(SW_All.StRegValues.oldavgLyrTempR[i], -100); //Values interpolated into sTempInitR should be realistic
-      EXPECT_LT(SW_All.StRegValues.oldavgLyrTempR[i], 100); //Values interpolated into sTempInitR should be realistic
-      if(GT(SW_All.StRegValues.oldavgLyrTempR[i], maxvalR)) {
-        maxvalR = SW_All.StRegValues.oldavgLyrTempR[i];
+      EXPECT_GT(SW_StRegValues.oldavgLyrTempR[i], -100); //Values interpolated into sTempInitR should be realistic
+      EXPECT_LT(SW_StRegValues.oldavgLyrTempR[i], 100); //Values interpolated into sTempInitR should be realistic
+      if(GT(SW_StRegValues.oldavgLyrTempR[i], maxvalR)) {
+        maxvalR = SW_StRegValues.oldavgLyrTempR[i];
       }
     }
     EXPECT_LE(maxvalR, sTconst);//Maximum interpolated sTempInitR value should be less than or equal to maximum in sTempInit2 (sTconst = last layer)
-    EXPECT_EQ(SW_All.StRegValues.oldavgLyrTempR[nRgr + 1], sTconst); //Temperature in last interpolated layer should equal sTconst
+    EXPECT_EQ(SW_StRegValues.oldavgLyrTempR[nRgr + 1], sTconst); //Temperature in last interpolated layer should equal sTconst
 
     // *****  Test when nlyrs = MAX_LAYERS (SW_Defines.h)  ***** //
     /// generate inputs using a for loop
@@ -266,42 +285,43 @@ namespace {
       EXPECT_GT(wp2[i], 0);
     }
 
-    soil_temperature_setup(&SW_All.StRegValues, bDensity2, width2, sTempInit2,
+    soil_temperature_setup(&SW_StRegValues, bDensity2, width2, sTempInit2,
       sTconst, nlyrs, fc2, wp2, deltaX, theMaxDepth, nRgr, &ptr_stError,
-      &SW_All.StRegValues.soil_temp_init, &LogInfo);
+      &SW_StRegValues.soil_temp_init, &LogInfo);
 
     // lyrSoil_to_lyrTemp tests
     for (i = 0; i < nRgr + 1; i++) {  // all Values should be greater than 0
-      EXPECT_GT(SW_All.StRegValues.bDensityR[i], 0);
-      EXPECT_GT(SW_All.StRegValues.fcR[i], 0);
-      EXPECT_GT(SW_All.StRegValues.wpR[i], 0);
+      EXPECT_GT(SW_StRegValues.bDensityR[i], 0);
+      EXPECT_GT(SW_StRegValues.fcR[i], 0);
+      EXPECT_GT(SW_StRegValues.wpR[i], 0);
     }
 
-    for (i = ceil(SW_All.StRegValues.depths[nlyrs - 1]/deltaX) + 1; i < nRgr + 1; i++) {
+    for (i = ceil(SW_StRegValues.depths[nlyrs - 1]/deltaX) + 1; i < nRgr + 1; i++) {
       //The TempLayer values that are at depths greater than the max SoilLayer depth should be uniform
-      EXPECT_EQ(SW_All.StRegValues.bDensityR[i], SW_All.StRegValues.bDensityR[i - 1]);
-      EXPECT_EQ(SW_All.StRegValues.fcR[i], SW_All.StRegValues.fcR[i - 1]);
-      EXPECT_EQ(SW_All.StRegValues.wpR[i], SW_All.StRegValues.wpR[i - 1]);
+      EXPECT_EQ(SW_StRegValues.bDensityR[i], SW_StRegValues.bDensityR[i - 1]);
+      EXPECT_EQ(SW_StRegValues.fcR[i], SW_StRegValues.fcR[i - 1]);
+      EXPECT_EQ(SW_StRegValues.wpR[i], SW_StRegValues.wpR[i - 1]);
     }
 
     // lyrSoil_to_lyrTemp_temperature tests
-    EXPECT_TRUE(missing(SW_All.StRegValues.oldavgLyrTempR[0])); // surface temperature is initialized to missing because not used
+    EXPECT_TRUE(missing(SW_StRegValues.oldavgLyrTempR[0])); // surface temperature is initialized to missing because not used
     maxvalR = 0.;
     for (i = 1; i <= nRgr + 1; i++) {
-      EXPECT_GT(SW_All.StRegValues.oldavgLyrTempR[i], -200); //Values interpolated into sTempInitR should be realistic
-      EXPECT_LT(SW_All.StRegValues.oldavgLyrTempR[i], 200); //Values interpolated into sTempInitR should be realistic
-      if(GT(SW_All.StRegValues.oldavgLyrTempR[i], maxvalR)) {
-        maxvalR = SW_All.StRegValues.oldavgLyrTempR[i];
+      EXPECT_GT(SW_StRegValues.oldavgLyrTempR[i], -200); //Values interpolated into sTempInitR should be realistic
+      EXPECT_LT(SW_StRegValues.oldavgLyrTempR[i], 200); //Values interpolated into sTempInitR should be realistic
+      if(GT(SW_StRegValues.oldavgLyrTempR[i], maxvalR)) {
+        maxvalR = SW_StRegValues.oldavgLyrTempR[i];
       }
     }
     EXPECT_LE(maxvalR, sTconst);//Maximum interpolated sTempInitR value should be less than or equal to maximum in sTempInit2 (sTconst = last layer)
-    EXPECT_EQ(SW_All.StRegValues.oldavgLyrTempR[nRgr + 1], sTconst); //Temperature in last interpolated layer should equal sTconst
+    EXPECT_EQ(SW_StRegValues.oldavgLyrTempR[nRgr + 1], sTconst); //Temperature in last interpolated layer should equal sTconst
 
     delete[] bDensity2; delete[] fc2; delete[] wp2;
   }
 
   // Test set layer to frozen or unfrozen 'set_frozen_unfrozen'
-  TEST_F(AllTest, SWFlowTempSetFrozenUnfrozen){
+  TEST(SWFlowTempTest, SWFlowTempSetFrozenUnfrozen){
+    RealD lyrFrozen[MAX_LAYERS] = {0};
 
     // declare inputs and output
     // *****  Test when nlyrs = 1  ***** //
@@ -309,17 +329,17 @@ namespace {
     unsigned int nlyrs = 1;
     double sTemp[] = {-5}, swc[] = {1.5}, swc_sat[] = {1.8}, width[] = {5};
 
-    set_frozen_unfrozen(nlyrs, sTemp, swc, swc_sat, width, SW_All.SoilWat.lyrFrozen);
+    set_frozen_unfrozen(nlyrs, sTemp, swc, swc_sat, width, lyrFrozen);
 
-    EXPECT_EQ(1,SW_All.SoilWat.lyrFrozen[0]); // Soil should freeze when sTemp is <= -1
+    EXPECT_EQ(1, lyrFrozen[0]); // Soil should freeze when sTemp is <= -1
     // AND swc is > swc_sat - width * .13
 
     /// ***** Test that soil does not freeze ***** ///
     double sTemp2[] = {0};
 
-    set_frozen_unfrozen(nlyrs, sTemp2, swc, swc_sat, width, SW_All.SoilWat.lyrFrozen);
+    set_frozen_unfrozen(nlyrs, sTemp2, swc, swc_sat, width, lyrFrozen);
 
-    EXPECT_EQ(0,SW_All.SoilWat.lyrFrozen[0]); // Soil should NOT freeze when sTemp is > -1
+    EXPECT_EQ(0, lyrFrozen[0]); // Soil should NOT freeze when sTemp is > -1
 
     // *****  Test when nlyrs = MAX_LAYERS (SW_Defines.h)  ***** //
     nlyrs = MAX_LAYERS;
@@ -336,25 +356,25 @@ namespace {
       swc2[i] = 5; // set swc to a high value so will be > swc_sat - width * .13
       swc_sat2[i] = 1;
       // run
-      set_frozen_unfrozen(nlyrs, sTemp3, swc2, swc_sat2, width2, SW_All.SoilWat.lyrFrozen);
+      set_frozen_unfrozen(nlyrs, sTemp3, swc2, swc_sat2, width2, lyrFrozen);
       // Test
-      EXPECT_EQ(1,SW_All.SoilWat.lyrFrozen[i]);
+      EXPECT_EQ(1, lyrFrozen[i]);
       // run
-      set_frozen_unfrozen(nlyrs, sTemp4, swc2, swc_sat2, width2, SW_All.SoilWat.lyrFrozen);
+      set_frozen_unfrozen(nlyrs, sTemp4, swc2, swc_sat2, width2, lyrFrozen);
       // Test
-      EXPECT_EQ(0,SW_All.SoilWat.lyrFrozen[i]);
+      EXPECT_EQ(0, lyrFrozen[i]);
     }
 
     delete[] sTemp3; delete[] sTemp4; delete[] swc2; delete[] swc_sat2;
   }
 
   // Test soil temperature today function 'soil_temperature_today'
-  TEST_F(AllTest, SWFlowTempSoilTemperatureTodayFunction) {
+  TEST(SWFlowTempTest, SWFlowTempSoilTemperatureTodayFunction) {
 
     // declare inputs and output
     double delta_time = 86400., deltaX = 15.0, T1 = 20.0, sTconst = 4.16, csParam1 = 0.00070,
     csParam2 = 0.000030, shParam = 0.18, surface_range = 1.;
-    unsigned int nRgr =65;
+    unsigned int nRgr =65, year = 1980, doy = 1;
     Bool ptr_stError = swFALSE;
 
     pcg32_random_t STTF_rng;
@@ -384,7 +404,7 @@ namespace {
 
     soil_temperature_today(&delta_time, deltaX, T1, sTconst, nRgr, sTempR, sTempInitR,
       vwcR, wpR, fcR, bDensityR, csParam1, csParam2, shParam, &ptr_stError, surface_range,
-      temperatureRangeR, depthsR, SW_All.Model.year, SW_All.Model.doy);
+      temperatureRangeR, depthsR, year, doy);
 
     // Check that values that are set, are set right.
     EXPECT_EQ(sTempR[0], T1);
@@ -412,7 +432,7 @@ namespace {
 
     soil_temperature_today(&delta_time, deltaX, T1, sTconst, nRgr, sTempR2, sTempInitR3,
         vwcR, wpR, fcR, bDensityR, csParam1, csParam2, shParam, &ptr_stError, surface_range,
-        temperatureRangeR, depthsR, SW_All.Model.year, SW_All.Model.doy);
+        temperatureRangeR, depthsR, year, doy);
 
     //Check that ptr_stError is TRUE
     EXPECT_EQ(ptr_stError, 1);
@@ -425,9 +445,18 @@ namespace {
   // Test main soil temperature function 'soil_temperature'
   // AND lyrTemp_to_lyrSoil_temperature as this function
   // is only called in the soil_temperature function
-  TEST_F(AllTest, SWFlowTempMainSoilTemperatureFunction_Lyr01) {
+  TEST(SWFlowTempTest, SWFlowTempMainSoilTemperatureFunction_Lyr01) {
+    ST_RGR_VALUES SW_StRegValues;
+    SW_ST_init_run(&SW_StRegValues);
 
-    unsigned int k;
+    SW_SITE SW_Site;
+
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
+
+    RealD lyrFrozen[MAX_LAYERS] = {0};
+
+    unsigned int k, year = 1980, doy = 1;
 
     // *****  Test when nlyrs = 1  ***** //
     unsigned int nlyrs = 1, nRgr = 65;
@@ -441,39 +470,42 @@ namespace {
     double swc[] = {1.0}, swc_sat[] = {1.5}, bDensity[] = {1.8}, width[] = {20},
     sTemp[1], min_temp[] = {10.0}, max_temp[] = {1.0};
 
-    SW_All.Site.avgLyrTempInit[0] = 5.0;
-    SW_All.Site.soilBulk_density[0] = 1.8;
-    SW_All.Site.width[0] = 20;
-    SW_All.Site.n_layers = 1;
-    SW_All.Site.swcBulk_fieldcap[0] = 2.6;
-    SW_All.Site.swcBulk_wiltpt[0] = 1.0;
-    SW_All.Site.stNRGR = 65;
-    SW_All.Site.stDeltaX = 15;
-    SW_All.Site.Tsoil_constant = 4.15;
-    SW_All.Site.stMaxDepth = 990.;
-    SW_All.Site.swcBulk_saturated[0] = 1.5;
+    SW_Site.n_layers = nlyrs;
+    SW_Site.stNRGR = nRgr;
+
+    SW_Site.soilBulk_density[0] = 1.8;
+    SW_Site.width[0] = 20;
+    SW_Site.avgLyrTempInit[0] = 5.0;
+    SW_Site.Tsoil_constant = 4.15;
+    SW_Site.swcBulk_fieldcap[0] = 2.6;
+    SW_Site.swcBulk_wiltpt[0] = 1.0;
+    SW_Site.stDeltaX = 15;
+    SW_Site.stMaxDepth = 990.;
+
+    SW_Site.swcBulk_saturated[0] = 1.5;
 
 
     SW_ST_setup_run(
-      &SW_All.StRegValues,
-      &SW_All.Site,
+      &SW_StRegValues,
+      &SW_Site,
       &ptr_stError,
-      &SW_All.StRegValues.soil_temp_init,
+      &SW_StRegValues.soil_temp_init,
       airTemp,
       swc,
       &surfaceTemp,
       sTemp,
-      SW_All.SoilWat.lyrFrozen,
+      lyrFrozen,
       &LogInfo
     );
 
-    soil_temperature(&SW_All.StRegValues,
-      &surface_max, &surface_min, SW_All.SoilWat.lyrFrozen,
+    soil_temperature(
+      &SW_StRegValues,
+      &surface_max, &surface_min, lyrFrozen,
       airTemp, pet, aet, biomass, swc, swc_sat, bDensity, width,
       sTemp, &surfaceTemp, nlyrs, bmLimiter, t1Param1, t1Param2,
       t1Param3, csParam1, csParam2, shParam, snowdepth, sTconst, deltaX,
       theMaxDepth, nRgr, snow, max_air_temp, min_air_temp, H_gt,
-      SW_All.Model.year, SW_All.Model.doy, min_temp, max_temp, &ptr_stError, &LogInfo);
+      year, doy, min_temp, max_temp, &ptr_stError, &LogInfo);
 
     // Expect that surface temp equals surface_temperature_under_snow() because snow > 0
     EXPECT_EQ(surfaceTemp, surface_temperature_under_snow(airTemp, snow));
@@ -484,16 +516,17 @@ namespace {
     snowdepth = 0;
 
     for (k = 0; k < nlyrs; k++) {
-      sTemp[k] = SW_All.Site.avgLyrTempInit[k];
+      sTemp[k] = SW_Site.avgLyrTempInit[k];
     }
 
-    soil_temperature(&SW_All.StRegValues,
-      &surface_max, &surface_min, SW_All.SoilWat.lyrFrozen,
+    soil_temperature(
+      &SW_StRegValues,
+      &surface_max, &surface_min, lyrFrozen,
       airTemp, pet, aet, biomass, swc, swc_sat, bDensity, width,
       sTemp, &surfaceTemp, nlyrs, bmLimiter, t1Param1, t1Param2,
       t1Param3, csParam1, csParam2, shParam, snowdepth, sTconst, deltaX,
       theMaxDepth, nRgr, snow, max_air_temp, min_air_temp, H_gt,
-      SW_All.Model.year, SW_All.Model.doy, min_temp, max_temp, &ptr_stError, &LogInfo);
+      year, doy, min_temp, max_temp, &ptr_stError, &LogInfo);
 
     EXPECT_EQ(surfaceTemp, airTemp + (t1Param1 * pet * (1. - (aet / pet)) * (1. - (biomass / bmLimiter))));
     EXPECT_NE(surfaceTemp, airTemp + ((t1Param2 * (biomass - bmLimiter)) / t1Param3));
@@ -503,16 +536,17 @@ namespace {
     biomass = 305;
 
     for (k = 0; k < nlyrs; k++) {
-      sTemp[k] = SW_All.Site.avgLyrTempInit[k];
+      sTemp[k] = SW_Site.avgLyrTempInit[k];
     }
 
-    soil_temperature(&SW_All.StRegValues,
-      &surface_max, &surface_min, SW_All.SoilWat.lyrFrozen,
+    soil_temperature(
+      &SW_StRegValues,
+      &surface_max, &surface_min, lyrFrozen,
       airTemp, pet, aet, biomass, swc, swc_sat, bDensity, width,
       sTemp, &surfaceTemp, nlyrs, bmLimiter, t1Param1, t1Param2,
       t1Param3, csParam1, csParam2, shParam, snowdepth, sTconst, deltaX,
       theMaxDepth, nRgr, snow, max_air_temp, min_air_temp, H_gt,
-      SW_All.Model.year, SW_All.Model.doy, min_temp, max_temp, &ptr_stError, &LogInfo);
+      year, doy, min_temp, max_temp, &ptr_stError, &LogInfo);
 
     EXPECT_EQ(surfaceTemp, airTemp + ((t1Param2 * (biomass - bmLimiter)) / t1Param3));
     EXPECT_NE(surfaceTemp, airTemp + (t1Param1 * pet * (1. - (aet / pet)) * (1. - (biomass / bmLimiter))));
@@ -528,8 +562,8 @@ namespace {
     // Expect that sTempInitR is updated to sTempR for the next day
     for (k = 0; k <= nRgr + 1; k++)
     {
-      //swprintf("\n k %u, newoldtempR %f", k, SW_All.StRegValues.oldavgLyrTempR[k]);
-      EXPECT_NE(SW_All.StRegValues.oldavgLyrTempR[k], SW_MISSING);
+      //swprintf("\n k %u, newoldtempR %f", k, SW_StRegValues.oldavgLyrTempR[k]);
+      EXPECT_NE(SW_StRegValues.oldavgLyrTempR[k], SW_MISSING);
     }
 
     // ptr_stError should be set to TRUE if soil_temperature_today fails (i.e. unrealistic temp values)
@@ -537,27 +571,28 @@ namespace {
     airTemp = 1500.;
 
     SW_ST_setup_run(
-      &SW_All.StRegValues,
-      &SW_All.Site,
+      &SW_StRegValues,
+      &SW_Site,
       &ptr_stError,
-      &SW_All.StRegValues.soil_temp_init,
+      &SW_StRegValues.soil_temp_init,
       airTemp,
       swc,
       &surfaceTemp,
       sTemp,
-      SW_All.SoilWat.lyrFrozen,
+      lyrFrozen,
       &LogInfo
     );
 
     EXPECT_EQ(ptr_stError, swFALSE);
 
-    soil_temperature(&SW_All.StRegValues,
-      &surface_max, &surface_max, SW_All.SoilWat.lyrFrozen,
+    soil_temperature(
+      &SW_StRegValues,
+      &surface_max, &surface_max, lyrFrozen,
       airTemp, pet, aet, biomass, swc, swc_sat, bDensity, width,
       sTemp, &surfaceTemp, nlyrs, bmLimiter, t1Param1, t1Param2, t1Param3,
       csParam1, csParam2, shParam, snowdepth, sTconst, deltaX, theMaxDepth,
-      nRgr, snow, max_air_temp, min_air_temp, H_gt, SW_All.Model.year,
-      SW_All.Model.doy, min_temp, max_temp, &ptr_stError, &LogInfo);
+      nRgr, snow, max_air_temp, min_air_temp, H_gt, year,
+      doy, min_temp, max_temp, &ptr_stError, &LogInfo);
 
     // Check that error has occurred as indicated by ptr_stError
     EXPECT_EQ(ptr_stError, swTRUE);
@@ -566,13 +601,24 @@ namespace {
   // Test main soil temperature function 'soil_temperature'
   // AND lyrTemp_to_lyrSoil_temperature as this function
   // is only called in the soil_temperature function
-  TEST_F(AllTest, SWFlowTempMainSoilTemperatureFunction_LyrMAX) {
+  TEST(SWFlowTempTest, SWFlowTempMainSoilTemperatureFunction_LyrMAX) {
+    ST_RGR_VALUES SW_StRegValues;
+    SW_ST_init_run(&SW_StRegValues);
+
+    SW_SITE SW_Site;
+
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
+
+    RealD lyrFrozen[MAX_LAYERS] = {0};
+
+
     // *****  Test when nlyrs = MAX_LAYERS  ***** //
     pcg32_random_t soilTemp_rng;
     RandSeed(0u, 0u, &soilTemp_rng);
 
 
-    unsigned int i, k;
+    unsigned int i, k, year = 1980, doy = 1;
 
     // intialize values
     unsigned int nRgr = 65;
@@ -595,42 +641,47 @@ namespace {
     double *swc_sat2 = new double[nlyrs2];
     double *min_temp = new double[nlyrs2];
     double *max_temp = new double[nlyrs2];
-    for (i = 0; i < nlyrs2; i++) {
-      SW_All.Site.avgLyrTempInit[i] = sTempInit3[i];
-      // SWC(wilting point): width > swc_wp > 0
-      SW_All.Site.swcBulk_wiltpt[i] = 0.1 * width2[i];
-      // SWC(field capacity): width > swc_fc > swc_wp
-      SW_All.Site.swcBulk_fieldcap[i] =
-           fminf(width2[i], SW_All.Site.swcBulk_wiltpt[i] + 0.15 * width2[i]);
-      // SWC(saturation): width > swc_sat > swc_fc
-      SW_All.Site.swcBulk_saturated[i] =
-          fminf(width2[i], SW_All.Site.swcBulk_fieldcap[i] + 0.2 * width2[i]);
-      // SWC: swc_sat >= SWC > 0; here, swc_fc >= SWC >= swc_wp
-      swc2[i] = RandUniFloatRange(SW_All.Site.swcBulk_wiltpt[i],
-                              SW_All.Site.swcBulk_fieldcap[i], &soilTemp_rng);
 
-      SW_All.Site.soilBulk_density[i] = 1.;
-      SW_All.Site.width[i] = width2[i];
-      SW_All.Site.swcBulk_fieldcap[0] = 2.6;
-      SW_All.Site.swcBulk_wiltpt[0] = 1.0;
-      SW_All.Site.stDeltaX = 15;
-      SW_All.Site.stMaxDepth = 990.;
+    SW_Site.n_layers = nlyrs2;
+    SW_Site.stNRGR = nRgr;
+
+    for (i = 0; i < nlyrs2; i++) {
+      SW_Site.avgLyrTempInit[i] = sTempInit3[i];
+      // SWC(wilting point): width > swc_wp > 0
+      SW_Site.swcBulk_wiltpt[i] = 0.1 * width2[i];
+      // SWC(field capacity): width > swc_fc > swc_wp
+      SW_Site.swcBulk_fieldcap[i] =
+           fminf(width2[i], SW_Site.swcBulk_wiltpt[i] + 0.15 * width2[i]);
+      // SWC(saturation): width > swc_sat > swc_fc
+      SW_Site.swcBulk_saturated[i] =
+          fminf(width2[i], SW_Site.swcBulk_fieldcap[i] + 0.2 * width2[i]);
+      // SWC: swc_sat >= SWC > 0; here, swc_fc >= SWC >= swc_wp
+      swc2[i] = RandUniFloatRange(SW_Site.swcBulk_wiltpt[i],
+                              SW_Site.swcBulk_fieldcap[i], &soilTemp_rng);
+
+      SW_Site.soilBulk_density[i] = 1.;
+      SW_Site.width[i] = width2[i];
+      SW_Site.swcBulk_fieldcap[0] = 2.6;
+      SW_Site.swcBulk_wiltpt[0] = 1.0;
+      SW_Site.stDeltaX = 15;
+      SW_Site.stMaxDepth = 990.;
 
       //swprintf("\n i %u, bDensity %f, swc_sat %f, fc %f, swc %f,  wp %f",
       //  i, bDensity2[i],  swc_sat2[i], fc2[i], swc2[i], wp2[i] );
     }
-    SW_All.Site.n_layers = nlyrs2;
+
+    SW_Site.Tsoil_constant = 4.15;
 
     SW_ST_setup_run(
-      &SW_All.StRegValues,
-      &SW_All.Site,
+      &SW_StRegValues,
+      &SW_Site,
       &ptr_stError,
-      &SW_All.StRegValues.soil_temp_init,
+      &SW_StRegValues.soil_temp_init,
       airTemp,
       swc2,
       &surfaceTemp,
       sTemp3,
-      SW_All.SoilWat.lyrFrozen,
+      lyrFrozen,
       &LogInfo
     );
 
@@ -638,12 +689,12 @@ namespace {
     // Test surface temp equals surface_temperature_under_snow() because snow > 0
     snowdepth = 5;
 
-    soil_temperature(&SW_All.StRegValues, &surface_max, &surface_min,
-      SW_All.SoilWat.lyrFrozen, airTemp, pet, aet, biomass, swc2, swc_sat2,
+    soil_temperature(&SW_StRegValues, &surface_max, &surface_min,
+      lyrFrozen, airTemp, pet, aet, biomass, swc2, swc_sat2,
       bDensity2, width2, sTemp3, &surfaceTemp, nlyrs2, bmLimiter, t1Param1,
       t1Param2, t1Param3, csParam1, csParam2, shParam, snowdepth, sTconst,
       deltaX, theMaxDepth, nRgr, snow, max_air_temp, min_air_temp, H_gt,
-      SW_All.Model.year, SW_All.Model.doy, min_temp, max_temp, &ptr_stError,
+      year, doy, min_temp, max_temp, &ptr_stError,
       &LogInfo);
 
     EXPECT_EQ(surfaceTemp, surface_temperature_under_snow(airTemp, snow));
@@ -657,12 +708,12 @@ namespace {
       sTemp3[k] = sTempInit3[k];
     }
 
-    soil_temperature(&SW_All.StRegValues, &surface_max, &surface_min,
-      SW_All.SoilWat.lyrFrozen, airTemp, pet, aet, biomass, swc2, swc_sat2,
+    soil_temperature(&SW_StRegValues, &surface_max, &surface_min,
+      lyrFrozen, airTemp, pet, aet, biomass, swc2, swc_sat2,
       bDensity2, width2, sTemp3, &surfaceTemp, nlyrs2, bmLimiter, t1Param1,
       t1Param2, t1Param3, csParam1, csParam2, shParam, snowdepth, sTconst,
       deltaX, theMaxDepth, nRgr, snow, max_air_temp, min_air_temp, H_gt,
-      SW_All.Model.year, SW_All.Model.doy, min_temp, max_temp, &ptr_stError,
+      year, doy, min_temp, max_temp, &ptr_stError,
       &LogInfo);
 
     EXPECT_EQ(surfaceTemp, airTemp + (t1Param1 * pet * (1. - (aet / pet)) * (1. - (biomass / bmLimiter))));
@@ -672,15 +723,15 @@ namespace {
     //Test surface temp equals equation when biomass < blimititer & snow = 0
     biomass = 305;
     for (k = 0; k < nlyrs2; k++) {
-      sTemp3[k] = SW_All.Site.avgLyrTempInit[k];
+      sTemp3[k] = SW_Site.avgLyrTempInit[k];
     }
 
-    soil_temperature(&SW_All.StRegValues, &surface_max, &surface_min,
-      SW_All.SoilWat.lyrFrozen, airTemp, pet, aet, biomass, swc2, swc_sat2,
+    soil_temperature(&SW_StRegValues, &surface_max, &surface_min,
+      lyrFrozen, airTemp, pet, aet, biomass, swc2, swc_sat2,
       bDensity2, width2, sTemp3, &surfaceTemp, nlyrs2, bmLimiter, t1Param1,
       t1Param2, t1Param3, csParam1, csParam2, shParam, snowdepth, sTconst,
       deltaX, theMaxDepth, nRgr, snow, max_air_temp, min_air_temp, H_gt,
-      SW_All.Model.year, SW_All.Model.doy, min_temp, max_temp, &ptr_stError,
+      year, doy, min_temp, max_temp, &ptr_stError,
       &LogInfo);
 
     EXPECT_EQ(surfaceTemp, airTemp + ((t1Param2 * (biomass - bmLimiter)) / t1Param3));
@@ -701,8 +752,8 @@ namespace {
     // Expect that sTempInitR is updated to sTempR for the next day
     for (k = 0; k <= nRgr + 1; k++)
     {
-      //swprintf("\n k %u, newoldtempR %f", k, SW_All.StRegValues.oldavgLyrTempR[k]);
-      EXPECT_NE(SW_All.StRegValues.oldavgLyrTempR[k], SW_MISSING);
+      //swprintf("\n k %u, newoldtempR %f", k, SW_StRegValues.oldavgLyrTempR[k]);
+      EXPECT_NE(SW_StRegValues.oldavgLyrTempR[k], SW_MISSING);
     }
 
     double *array_list[] = { swc2, swc_sat2, min_temp, max_temp};
@@ -712,9 +763,16 @@ namespace {
   }
 
   // Test that main soil temperature functions fails when it is supposed to
-  TEST_F(AllDeathTest, SWFlowTempMainSoilTemperatureFunctionDeathTest) {
+  TEST(SWFlowTempDeathTest, SWFlowTempMainSoilTemperatureFunctionDeathTest) {
+    ST_RGR_VALUES SW_StRegValues;
+    SW_ST_init_run(&SW_StRegValues);
 
-    unsigned int nlyrs = 1, nRgr = 65;
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
+
+    RealD lyrFrozen[MAX_LAYERS] = {0};
+
+    unsigned int nlyrs = 1, nRgr = 65, year = 1980, doy = 1;
     double airTemp = 25.0, pet = 5.0, aet = 4.0, biomass = 100., surfaceTemp = 15.,
     bmLimiter = 300., t1Param1 = 15., t1Param2 = -4., t1Param3 = 600., csParam1 =0.00070,
     csParam2 = 0.00030, shParam = 0.18, snowdepth = 5, sTconst = 4.15, deltaX = 15,
@@ -727,13 +785,13 @@ namespace {
 
     // Should fail when soil_temperature was not initialized
     EXPECT_DEATH_IF_SUPPORTED(
-      soil_temperature(&SW_All.StRegValues,
-        &surface_max, &surface_min, SW_All.SoilWat.lyrFrozen,
+      soil_temperature(&SW_StRegValues,
+        &surface_max, &surface_min, lyrFrozen,
         airTemp, pet, aet, biomass, swc, swc_sat, bDensity, width,
         sTemp, &surfaceTemp, nlyrs, bmLimiter, t1Param1, t1Param2,
         t1Param3, csParam1, csParam2, shParam, snowdepth,
         sTconst, deltaX, theMaxDepth, nRgr, snow, max_air_temp,
-        min_air_temp, H_gt, SW_All.Model.year, SW_All.Model.doy,
+        min_air_temp, H_gt, year, doy,
         min_temp, max_temp, &ptr_stError, &LogInfo
       ),
       "SOILWAT2 ERROR soil temperature module was not initialized"

--- a/tests/gtests/test_SW_Markov.cc
+++ b/tests/gtests/test_SW_Markov.cc
@@ -44,65 +44,84 @@ extern void (*test_temp_correct_wetdry)(RealD *, RealD *, RealD, RealD, RealD, R
 
 namespace {
   // Test the SW_MARKOV constructor 'SW_MKV_construct'
-  TEST_F(AllTest, WeatherGeneratorConstructor) {
-    SW_MKV_construct(SW_All.Weather.rng_seed, &SW_All.Markov, &LogInfo);
+  TEST(WeatherGeneratorTest, WeatherGeneratorConstructor) {
+    SW_MARKOV SW_Markov;
+
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
+
+    int rng_seed = 8;
+
+    SW_MKV_construct(rng_seed, &SW_Markov, &LogInfo); // allocates memory
 
     // Check that at least first array elements are initialized to zero
-    EXPECT_DOUBLE_EQ(0., SW_All.Markov.wetprob[0]);
-    EXPECT_DOUBLE_EQ(0., SW_All.Markov.dryprob[0]);
-    EXPECT_DOUBLE_EQ(0., SW_All.Markov.avg_ppt[0]);
-    EXPECT_DOUBLE_EQ(0., SW_All.Markov.std_ppt[0]);
-    EXPECT_DOUBLE_EQ(0., SW_All.Markov.cfxw[0]);
-    EXPECT_DOUBLE_EQ(0., SW_All.Markov.cfxd[0]);
-    EXPECT_DOUBLE_EQ(0., SW_All.Markov.cfnw[0]);
-    EXPECT_DOUBLE_EQ(0., SW_All.Markov.cfnd[0]);
+    EXPECT_DOUBLE_EQ(0., SW_Markov.wetprob[0]);
+    EXPECT_DOUBLE_EQ(0., SW_Markov.dryprob[0]);
+    EXPECT_DOUBLE_EQ(0., SW_Markov.avg_ppt[0]);
+    EXPECT_DOUBLE_EQ(0., SW_Markov.std_ppt[0]);
+    EXPECT_DOUBLE_EQ(0., SW_Markov.cfxw[0]);
+    EXPECT_DOUBLE_EQ(0., SW_Markov.cfxd[0]);
+    EXPECT_DOUBLE_EQ(0., SW_Markov.cfnw[0]);
+    EXPECT_DOUBLE_EQ(0., SW_Markov.cfnd[0]);
 
-    SW_MKV_deconstruct(&SW_All.Markov);
+    SW_MKV_deconstruct(&SW_Markov);
   }
 
 
   // Check seeding of RNG for weather generator
-  TEST_F(AllTest, WeatherGeneratorRNGSeeding) {
-    short k, n = 18, seed = 42;
+  TEST(WeatherGeneratorTest, WeatherGeneratorRNGSeeding) {
+    SW_MARKOV SW_Markov;
+
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
+
+    char *InFiles[SW_NFILES];
+    for (short file = 0; file < SW_NFILES; file++) {
+      InFiles[file] = NULL;
+    }
+
+    InFiles[eMarkovCov] = Str_Dup("Input/mkv_covar.in", &LogInfo);
+    InFiles[eMarkovProb] = Str_Dup("Input/mkv_prob.in", &LogInfo);
+
+    int
+      rng_seed,
+      // Turn on Markov weather generator
+      generateWeatherMethod = 2;
+
+    short k, n = 18, seed = 42, year = 1980;
     RealD
       tmax, *tmax0 = new double[n],
       tmin, *tmin0 = new double[n],
       ppt, *ppt0 = new double[n];
 
-    // Turn on Markov weather generator
-    SW_All.Weather.generateWeatherMethod = 2;
 
 
     //--- Generate some weather values with fixed seed ------
 
-    // Initialize weather generator
-    SW_All.Weather.rng_seed = seed;
-    SW_MKV_setup(&SW_All.Markov, SW_All.Weather.rng_seed,
-                 SW_All.Weather.generateWeatherMethod,
-                 PathInfo.InFiles, &LogInfo);
+    // Initialize weather generator and read input files mkv_cover and mkv_prob
+    rng_seed = seed;
+    SW_MKV_setup(&SW_Markov, rng_seed, generateWeatherMethod, InFiles, &LogInfo);
+
     ppt = 0.; // `SW_MKV_today()` uses incoming value of `ppt`
 
     for (k = 0; k < n; k++) {
-      SW_MKV_today(&SW_All.Markov, k, SW_All.Model.year,
-                   &tmax0[k], &tmin0[k], &ppt, &LogInfo);
+      SW_MKV_today(&SW_Markov, k, year, &tmax0[k], &tmin0[k], &ppt, &LogInfo);
       ppt0[k] = ppt;
     }
 
     // Reset weather generator
-    SW_MKV_deconstruct(&SW_All.Markov);
+    SW_MKV_deconstruct(&SW_Markov);
 
 
     //--- Expect that generated weather is different with time-varying seed ----
-    // Re-initialize weather generator
-    SW_All.Weather.rng_seed = 0;
-    SW_MKV_setup(&SW_All.Markov, SW_All.Weather.rng_seed,
-                 SW_All.Weather.generateWeatherMethod,
-                 PathInfo.InFiles, &LogInfo);
+    // Initialize weather generator and read input files mkv_cover and mkv_prob
+    rng_seed = 0;
+    SW_MKV_setup(&SW_Markov, rng_seed, generateWeatherMethod, InFiles, &LogInfo);
+
     ppt = 0.; // `SW_MKV_today()` uses incoming value of `ppt`
 
     for (k = 0; k < n; k++) {
-      SW_MKV_today(&SW_All.Markov, k, SW_All.Model.year,
-                   &tmax, &tmin, &ppt, &LogInfo);
+      SW_MKV_today(&SW_Markov, k, year, &tmax, &tmin, &ppt, &LogInfo);
 
       EXPECT_NE(tmax, tmax0[k]);
       EXPECT_NE(tmin, tmin0[k]);
@@ -112,20 +131,18 @@ namespace {
     }
 
     // Reset weather generator
-    SW_MKV_deconstruct(&SW_All.Markov);
+    SW_MKV_deconstruct(&SW_Markov);
 
 
     //--- Expect that generated weather is reproducible with same seed ------
-    // Re-initialize weather generator
-    SW_All.Weather.rng_seed = seed;
-    SW_MKV_setup(&SW_All.Markov, SW_All.Weather.rng_seed,
-                 SW_All.Weather.generateWeatherMethod,
-                 PathInfo.InFiles, &LogInfo);
+    // Initialize weather generator and read input files mkv_cover and mkv_prob
+    rng_seed = seed;
+    SW_MKV_setup(&SW_Markov, rng_seed, generateWeatherMethod, InFiles, &LogInfo);
+
     ppt = 0.; // `SW_MKV_today()` uses incoming value of `ppt`
 
     for (k = 0; k < n; k++) {
-      SW_MKV_today(&SW_All.Markov, k, SW_All.Model.year,
-                   &tmax, &tmin, &ppt, &LogInfo);
+      SW_MKV_today(&SW_Markov, k, year, &tmax, &tmin, &ppt, &LogInfo);
 
       EXPECT_DOUBLE_EQ(tmax, tmax0[k]);
       EXPECT_DOUBLE_EQ(tmin, tmin0[k]);
@@ -133,19 +150,31 @@ namespace {
     }
 
 
+    // Reset weather generator
+    SW_MKV_deconstruct(&SW_Markov);
+
+
     // Deallocate arrays
     delete[] tmax0;
     delete[] tmin0;
     delete[] ppt0;
+
+    SW_F_deconstruct(InFiles);
   }
 
 
   // Test drawing multivariate normal variates for daily maximum/minimum temp
-  TEST_F(AllTest, WeatherGeneratormvnorm) {
+  TEST(WeatherGeneratorTest, WeatherGeneratormvnorm) {
+    SW_MARKOV SW_Markov;
+
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
+
+    int rng_seed = 9;
     short k, n = 3;
     RealD tmax = 0., tmin = 0., tval;
 
-    SW_MKV_construct(SW_All.Weather.rng_seed, &SW_All.Markov, &LogInfo); // initialize markov_rng
+    SW_MKV_construct(rng_seed, &SW_Markov, &LogInfo); // initialize markov_rng
 
     for (k = 0; k < n; k++) {
       // Create temperature values: here with n = 3: -10, 0, +10
@@ -153,56 +182,68 @@ namespace {
 
       // Case: wtmax = wtmin, variance = 0, covar = 0 ==> input = output
       (test_mvnorm)(&tmax, &tmin, tval, tval, 0., 0., 0.,
-                    &SW_All.Markov.markov_rng, &LogInfo);
+                    &SW_Markov.markov_rng, &LogInfo);
       EXPECT_DOUBLE_EQ(tmax, tval);
       EXPECT_DOUBLE_EQ(tmin, tval);
       EXPECT_DOUBLE_EQ(tmin, tmax);
 
       // Case: wtmax = wtmin, variance = 0, covar > 0 ==> input = output
       (test_mvnorm)(&tmax, &tmin, tval, tval, 0., 0., 1.,
-                    &SW_All.Markov.markov_rng, &LogInfo);
+                    &SW_Markov.markov_rng, &LogInfo);
       EXPECT_DOUBLE_EQ(tmax, tval);
       EXPECT_DOUBLE_EQ(tmin, tval);
       EXPECT_DOUBLE_EQ(tmin, tmax);
 
       // Case: wtmax > wtmin, variance > 0, covar > 0 ==> tmin <= tmax
       (test_mvnorm)(&tmax, &tmin, tval + 1., tval, 1., 1., 1.,
-                    &SW_All.Markov.markov_rng, &LogInfo);
+                    &SW_Markov.markov_rng, &LogInfo);
       EXPECT_LE(tmin, tmax);
 
       // Case: wtmax < wtmin, variance > 0, covar > 0 ==> tmin == tmax
       (test_mvnorm)(&tmax, &tmin, tval - 1., tval, 1., 1., 1.,
-                    &SW_All.Markov.markov_rng, &LogInfo);
+                    &SW_Markov.markov_rng, &LogInfo);
       EXPECT_DOUBLE_EQ(tmin, tmax);
     }
 
-    SW_MKV_deconstruct(&SW_All.Markov);
+    SW_MKV_deconstruct(&SW_Markov);
   }
 
-  TEST_F(AllDeathTest, WeatherGeneratormvnormDeathTest) {
+  TEST(WeatherGeneratorDeathTest, WeatherGeneratormvnormDeathTest) {
+    SW_MARKOV SW_Markov;
+
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
+
+    int rng_seed = 11;
     RealD tmax = 0., tmin = 0.;
 
-    SW_MKV_construct(SW_All.Weather.rng_seed, &SW_All.Markov, &LogInfo); // initialize markov_rng
+    SW_MKV_construct(rng_seed, &SW_Markov, &LogInfo); // initialize markov_rng
 
     // Case: (wT_covar ^ 2 / wTmax_var) > wTmin_var --> LOGFATAL
     EXPECT_DEATH_IF_SUPPORTED(
       (test_mvnorm)(&tmax, &tmin, 0., 0., 1., 1., 2.,
-                                &SW_All.Markov.markov_rng, &LogInfo),
+                                &SW_Markov.markov_rng, &LogInfo),
       "Bad covariance matrix"
     );
 
-    SW_MKV_deconstruct(&SW_All.Markov);
+    SW_MKV_deconstruct(&SW_Markov);
   }
 
 
   // Test correcting daily temperatures for wet/dry days
-  TEST_F(AllTest, WeatherGeneratorWetDryTemperatureCorrection) {
+  TEST(WeatherGeneratorTest, WeatherGeneratorWetDryTemperatureCorrection) {
+    SW_MARKOV SW_Markov;
+
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
+
+    int rng_seed = 13;
     RealD
       tmax = 0., tmin = 0., t0 = 0., t10 = 10.,
       wet = 1., dry = 0.,
       cf0 = 0., cf_pos = 5., cf_neg = -5.;
 
-    SW_MKV_construct(SW_All.Weather.rng_seed, &SW_All.Markov, &LogInfo); // initialize markov_rng
+    SW_MKV_construct(rng_seed, &SW_Markov, &LogInfo); // initialize markov_rng
 
     // Case: tmax = tmin; wet; cf_*_wet = 0 ==> input = output
     tmax = t0;
@@ -234,7 +275,7 @@ namespace {
     EXPECT_DOUBLE_EQ(tmin, fmin(tmax, t10 + cf_pos));
     EXPECT_LE(tmin, tmax);
 
-    SW_MKV_deconstruct(&SW_All.Markov);
+    SW_MKV_deconstruct(&SW_Markov);
   }
 
 } // namespace

--- a/tests/gtests/test_SW_Site.cc
+++ b/tests/gtests/test_SW_Site.cc
@@ -449,7 +449,7 @@ namespace {
     help = SW_All.Site.evap_coeff[n1];
     SW_All.Site.evap_coeff[n1] = -0.5;
     EXPECT_DEATH_IF_SUPPORTED(
-      SW_SIT_init_run(&SW_All.VegProd, &SW_All.Site, PathInfo.InFiles, &LogInfo),
+      SW_SIT_init_run(&SW_All.VegProd, &SW_All.Site, &LogInfo),
       "'bare-soil evaporation coefficient' has an invalid value"
     );
     SW_All.Site.evap_coeff[n1] = help;
@@ -457,14 +457,14 @@ namespace {
     // Check error for bad transpiration coefficient (should be [0-1])
     SW_All.Site.transp_coeff[k][n2] = 1.5;
     EXPECT_DEATH_IF_SUPPORTED(
-      SW_SIT_init_run(&SW_All.VegProd, &SW_All.Site, PathInfo.InFiles, &LogInfo),
+      SW_SIT_init_run(&SW_All.VegProd, &SW_All.Site, &LogInfo),
       "'transpiration coefficient' has an invalid value"
     );
   }
 
 
   // Test that soil transpiration regions are derived well
-  TEST_F(AllTest, SiteSoilTranspirationRegions) {
+  TEST_F(SiteStructTest, SiteSoilTranspirationRegions) {
     /* Notes:
         - SW_Site.n_layers is base1
         - soil layer information in _TranspRgnBounds is base0
@@ -592,7 +592,7 @@ namespace {
     // Inputs represent matric density
     SW_All.Site.type_soilDensityInput = SW_MATRIC;
     SW_All.Site.fractionVolBulk_gravel[0] = fcoarse;
-    SW_SIT_init_run(&SW_All.VegProd, &SW_All.Site, PathInfo.InFiles, &LogInfo);
+    SW_SIT_init_run(&SW_All.VegProd, &SW_All.Site, &LogInfo);
 
     EXPECT_GT(
       SW_All.Site.soilBulk_density[0],
@@ -603,7 +603,7 @@ namespace {
     // Inputs represent bulk density
     SW_All.Site.type_soilDensityInput = SW_BULK;
     SW_All.Site.fractionVolBulk_gravel[0] = fcoarse;
-    SW_SIT_init_run(&SW_All.VegProd, &SW_All.Site, PathInfo.InFiles, &LogInfo);
+    SW_SIT_init_run(&SW_All.VegProd, &SW_All.Site, &LogInfo);
 
     EXPECT_GT(
       SW_All.Site.soilBulk_density[0],
@@ -626,7 +626,7 @@ namespace {
     SW_All.Site.type_soilDensityInput = SW_MISSING;
 
     EXPECT_DEATH_IF_SUPPORTED(
-      SW_SIT_init_run(&SW_All.VegProd, &SW_All.Site,  PathInfo.InFiles, &LogInfo),
+      SW_SIT_init_run(&SW_All.VegProd, &SW_All.Site, &LogInfo),
       "Soil density type not recognized"
     );
   }

--- a/tests/gtests/test_SW_SoilWater.cc
+++ b/tests/gtests/test_SW_SoilWater.cc
@@ -21,21 +21,36 @@
 
 namespace{
   // Test the 'SW_SoilWater' function 'SW_SWC_adjust_snow'
-  TEST_F(AllTest, SoilWaterSWCadjustSnow){
-    // setup mock variables
-    SW_All.Site.TminAccu2 = 0;
-    SW_All.Model.doy = 1;
-    SW_All.Site.RmeltMax = 1;
-    SW_All.Site.RmeltMin = 0;
-    SW_All.Site.lambdasnow = .1;
-    SW_All.Site.TmaxCrit = 1;
 
-    RealD temp_min = 0, temp_max = 10, ppt = 1, rain = 1.5, snow = 1.5,
-    snowmelt = 1.2;
+  TEST(SoilWaterTest, SoilWaterSWCadjustSnow){
+    // setup variables
+    RealD
+      doy = 1,
+      temp_min = 0,
+      temp_max = 10,
+      ppt = 1,
+      rain = 1.5,
+      snow = 1.5,
+      snowmelt = 1.2,
+      temp_snow = 0,
+      snowpack[TWO_DAYS] = {0};
 
-    SW_SWC_adjust_snow(&SW_All.Weather.temp_snow, SW_All.SoilWat.snowpack,
-                       &SW_All.Site, temp_min, temp_max, ppt,
-                       SW_All.Model.doy, &rain, &snow, &snowmelt);
+    SW_SITE SW_Site;
+
+    SW_Site.TminAccu2 = 0;
+    SW_Site.RmeltMax = 1;
+    SW_Site.RmeltMin = 0;
+    SW_Site.lambdasnow = .1;
+    SW_Site.TmaxCrit = 1;
+
+
+    SW_SWC_adjust_snow(
+      &temp_snow, snowpack,
+      &SW_Site,
+      temp_min, temp_max, ppt, doy,
+      &rain, &snow, &snowmelt
+    );
+
     // when average temperature >= SW_Site.TminAccu2, we expect rain == ppt
     EXPECT_EQ(rain, 1);
     // when average temperature >= SW_All.Site.TminAccu2, we expect snow == 0
@@ -43,11 +58,15 @@ namespace{
     // when temp_snow <= SW_All.Site.TmaxCrit, we expect snowmelt == 0
     EXPECT_EQ(snowmelt, 0);
 
-    SW_All.Site.TminAccu2 = 6;
+    SW_Site.TminAccu2 = 6;
 
-    SW_SWC_adjust_snow(&SW_All.Weather.temp_snow, SW_All.SoilWat.snowpack,
-                       &SW_All.Site, temp_min, temp_max, ppt,
-                       SW_All.Model.doy, &rain, &snow, &snowmelt);
+    SW_SWC_adjust_snow(
+      &temp_snow, snowpack,
+      &SW_Site,
+      temp_min, temp_max, ppt, doy,
+      &rain, &snow, &snowmelt
+    );
+
     // when average temperature < SW_Site.TminAccu2, we expect rain == 0
     EXPECT_EQ(rain, 0);
     // when average temperature < SW_All.Site.TminAccu2, we expect snow == ppt
@@ -56,21 +75,34 @@ namespace{
     EXPECT_EQ(snowmelt, 0);
   }
 
-  TEST_F(AllTest, SoilWaterSWCadjustSnow2) {
-        // setup mock variables
-    SW_All.Site.TminAccu2 = 0;
-    SW_All.Model.doy = 1;
-    SW_All.Site.RmeltMax = 1;
-    SW_All.Site.RmeltMin = 0;
-    SW_All.Site.lambdasnow = .1;
-    SW_All.Site.TmaxCrit = 1;
+  TEST(SoilWaterTest, SoilWaterSWCadjustSnow2) {
+    RealD
+      doy = 1,
+      temp_min = 0,
+      temp_max = 22,
+      ppt = 1,
+      rain = 1.5,
+      snow = 1.5,
+      snowmelt = 1.2,
+      temp_snow = 0,
+      snowpack[TWO_DAYS] = {0};
 
-    RealD temp_min = 0, temp_max = 22, ppt = 1, rain = 1.5, snow = 1.5,
-    snowmelt = 1.2;
+    SW_SITE SW_Site;
 
-    SW_SWC_adjust_snow(&SW_All.Weather.temp_snow, SW_All.SoilWat.snowpack,
-                       &SW_All.Site, temp_min, temp_max, ppt,
-                       SW_All.Model.doy, &rain, &snow, &snowmelt);
+    SW_Site.TminAccu2 = 0;
+    SW_Site.RmeltMax = 1;
+    SW_Site.RmeltMin = 0;
+    SW_Site.lambdasnow = .1;
+    SW_Site.TmaxCrit = 1;
+
+
+    SW_SWC_adjust_snow(
+      &temp_snow, snowpack,
+      &SW_Site,
+      temp_min, temp_max, ppt, doy,
+      &rain, &snow, &snowmelt
+    );
+
     // when average temperature >= SW_Site.TminAccu2, we expect rain == ppt
     EXPECT_EQ(rain, 1);
     // when average temperature >= SW_All.Site.TminAccu2, we expect snow == 0
@@ -81,7 +113,10 @@ namespace{
 
 
   // Test the 'SW_SoilWater' functions 'SWRC_SWCtoSWP' and `SWRC_SWPtoSWC`
-  TEST_F(AllTest, SoilWaterTranslateBetweenSWCandSWP) {
+  TEST(SoilWaterTest, SoilWaterTranslateBetweenSWCandSWP) {
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
+
     // set up mock variables
     unsigned int swrc_type, ptf_type, k;
     const int em = LOGFATAL;
@@ -269,7 +304,10 @@ namespace{
 
 
   // Death Tests of 'SW_SoilWater' function 'SWRC_SWCtoSWP'
-  TEST_F(AllDeathTest, SoilWaterSWCtoSWPDeathTest) {
+  TEST(SoilWaterDeathTest, SoilWaterSWCtoSWPDeathTest) {
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
+
     // set up mock variables
     RealD
       swrcp[SWRC_PARAM_NMAX],
@@ -346,7 +384,10 @@ namespace{
 
 
   // Death Tests of 'SW_SoilWater' function 'SWRC_SWPtoSWC'
-  TEST_F(AllDeathTest, SoilWaterSWPtoSWCDeathTest) {
+  TEST(SoilWaterDeathTest, SoilWaterSWPtoSWCDeathTest) {
+    LOG_INFO LogInfo;
+    silent_tests(&LogInfo);
+
     // set up mock variables
     RealD
       swrcp[SWRC_PARAM_NMAX],

--- a/tests/gtests/test_SW_VegEstab.cc
+++ b/tests/gtests/test_SW_VegEstab.cc
@@ -11,7 +11,7 @@
 
 namespace {
   // Run a simulation with vegetation establishment turn on
-  TEST_F(AllTest, SimulateWithVegEstab) {
+  TEST_F(VegEstabFixtureTest, SimulateWithVegEstab) {
     // Turn on vegetation establishment and process inputs (but ignore use flag)
     SW_VES_read2(&SW_All.VegEstab, swTRUE, swFALSE, PathInfo.InFiles,
                  PathInfo._ProjDir, &LogInfo);

--- a/tests/gtests/test_SW_Weather.cc
+++ b/tests/gtests/test_SW_Weather.cc
@@ -25,7 +25,7 @@
 
 namespace {
 
-    TEST_F(AllTest, ReadAllWeatherDefaultValues) {
+    TEST_F(WeatherFixtureTest, WeatherDefaultValues) {
 
         // Testing to fill allHist from `SW_Weather`
         SW_SKY_read(PathInfo.InFiles, &SW_All.Sky, &LogInfo);
@@ -58,7 +58,7 @@ namespace {
         EXPECT_NEAR(SW_All.Weather.allHist[0]->ppt[0], .220000, tol6);
     }
 
-    TEST_F(AllTest, ReadAllWeatherNoMemoryLeakIfDecreasedNumberOfYears) {
+    TEST_F(WeatherFixtureTest, WeatherNoMemoryLeakIfDecreasedNumberOfYears) {
 
         // Default number of years is 31
         EXPECT_EQ(SW_All.Weather.n_years, 31);
@@ -77,7 +77,7 @@ namespace {
 
     }
 
-    TEST_F(AllTest, ReadAllWeatherSomeMissingValuesDays) {
+    TEST_F(WeatherFixtureTest, WeatherSomeMissingValuesDays) {
 
         SW_All.Weather.generateWeatherMethod = 2;
 
@@ -105,7 +105,7 @@ namespace {
 
     }
 
-    TEST_F(AllTest, ReadAllWeatherSomeMissingValuesYears) {
+    TEST_F(WeatherFixtureTest, WeatherSomeMissingValuesYears) {
 
         int year, day;
         SW_All.Weather.generateWeatherMethod = 2;
@@ -137,7 +137,7 @@ namespace {
 
     }
 
-    TEST_F(AllTest, ReadAllWeatherWeatherGeneratorOnly) {
+    TEST_F(WeatherFixtureTest, WeatherWeatherGeneratorOnly) {
 
         int year, day;
 
@@ -161,38 +161,36 @@ namespace {
                 EXPECT_TRUE(!missing(SW_All.Weather.allHist[year]->temp_max[day]));
             }
         }
-
-
-
-
     }
 
-    TEST_F(AllDeathTest, ReadAllWeatherTooManyMissingForLOCFDeathTest) {
 
-        // Change to directory without input files
-        strcpy(SW_All.Weather.name_prefix, "Input/data_weather_nonexisting/weath");
-
-        // Set LOCF (temp) + 0 (PPT) method
-        SW_All.Weather.generateWeatherMethod = 1;
-
-        SW_All.Model.startyr = 1981;
-        SW_All.Model.endyr = 1981;
-
-        SW_WTH_read(&SW_All.Weather, &SW_All.Sky, &SW_All.Model, &LogInfo);
+    TEST(WeatherStructDeathTest, ReadAllWeatherTooManyMissingForLOCFDeathTest) {
 
         // Error: too many missing values and weather generator turned off
-        EXPECT_DEATH_IF_SUPPORTED(
-          SW_WTH_finalize_all_weather(&SW_All.Markov, &SW_All.Weather,
-          SW_All.Model.cum_monthdays, SW_All.Model.days_in_month, &LogInfo),
+        EXPECT_DEATH_IF_SUPPORTED({
+            AllTestStruct sw = AllTestStruct();
+
+            // Change to directory without input files
+            strcpy(sw.SW_All.Weather.name_prefix, "Input/data_weather_nonexisting/weath");
+
+            // Set LOCF (temp) + 0 (PPT) method
+            sw.SW_All.Weather.generateWeatherMethod = 1;
+
+            sw.SW_All.Model.startyr = 1981;
+            sw.SW_All.Model.endyr = 1981;
+
+            SW_WTH_read(&sw.SW_All.Weather, &sw.SW_All.Sky, &sw.SW_All.Model, &sw.LogInfo);
+
+            SW_WTH_finalize_all_weather(
+              &sw.SW_All.Markov, &sw.SW_All.Weather,
+              sw.SW_All.Model.cum_monthdays, sw.SW_All.Model.days_in_month, &sw.LogInfo
+            );
+          },
           "more than 3 days missing in year 1981 and weather generator turned off"
         );
-
-
-
-
     }
 
-    TEST_F(AllTest, ClimateVariableClimateFromDefaultWeather) {
+    TEST_F(WeatherFixtureTest, ClimateVariableClimateFromDefaultWeather) {
 
         // This test relies on allHist from `SW_WEATHER` being already filled
         SW_CLIMATE_YEARLY climateOutput;
@@ -302,7 +300,7 @@ namespace {
 
 
 
-    TEST_F(AllTest, ClimateVariableClimateFromOneYearWeather) {
+    TEST_F(WeatherFixtureTest, ClimateVariableClimateFromOneYearWeather) {
 
         // This test relies on allHist from `SW_WEATHER` being already filled
         SW_CLIMATE_YEARLY climateOutput;
@@ -423,7 +421,7 @@ namespace {
 
     }
 
-    TEST_F(AllTest, ClimateFromDefaultWeatherSouth) {
+    TEST_F(WeatherFixtureTest, ClimateFromDefaultWeatherSouth) {
 
         /* ==================================================================
          Values for these SOILWAT2 tests and in rSOILWAT2 v6.0.0 for
@@ -548,7 +546,7 @@ namespace {
     }
 
 
-    TEST_F(AllTest, ClimateVariableClimateFromConstantWeather) {
+    TEST_F(WeatherFixtureTest, ClimateVariableClimateFromConstantWeather) {
 
         SW_CLIMATE_YEARLY climateOutput;
         SW_CLIMATE_CLIM climateAverages;
@@ -653,7 +651,7 @@ namespace {
     }
 
 
-    TEST_F(AllTest, ClimateVariableAverageTemperatureOfDriestQuarterTest) {
+    TEST_F(WeatherFixtureTest, ClimateVariableAverageTemperatureOfDriestQuarterTest) {
 
         double monthlyPPT[MAX_MONTHS] = {.5, .5, .1, .4, .9, 1.0, 1.2, 6.5, 7.5, 1.2, 4., .6};
         double monthlyTemp[MAX_MONTHS] = {-3.2, -.4, 1.2, 3.5, 7.5, 4.5, 6.5, 8.2, 2.0, 3., .1, -.3};
@@ -722,14 +720,14 @@ namespace {
 
     }
 
-    TEST_F(AllTest, WeatherReadInitialization) {
+    TEST_F(WeatherFixtureTest, WeatherReadInitialization) {
 
         SW_WTH_read(&SW_All.Weather, &SW_All.Sky, &SW_All.Model, &LogInfo);
 
         EXPECT_FLOAT_EQ(SW_All.Weather.allHist[0]->temp_max[0], -.52);
     }
 
-    TEST_F(AllTest, MonthlyWeatherInputPrioritization) {
+    TEST_F(WeatherFixtureTest, WeatherMonthlyInputPrioritization) {
         /*
            This section covers the correct prioritization of monthly input values
            instead of daily read-in values
@@ -754,7 +752,7 @@ namespace {
          EXPECT_NEAR(SW_All.Weather.allHist[yearIndex]->windspeed_daily[midJanDay], SW_All.Sky.windspeed[0], tol6);
      }
 
-     TEST_F(AllTest, DailyWeatherInputDailyGridMet) {
+     TEST_F(WeatherFixtureTest, WeatherInputDailyGridMet) {
 
          /*
             This section tests humidity-related values that can be averaged,
@@ -851,7 +849,7 @@ namespace {
          checkAllWeather(&SW_All.Weather, &LogInfo);
      }
 
-     TEST_F(AllTest, DailyWeatherInputDayMet) {
+     TEST_F(WeatherFixtureTest, WeatherInputDayMet) {
 
          /*
             This section covers the assurance that if a daily value is provided
@@ -951,7 +949,7 @@ namespace {
          checkAllWeather(&SW_All.Weather, &LogInfo);
      }
 
-     TEST_F(AllTest, DailyWeatherInputMACA) {
+     TEST_F(WeatherFixtureTest, WeatherInputMACA) {
 
          /*
             This section assures that a variable aside from humidity-related ones,
@@ -1054,7 +1052,7 @@ namespace {
          checkAllWeather(&SW_All.Weather, &LogInfo);
      }
 
-     TEST_F(AllTest, DailyLOCFInputValues) {
+     TEST_F(WeatherFixtureTest, WeatherDailyLOCFInputValues) {
 
          /*
             Since SOILWAT2 now has the ability to deal with more than
@@ -1101,7 +1099,7 @@ namespace {
         }
      }
 
-     TEST_F(AllDeathTest, MonthlyWeatherInputReasonableValuesAndFlagsDeathTest) {
+    TEST(WeatherStructDeathTest, WeatherDailyInputWrongColumnNumberDeathTest) {
          /*
             This section covers number of flags and the testing of reasonable results (`checkAllWeather()`).
 
@@ -1112,67 +1110,92 @@ namespace {
             `checkAllWeather()` should result in a crash.
           */
 
-          // Initialize any variables
-          TimeInt year = 1980;
-          double originVal;
+        // Initialize any variables
+        TimeInt year = 1980;
 
-         /* Not the same number of flags as columns */
+        /* Not the same number of flags as columns */
+        // Run death test
+        EXPECT_DEATH_IF_SUPPORTED({
+                AllTestStruct sw = AllTestStruct();
 
-         SW_WTH_read(&SW_All.Weather, &SW_All.Sky, &SW_All.Model, &LogInfo);
+                SW_WTH_read(&sw.SW_All.Weather, &sw.SW_All.Sky, &sw.SW_All.Model, &sw.LogInfo);
 
-         // Set SW_WEATHER's n_input_forcings to a number that is
-         // not the columns being read in
-         SW_All.Weather.n_input_forcings = 0;
+                // Set SW_WEATHER's n_input_forcings to a number that is
+                // not the columns being read in
+                sw.SW_All.Weather.n_input_forcings = 0;
 
-             // Run death test
-         EXPECT_DEATH_IF_SUPPORTED(
-             _read_weather_hist(
-                 year,
-                 SW_All.Weather.allHist[0],
-                 SW_All.Weather.name_prefix,
-                 SW_All.Weather.n_input_forcings,
-                 SW_All.Weather.dailyInputIndices,
-                 SW_All.Weather.dailyInputFlags,
-                 &LogInfo
-             ),
-             "Incomplete record 1"
-         );
+                _read_weather_hist(
+                    year,
+                    sw.SW_All.Weather.allHist[0],
+                    sw.SW_All.Weather.name_prefix,
+                    sw.SW_All.Weather.n_input_forcings,
+                    sw.SW_All.Weather.dailyInputIndices,
+                    sw.SW_All.Weather.dailyInputFlags,
+                    &sw.LogInfo
+                );
+            },
+            "Incomplete record 1"
+        );
+    }
 
+
+    TEST(WeatherStructDeathTest, WeatherDailyInputBadTemperatureDeathTest) {
          /* Check for value(s) that are not within reasonable range these
             tests will make use of `checkAllWeather()` */
 
          // Edit SW_WEATHER_HIST values from their original value
-             // Make temperature unreasonable (not within [-100, 100])
 
-         originVal = SW_All.Weather.allHist[0]->temp_max[0];
+        EXPECT_DEATH_IF_SUPPORTED({
+                AllTestStruct sw = AllTestStruct();
 
-         SW_All.Weather.allHist[0]->temp_max[0] = -102.;
+                SW_WTH_read(&sw.SW_All.Weather, &sw.SW_All.Sky, &sw.SW_All.Model, &sw.LogInfo);
 
-         EXPECT_DEATH_IF_SUPPORTED(
-             checkAllWeather(&SW_All.Weather, &LogInfo),
-             "Daily input value for minimum temperature is greater than daily input value for maximum temperature"
-         );
+                // Make temperature unreasonable (not within [-100, 100])
+                sw.SW_All.Weather.allHist[0]->temp_max[0] = -102.;
 
-             // Make precipitation unresonable (< 0)
-         SW_All.Weather.allHist[0]->temp_max[0] = originVal;
+                checkAllWeather(&sw.SW_All.Weather, &sw.LogInfo);
+            },
+            "Daily input value for minimum temperature is greater than daily input value for maximum temperature"
+        );
+    }
 
-         originVal = SW_All.Weather.allHist[0]->ppt[0];
+    TEST(WeatherStructDeathTest, WeatherDailyInputBadPrecipitationDeathTest) {
+         /* Check for value(s) that are not within reasonable range these
+            tests will make use of `checkAllWeather()` */
 
-         SW_All.Weather.allHist[0]->ppt[0] = -1.;
+         // Edit SW_WEATHER_HIST values from their original value
 
-         EXPECT_DEATH_IF_SUPPORTED(
-             checkAllWeather(&SW_All.Weather, &LogInfo),
-             "Invalid daily precipitation value"
-         );
+        EXPECT_DEATH_IF_SUPPORTED({
+                AllTestStruct sw = AllTestStruct();
 
-             // Make relative humidity unreasonable (< 0%)
-         SW_All.Weather.allHist[0]->ppt[0] = originVal;
+                SW_WTH_read(&sw.SW_All.Weather, &sw.SW_All.Sky, &sw.SW_All.Model, &sw.LogInfo);
 
-         SW_All.Weather.allHist[0]->r_humidity_daily[0] = -.1252;
+                // Make precipitation unresonable (< 0)
+                sw.SW_All.Weather.allHist[0]->ppt[0] = -1.;
 
-         EXPECT_DEATH_IF_SUPPORTED(
-             checkAllWeather(&SW_All.Weather, &LogInfo),
-             "relative humidity value did not fall in the range"
-         );
-     }
+                checkAllWeather(&sw.SW_All.Weather, &sw.LogInfo);
+            },
+            "Invalid daily precipitation value"
+        );
+    }
+
+    TEST(WeatherStructDeathTest, WeatherDailyInputBadHumidityDeathTest) {
+         /* Check for value(s) that are not within reasonable range these
+            tests will make use of `checkAllWeather()` */
+
+         // Edit SW_WEATHER_HIST values from their original value
+
+        EXPECT_DEATH_IF_SUPPORTED({
+                AllTestStruct sw = AllTestStruct();
+
+                SW_WTH_read(&sw.SW_All.Weather, &sw.SW_All.Sky, &sw.SW_All.Model, &sw.LogInfo);
+
+                // Make relative humidity unreasonable (< 0%)
+                sw.SW_All.Weather.allHist[0]->r_humidity_daily[0] = -.1252;
+
+                checkAllWeather(&sw.SW_All.Weather, &sw.LogInfo);
+            },
+            "relative humidity value did not fall in the range"
+        );
+    }
 }

--- a/tests/gtests/test_Times.cc
+++ b/tests/gtests/test_Times.cc
@@ -21,38 +21,39 @@
 #include "tests/gtests/sw_testhelpers.h"
 
 namespace{
-  TEST_F(AllTest, TimesLeapYear) {
+  TEST(TimesTest, TimesLeapYear) {
+    TimeInt
+      days_in_month[MAX_MONTHS],
+      cum_monthdays[MAX_MONTHS];
+
     unsigned int k, lpadd,
       years[] = {1900, 1980, 1981, 2000}; // noleap, leap, noleap, leap years
 
     Bool kleap,
       isleap[] = {swFALSE, swTRUE, swFALSE, swTRUE};
 
+    Time_init_model(days_in_month);
+
     // Loop through years and tests
     for (k = 0; k < length(years); k++) {
-      Time_new_year(years[k], SW_All.Model.days_in_month,
-                    SW_All.Model.cum_monthdays);
-      kleap = isleapyear(years[k]);
+      Time_new_year(years[k], days_in_month, cum_monthdays);
 
+      kleap = isleapyear(years[k]);
       lpadd = kleap ? 1 : 0;
 
       EXPECT_EQ(kleap, isleap[k]);
-      EXPECT_EQ(Time_days_in_month(Feb, SW_All.Model.days_in_month), 28 + lpadd);
+      EXPECT_EQ(Time_days_in_month(Feb, days_in_month), 28 + lpadd);
       EXPECT_EQ(Time_get_lastdoy_y(years[k]), 365 + lpadd);
 
-      EXPECT_EQ(doy2month(1, SW_All.Model.cum_monthdays), Jan); // first day of January
-      EXPECT_EQ(doy2month(59 + lpadd, SW_All.Model.cum_monthdays), Feb); // last day of February
-      EXPECT_EQ(doy2month(60 + lpadd, SW_All.Model.cum_monthdays), Mar); // first day of March
-      EXPECT_EQ(doy2month(365 + lpadd, SW_All.Model.cum_monthdays), Dec); // last day of December
+      EXPECT_EQ(doy2month(1, cum_monthdays), Jan); // first day of January
+      EXPECT_EQ(doy2month(59 + lpadd, cum_monthdays), Feb); // last day of February
+      EXPECT_EQ(doy2month(60 + lpadd, cum_monthdays), Mar); // first day of March
+      EXPECT_EQ(doy2month(365 + lpadd, cum_monthdays), Dec); // last day of December
 
-      EXPECT_EQ(doy2mday(1, SW_All.Model.cum_monthdays,
-                        SW_All.Model.days_in_month), 1); // first day of January
-      EXPECT_EQ(doy2mday(59 + lpadd, SW_All.Model.cum_monthdays,
-                        SW_All.Model.days_in_month), 28 + lpadd); // last day of February
-      EXPECT_EQ(doy2mday(60 + lpadd, SW_All.Model.cum_monthdays,
-                        SW_All.Model.days_in_month), 1); // first day of March
-      EXPECT_EQ(doy2mday(365 + lpadd, SW_All.Model.cum_monthdays,
-                        SW_All.Model.days_in_month), 31); // last day of December
+      EXPECT_EQ(doy2mday(1, cum_monthdays, days_in_month), 1); // first day of January
+      EXPECT_EQ(doy2mday(59 + lpadd, cum_monthdays, days_in_month), 28 + lpadd); // last day of February
+      EXPECT_EQ(doy2mday(60 + lpadd, cum_monthdays, days_in_month), 1); // first day of March
+      EXPECT_EQ(doy2mday(365 + lpadd, cum_monthdays, days_in_month), 31); // last day of December
 
       EXPECT_EQ(doy2week(1), 0); // first day of first (base0) 7-day period
       EXPECT_EQ(doy2week(7), 0); // last day of first 7-day period
@@ -67,11 +68,19 @@ namespace{
     return v1 + (v2 - v1) * sign * (mday - 15.) / delta_days;
   }
 
-  TEST_F(AllTest, TimesInterpolateMonthlyValues) {
+  TEST(TimesTest, TimesInterpolateMonthlyValues) {
     // point to the structure that contains cloud coverage monthly values
-    SW_SKY SW_Sky;
-    SW_SKY *xintpl = &SW_Sky;
-    SW_WEATHER_HIST xintpl_weather[1][1];
+    RealD
+      cloudcov_monthly[MAX_MONTHS],
+      // `interpolate_monthlyValues()` needs an array of length `MAX_DAYS + 1`
+      // if `interpAsBase1` is TRUE
+      cloudcov_daily[MAX_DAYS + 1];
+
+
+    TimeInt
+      days_in_month[MAX_MONTHS],
+      cum_monthdays[MAX_MONTHS];
+
     Bool interpAsBase1 = swFALSE;
 
     unsigned int i, k, doy, lpadd,
@@ -79,62 +88,69 @@ namespace{
 
     Bool isMon1;
 
+    Time_init_model(days_in_month);
+
     // Loop through years and tests
     for (k = 0; k < length(years); k++) {
-      Time_new_year(years[k], SW_All.Model.days_in_month,
-                    SW_All.Model.cum_monthdays);
+      Time_new_year(years[k], days_in_month, cum_monthdays);
       lpadd = isleapyear(years[k]) ? 1 : 0;
 
       // Test: all monthlyValues equal to 10
       //   (not affected by leap/nonleap yrs)
-      for (i = 0; i < length(xintpl -> cloudcov); i++) {
-        xintpl -> cloudcov[i] = 10;
+      for (i = 0; i < MAX_MONTHS; i++) {
+        cloudcov_monthly[i] = 10;
       }
-        xintpl_weather[0] -> cloudcov_daily[0] = SW_MISSING;
 
-      interpolate_monthlyValues(xintpl->cloudcov, interpAsBase1,
-        SW_All.Model.cum_monthdays, SW_All.Model.days_in_month,
-        xintpl_weather[0] -> cloudcov_daily);
+      cloudcov_daily[0] = SW_MISSING;
+
+      interpolate_monthlyValues(
+        cloudcov_monthly,
+        interpAsBase1,
+        cum_monthdays,
+        days_in_month,
+        cloudcov_daily
+      );
 
       // value for daily index 0 is 10 to make sure base0 is working correctly
-      EXPECT_NEAR(xintpl_weather[0] -> cloudcov_daily[0], 10.0, tol9);
+      EXPECT_NEAR(cloudcov_daily[0], 10.0, tol9);
 
       // Expect all xintpld values to be the same (constant input)
       for (doy = 0; doy < Time_get_lastdoy_y(years[k]); doy++) {
-        EXPECT_NEAR(xintpl_weather[0] -> cloudcov_daily[doy], 10.0, tol9);
+        EXPECT_NEAR(cloudcov_daily[doy], 10.0, tol9);
       }
 
       // Zero the first value in "cloudcov_daily" for testing on base1 interpolation
-      xintpl_weather[0] -> cloudcov_daily[0] = 0.;
+      cloudcov_daily[0] = 0.;
 
-      interpolate_monthlyValues(xintpl->cloudcov, swTRUE,
-        SW_All.Model.cum_monthdays, SW_All.Model.days_in_month,
-        xintpl_weather[0] -> cloudcov_daily);
+      interpolate_monthlyValues(
+        cloudcov_monthly,
+        swTRUE,
+        cum_monthdays,
+        days_in_month,
+        cloudcov_daily
+      );
 
       // Value for daily index 0 is unchanged because we use here a base1 index
-      EXPECT_NEAR(xintpl_weather[0] -> cloudcov_daily[0], 0, tol9);
-      EXPECT_NEAR(xintpl_weather[0] -> cloudcov_daily[1], 10., tol9);
+      EXPECT_NEAR(cloudcov_daily[0], 0, tol9);
+      EXPECT_NEAR(cloudcov_daily[1], 10., tol9);
 
       // Test: all monthlyValues equal to 10 except December and March are 20
       //   (affected by leap/nonleap yrs)
-      xintpl -> cloudcov[Mar] = 20;
-      xintpl -> cloudcov[Dec] = 20;
+      cloudcov_monthly[Mar] = 20;
+      cloudcov_monthly[Dec] = 20;
 
-      interpolate_monthlyValues(xintpl -> cloudcov, interpAsBase1,
-        SW_All.Model.cum_monthdays, SW_All.Model.days_in_month,
-        xintpl_weather[0] -> cloudcov_daily);
+      interpolate_monthlyValues(
+        cloudcov_monthly,
+        interpAsBase1,
+        cum_monthdays,
+        days_in_month,
+        cloudcov_daily
+      );
 
-      /* for (doy = 1; doy <= Time_get_lastdoy_y(years[k]); doy++) {
-        printf(
-          "yr=%d/doy=%d/mday=%d: val=%.6f\n",
-          years[k], doy, doy2mday(doy),
-          xintpl -> cloudcov_daily[doy]
-        );
-      } */
 
 
       // value for daily index 0 is ~14.5161 to make sure base0 is working correctly
-      EXPECT_NEAR(xintpl_weather[0] -> cloudcov_daily[0], 14.516129032, tol9);
+      EXPECT_NEAR(cloudcov_daily[0], 14.516129032, tol9);
 
       // Expect mid-Nov to mid-Jan and mid-Feb to mid-Apr values to vary,
       // all other are the same
@@ -142,57 +158,61 @@ namespace{
       // Expect Jan 1 to Jan 15 to vary
       for (doy = 0; doy < 15; doy++) {
         EXPECT_NEAR(
-          xintpl_weather[0] -> cloudcov_daily[doy],
-          valXd(10, 20, -1, doy2mday(doy + 1, SW_All.Model.cum_monthdays,
-                                     SW_All.Model.days_in_month), 31),
+          cloudcov_daily[doy],
+          valXd(
+            10,
+            20,
+            -1,
+            doy2mday(doy + 1, cum_monthdays, days_in_month),
+            31
+          ),
           tol9
         );
       }
 
       // Expect Jan 15 to Feb 15 to have same values as the constant input
       for (doy = 14; doy < 45; doy++) {
-        EXPECT_NEAR(xintpl_weather[0] -> cloudcov_daily[doy], 10.0, tol9);
+        EXPECT_NEAR(cloudcov_daily[doy], 10.0, tol9);
       }
 
       // Expect Feb 16 to March 15 to vary (account for leap years)
       for (doy = 45; doy < 74 + lpadd; doy++) {
         isMon1 = (Bool)(doy <= 58 + lpadd);
+
         EXPECT_NEAR(
-          xintpl_weather[0] -> cloudcov_daily[doy],
+          cloudcov_daily[doy],
           valXd(
             isMon1 ? 10 : 20,
             isMon1 ? 20 : 10,
             isMon1 ? 1 : -1,
-            doy2mday(doy + 1, SW_All.Model.cum_monthdays,
-                     SW_All.Model.days_in_month),
+            doy2mday(doy + 1, cum_monthdays, days_in_month),
             28 + lpadd
           ),
           tol9
-        ) << "year = " << years[k] << " doy = " << doy << " mday = " << doy2mday(doy + 1,
-                                    SW_All.Model.cum_monthdays, SW_All.Model.days_in_month);
+        ) << "year = " << years[k] << " doy = " << doy << " mday = " <<
+          doy2mday(doy + 1, cum_monthdays, days_in_month);
       }
 
       // Expect Apr 15 to Nov 15 to have same values as the constant input
       for (doy = 104 + lpadd; doy < 319 + lpadd; doy++) {
-        EXPECT_NEAR(xintpl_weather[0] -> cloudcov_daily[doy], 10.0, tol9);
+        EXPECT_NEAR(cloudcov_daily[doy], 10.0, tol9);
       }
 
       // Expect Dec 1 to Dec 31 to vary
       for (doy = 335 + lpadd; doy < 365 + lpadd; doy++) {
         isMon1 = (Bool)(doy < 349 + lpadd);
         EXPECT_NEAR(
-          xintpl_weather[0] -> cloudcov_daily[doy],
+          cloudcov_daily[doy],
           valXd(
             20, // Dec value
             10, // Nov or Jan value
             isMon1 ? -1 : 1,
-            doy2mday(doy + 1, SW_All.Model.cum_monthdays,
-                     SW_All.Model.days_in_month),
+            doy2mday(doy + 1, cum_monthdays, days_in_month),
             isMon1 ? 30 : 31
           ),
           tol9
-        ) << "year = " << years[k] << " doy = " << doy << " mday = " << doy2mday(doy + 1,
-                                    SW_All.Model.cum_monthdays, SW_All.Model.days_in_month);
+        ) << "year = " << years[k] << " doy = " << doy << " mday = " <<
+          doy2mday(doy + 1, cum_monthdays, days_in_month);
       }
     }
   }

--- a/tests/gtests/test_WaterBalance.cc
+++ b/tests/gtests/test_WaterBalance.cc
@@ -45,7 +45,7 @@ namespace {
       ii) Summarize checks added to debugging code of 'SW_SWC_water_flow' (which is
           compiled if flag 'SWDEBUG' is defined)
   */
-  TEST_F(AllTest, WaterBalanceExample1) { // default run == 'testing' example1
+  TEST_F(WaterBalanceFixtureTest, WaterBalanceExample1) { // default run == 'testing' example1
     int i;
 
     // Run the simulation
@@ -60,7 +60,7 @@ namespace {
   }
 
 
-  TEST_F(AllTest, WaterBalanceWithSoilTemperature) {
+  TEST_F(WaterBalanceFixtureTest, WaterBalanceWithSoilTemperature) {
     int i;
 
     // Turn on soil temperature simulations
@@ -78,7 +78,7 @@ namespace {
   }
 
 
-  TEST_F(AllTest, WithPondedWaterRunonRunoff) {
+  TEST_F(WaterBalanceFixtureTest, WaterBalanceWithPondedWaterRunonRunoff) {
     int i;
 
     // Turn on impermeability of first soil layer, runon, and runoff
@@ -99,7 +99,7 @@ namespace {
 
 
 
-  TEST_F(AllTest, WaterBalanceWithWeatherGeneratorOnly) {
+  TEST_F(WaterBalanceFixtureTest, WaterBalanceWithWeatherGeneratorOnly) {
     int i;
 
     // Turn on Markov weather generator (and turn off use of historical weather)
@@ -131,7 +131,7 @@ namespace {
   }
 
 
-  TEST_F(AllTest, WaterBalanceWithWeatherGeneratorForSomeMissingValues) {
+  TEST_F(WaterBalanceFixtureTest, WaterBalanceWithWeatherGeneratorForSomeMissingValues) {
     int i;
 
     // Turn on Markov weather generator
@@ -162,7 +162,7 @@ namespace {
   }
 
 
-  TEST_F(AllTest, WaterBalanceWithHighGravelVolume) {
+  TEST_F(WaterBalanceFixtureTest, WaterBalanceWithHighGravelVolume) {
     int i;
     LyrIndex s;
 
@@ -187,7 +187,7 @@ namespace {
   }
 
 
-  TEST_F(AllTest, WaterBalanceWithOneSoilLayer) {
+  TEST_F(WaterBalanceFixtureTest, WaterBalanceWithOneSoilLayer) {
     int i;
 
     // Setup one soil layer
@@ -213,7 +213,7 @@ namespace {
   }
 
 
-  TEST_F(AllTest, WaterBalanceWithMaxSoilLayers) {
+  TEST_F(WaterBalanceFixtureTest, WaterBalanceWithMaxSoilLayers) {
     int i;
 
     // Setup maximum number of soil layers
@@ -239,7 +239,7 @@ namespace {
   }
 
 
-  TEST_F(AllTest, WaterBalanceWithVegetationFromClimate1) {
+  TEST_F(WaterBalanceFixtureTest, WaterBalanceWithVegetationFromClimate1) {
     int i;
 
     // Select method to estimate vegetation from long-term climate
@@ -260,7 +260,7 @@ namespace {
     }
   }
 
-  TEST_F(AllTest, WaterBalanceWithSWRCvanGenuchten1980) {
+  TEST_F(WaterBalanceFixtureTest, WaterBalanceWithSWRCvanGenuchten1980) {
     int i;
 
     // Set SWRC and PTF (and SWRC parameter input filename)
@@ -292,7 +292,7 @@ namespace {
 
 
 
-  TEST_F(AllTest, WaterBalanceWithSWRCFXW) {
+  TEST_F(WaterBalanceFixtureTest, WaterBalanceWithSWRCFXW) {
     int i;
 
     // Set SWRC and PTF (and SWRC parameter input filename)
@@ -323,7 +323,7 @@ namespace {
   }
 
 
-  TEST_F(AllTest, WaterBalanceWithDaymet) {
+  TEST_F(WaterBalanceFixtureTest, WaterBalanceWithDaymet) {
     int i;
 
     // Point to Daymet weather data
@@ -362,7 +362,7 @@ namespace {
   }
 
 
-  TEST_F(AllTest, WaterBalanceWithGRIDMET) {
+  TEST_F(WaterBalanceFixtureTest, WaterBalanceWithGRIDMET) {
     int i;
 
     // Point to gridMET weather data
@@ -405,7 +405,7 @@ namespace {
   }
 
 
-  TEST_F(AllTest, WaterBalanceWithMACA) {
+  TEST_F(WaterBalanceFixtureTest, WaterBalanceWithMACA) {
     int i;
 
     // Point to MACA weather data

--- a/tests/gtests/test_WaterBalance.cc
+++ b/tests/gtests/test_WaterBalance.cc
@@ -173,7 +173,7 @@ namespace {
     }
 
     // Re-calculate soils
-    SW_SIT_init_run(&SW_All.VegProd, &SW_All.Site, PathInfo.InFiles, &LogInfo);
+    SW_SIT_init_run(&SW_All.VegProd, &SW_All.Site, &LogInfo);
 
     // Run the simulation
      SW_CTL_main(&SW_All, &SW_OutputPtrs, &PathInfo, &LogInfo);
@@ -193,7 +193,6 @@ namespace {
     // Setup one soil layer
     create_test_soillayers(
       1,
-      PathInfo.InFiles,
       &SW_All.VegProd,
       &SW_All.Site,
       &LogInfo
@@ -220,7 +219,6 @@ namespace {
     // Setup maximum number of soil layers
     create_test_soillayers(
       MAX_LAYERS,
-      PathInfo.InFiles,
       &SW_All.VegProd,
       &SW_All.Site,
       &LogInfo
@@ -279,7 +277,7 @@ namespace {
     SW_SWRC_read(&SW_All.Site, PathInfo.InFiles, &LogInfo);
 
     // Update soils
-    SW_SIT_init_run(&SW_All.VegProd, &SW_All.Site, PathInfo.InFiles, &LogInfo);
+    SW_SIT_init_run(&SW_All.VegProd, &SW_All.Site, &LogInfo);
 
     // Run the simulation
      SW_CTL_main(&SW_All, &SW_OutputPtrs, &PathInfo, &LogInfo);
@@ -311,7 +309,7 @@ namespace {
     SW_SWRC_read(&SW_All.Site, PathInfo.InFiles, &LogInfo);
 
     // Update soils
-    SW_SIT_init_run(&SW_All.VegProd, &SW_All.Site, PathInfo.InFiles, &LogInfo);
+    SW_SIT_init_run(&SW_All.VegProd, &SW_All.Site, &LogInfo);
 
     // Run the simulation
      SW_CTL_main(&SW_All, &SW_OutputPtrs, &PathInfo, &LogInfo);

--- a/tests/gtests/test_generic.cc
+++ b/tests/gtests/test_generic.cc
@@ -32,7 +32,7 @@ namespace {
       2.44949, 2.738613};
   float tol = 1e-6;
 
-  TEST_F(AllTest, GenericRunningMean) {
+  TEST(GenericTest, GenericRunningMean) {
     double m_at_k = 0.;
 
     for (k = 0; k < N; k++)
@@ -42,7 +42,7 @@ namespace {
     }
   }
 
-  TEST_F(AllTest, GenericRunningSD) {
+  TEST(GenericTest, GenericRunningSD) {
     double ss, sd_at_k;
 
     for (k = 0; k < N; k++)
@@ -60,7 +60,7 @@ namespace {
     }
   }
 
-    TEST_F(AllTest, GenericUnexpectedAndExpectedCasesSD) {
+    TEST(GenericTest, GenericUnexpectedAndExpectedCasesSD) {
         double value[1] = {5.};
         double values[5] = {5.4, 3.4, 7.6, 5.6, 1.8};
         double oneValMissing[5] = {5.4, SW_MISSING, 7.6, 5.6, 1.8};
@@ -87,7 +87,7 @@ namespace {
         EXPECT_NEAR(standardDev, 2.413848, tol);
     }
 
-    TEST_F(AllTest, GenericUnexpectedAndExpectedCasesMean) {
+    TEST(GenericTest, GenericUnexpectedAndExpectedCasesMean) {
 
         double result;
         double values[5] = {1.8, 2.2, 10., 13.5, 3.2};

--- a/tests/gtests/test_rands.cc
+++ b/tests/gtests/test_rands.cc
@@ -25,7 +25,7 @@
 
 namespace {
   // This tests the uniform random number generator
-  TEST_F(AllTest, RNGUnifZeroToOneOutput) {
+  TEST(RNGTest, RNGUnifZeroToOneOutput) {
     pcg32_random_t rng71, rng71b, rng11, rng12;
     int i, n = 10;
     double min = 0., max = 1.;
@@ -67,7 +67,7 @@ namespace {
     }
   }
 
-  TEST_F(AllTest, RNGUnifFloatRangeOutput) {
+  TEST(RNGTest, RNGUnifFloatRangeOutput) {
     pcg32_random_t rng71, rng71b, rng11, rng12;
     int i, n = 10;
     float min = 7.5, max = 77.7;
@@ -119,7 +119,7 @@ namespace {
   }
 
 
-  TEST_F(AllTest, RNGUnifIntRangeOutput) {
+  TEST(RNGTest, RNGUnifIntRangeOutput) {
     pcg32_random_t rng71, rng71b, rng11, rng12;
     int i, n = 10;
     int min = 7, max = 123;
@@ -174,7 +174,7 @@ namespace {
 
 
   // This tests the normal random number generator
-  TEST_F(AllTest, RNGNormMeanSD) {
+  TEST(RNGTest, RNGNormMeanSD) {
     pcg32_random_t rng71, rng71b, rng11, rng12;
     int i, n = 10, f = 9999;
     double
@@ -239,7 +239,7 @@ namespace {
 
 
   // This tests the beta random number generator
-  TEST_F(AllTest, RNGBetaZeroToOneOutput) {
+  TEST(RNGTest, RNGBetaZeroToOneOutput) {
     pcg32_random_t ZeroToOne_rng;
     RandSeed(0u, 0u, &ZeroToOne_rng);
     EXPECT_LT(RandBeta(0.5, 2, &ZeroToOne_rng), 1);
@@ -291,7 +291,7 @@ namespace {
     }
   }
 
-  TEST_F(AllDeathTest, RNGBetaErrorsDeathTest) {
+  TEST(RNGDeathTest, RNGBetaErrorsDeathTest) {
     pcg32_random_t error_rng;
     RandSeed(0u, 0u, &error_rng);
     EXPECT_DEATH_IF_SUPPORTED(RandBeta(-0.5, 2, &error_rng), "AA <= 0.0");


### PR DESCRIPTION
- fix memory issues (close #205, close #356)
- `SW_SIT_init_run()` does not need argument `PATH_INFO *PathInfo`
- Reorganized tests
    - only use test fixtures where really needed
    - do not use test fixtures in death tests
    - new class "AllTestStruct" that behaves just like "AllTestFixture" but does not inherit from `::testing::Test` -- which can be used in death tests
    - place all relevant code inside `EXPECT_DEATH` in a compound statement -- code will otherwise be run twice (including the creation of test fixtures or constructing of a local copy of "AllTestStruct")
 - tool "check_SOILWAT2.sh" now runs additional steps with the `leaks` command