### PR TITLE
Encapsulate RNG variable in dedicated type

### DIFF
--- a/include/SW_Defines.h
+++ b/include/SW_Defines.h
@@ -22,6 +22,11 @@
 #include <math.h>  /* >= C99; for: atan(), isfinite() */
 #include "include/generic.h"
 
+#if !defined(RSOILWAT) /* rSOILWAT2 uses R's RNGs */
+#include "external/pcg/pcg_basic.h" // see https://github.com/imneme/pcg-c-basic
+#endif
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -244,6 +249,17 @@ typedef enum { eF,   /* file management */
 typedef unsigned int TimeInt;
 typedef unsigned int LyrIndex;
 typedef signed char flag;
+
+
+/* =================================================== */
+/*                   RNG structs                    */
+/* --------------------------------------------------- */
+#if defined(RSOILWAT)
+typedef int sw_random_t; /* not used by rSOILWAT2; it uses instead R's RNG */
+#else
+typedef pcg32_random_t sw_random_t;
+#endif
+
 
 #ifdef __cplusplus
 }

--- a/include/SW_datastructs.h
+++ b/include/SW_datastructs.h
@@ -13,7 +13,7 @@
 #define DATATYPES_H
 
 #include "include/SW_Defines.h"
-#include "external/pcg/pcg_basic.h"
+
 
 // Array-based output:
 #if defined(RSOILWAT) || defined(STEPWAT)
@@ -26,6 +26,7 @@
 #endif
 
 #define SW_NFILES 23 // For `InFiles`
+
 
 /* =================================================== */
 /*                   Carbon structs                    */
@@ -846,7 +847,7 @@ typedef struct {
     u_cov[MAX_WEEKS][2], /* mean weekly maximum and minimum temperature in degree Celsius */
     v_cov[MAX_WEEKS][2][2]; /* covariance matrix */
   int ppt_events; /* number of ppt events generated this year */
-  pcg32_random_t markov_rng; // used by STEPWAT2
+  sw_random_t markov_rng; // used by STEPWAT2
 
 } SW_MARKOV;
 

--- a/include/rands.h
+++ b/include/rands.h
@@ -12,7 +12,6 @@
 
 #include <stdio.h>
 #include <float.h>
-#include "external/pcg/pcg_basic.h" // see https://github.com/imneme/pcg-c-basic
 #include "include/SW_datastructs.h"
 
 #ifdef __cplusplus
@@ -32,15 +31,15 @@ typedef long RandListType;
 void RandSeed(
   unsigned long initstate,
   unsigned long initseq,
-  pcg32_random_t* pcg_rng
+  sw_random_t* pcg_rng
 );
-double RandUni(pcg32_random_t* pcg_rng);
-int RandUniIntRange(const long first, const long last, pcg32_random_t* pcg_rng);
-float RandUniFloatRange(const float min, const float max, pcg32_random_t* pcg_rng);
-double RandNorm(double mean, double stddev, pcg32_random_t* pcg_rng);
+double RandUni(sw_random_t* pcg_rng);
+int RandUniIntRange(const long first, const long last, sw_random_t* pcg_rng);
+float RandUniFloatRange(const float min, const float max, sw_random_t* pcg_rng);
+double RandNorm(double mean, double stddev, sw_random_t* pcg_rng);
 void RandUniList(long count, long first, long last, RandListType list[],
-                 pcg32_random_t* pcg_rng, LOG_INFO* LogInfo);
-float RandBeta(float aa, float bb, pcg32_random_t* pcg_rng);
+                 sw_random_t* pcg_rng, LOG_INFO* LogInfo);
+float RandBeta(float aa, float bb, sw_random_t* pcg_rng);
 
 
 #ifdef __cplusplus

--- a/makefile
+++ b/makefile
@@ -101,6 +101,7 @@ dir_build_test := $(dir_build)/test
 #------ OUTPUT NAMES
 target := SOILWAT2
 lib_sw2 := $(dir_bin)/lib$(target).a
+lib_rsw2 := $(dir_bin)/libr$(target).a
 bin_sw2 := $(dir_bin)/$(target)
 
 target_test = $(target)_test
@@ -256,7 +257,7 @@ sources_test := $(wildcard $(dir_test)/*.cc)
 objects_test := $(sources_test:$(dir_test)/%.cc=$(dir_build_test)/%.o)
 
 
-# PCG random generator files
+# PCG random generator files (not used by rSOILWAT2)
 sources_pcg := $(dir_pcg)/pcg_basic.c
 objects_lib_pcg := $(sources_pcg:$(dir_pcg)/%.c=$(dir_build_sw2)/%.o)
 objects_test_pcg := $(sources_pcg:$(dir_pcg)/%.c=$(dir_build_test)/%.o)
@@ -273,15 +274,21 @@ all : $(bin_sw2)
 
 lib : $(lib_sw2)
 
+libr : $(lib_rsw2)
+
 test : $(bin_test)
 
-.PHONY : all lib test
+.PHONY : all lib libr test
 
 
 
-#--- SOILWAT2 library (utilized by SOILWAT2, rSOILWAT2, and STEPWAT2)
+#--- SOILWAT2 library (utilized by SOILWAT2 and STEPWAT2)
 $(lib_sw2) : $(objects_lib) $(objects_lib_pcg) | $(dir_bin)
 		$(AR) -rcs $(lib_sw2) $(objects_lib) $(objects_lib_pcg)
+
+#--- SOILWAT2 library without pcg (utilized by rSOILWAT2)
+$(lib_rsw2) : $(objects_lib) | $(dir_bin)
+		$(AR) -rcs $(lib_sw2) $(objects_lib)
 
 
 #--- SOILWAT2 stand-alone executable (utilizing SOILWAT2 library)
@@ -407,7 +414,7 @@ clean_bin:
 .PHONY : clean_build
 clean_build:
 		-@$(RM) -r $(dir_build_sw2)
-		-@$(RM) -f $(bin_sw2) $(lib_sw2)
+		-@$(RM) -f $(bin_sw2) $(lib_sw2) $(lib_rsw2)
 
 .PHONY : clean_test
 clean_test:

--- a/src/SW_Markov.c
+++ b/src/SW_Markov.c
@@ -110,7 +110,7 @@ static void temp_correct_wetdry(RealD *tmax, RealD *tmin, RealD rain,
     @return Daily minimum (*tmin) and maximum (*tmax) temperature.
 */
 static void mvnorm(RealD *tmax, RealD *tmin, RealD wTmax, RealD wTmin,
-	RealD wTmax_var, RealD wTmin_var, RealD wT_covar, pcg32_random_t *markov_rng,
+	RealD wTmax_var, RealD wTmin_var, RealD wT_covar, sw_random_t *markov_rng,
 	LOG_INFO* LogInfo) {
 	/* --------------------------------------------------- */
 	/* This proc is distilled from a much more general function
@@ -178,7 +178,7 @@ static void mvnorm(RealD *tmax, RealD *tmin, RealD wTmax, RealD wTmin,
   // since `mvnorm` is static we cannot do unit tests unless we set it up
   // as an externed function pointer
   void (*test_mvnorm)(RealD *, RealD *, RealD, RealD, RealD, RealD,
-  				      RealD, pcg32_random_t*, LOG_INFO*) = &mvnorm;
+  				      RealD, sw_random_t*, LOG_INFO*) = &mvnorm;
 #endif
 
 

--- a/src/rands.c
+++ b/src/rands.c
@@ -9,8 +9,6 @@
 #include "include/myMemory.h"
 #include "include/filefuncs.h"
 
-#include "external/pcg/pcg_basic.h"
-
 
 #ifdef RSOILWAT
   // R-API requires that we use it's own random number implementation
@@ -18,6 +16,10 @@
   // and https://cran.r-project.org/doc/manuals/R-exts.html#Random-numbers
   #include <R_ext/Random.h> // for the random number generators
   #include <Rmath.h> // for rnorm()
+
+#else
+#include "external/pcg/pcg_basic.h"
+
 #endif
 
 
@@ -56,7 +58,7 @@
 void RandSeed(
   unsigned long initstate,
   unsigned long initseq,
-  pcg32_random_t* pcg_rng
+  sw_random_t* pcg_rng
 ) {
 // R uses its own random number generators
 #ifndef RSOILWAT
@@ -72,7 +74,9 @@ void RandSeed(
 
 #else
   // silence compile warnings [-Wunused-parameter]
-  if (pcg_rng == NULL && initstate > 1u && initseq > 1u) {}
+  (void) pcg_rng;
+  (void) initstate;
+  (void) initseq;
 
 #endif
 }
@@ -90,7 +94,7 @@ void RandSeed(
 
   @return A pseudo-random number between 0 and 1.
 */
-double RandUni(pcg32_random_t* pcg_rng) {
+double RandUni(sw_random_t* pcg_rng) {
 
   double res;
 
@@ -99,7 +103,7 @@ double RandUni(pcg32_random_t* pcg_rng) {
     res = ldexp(pcg32_random_r(pcg_rng), -32);
 
   #else
-    if (pcg_rng == NULL) {} // silence compile warnings [-Wunused-parameter]
+    (void) pcg_rng; // silence compile warnings [-Wunused-parameter]
 
     GetRNGstate();
     res = unif_rand();
@@ -121,7 +125,7 @@ double RandUni(pcg32_random_t* pcg_rng) {
 
 	\return Random number between the two bounds defined.
 */
-int RandUniIntRange(const long first, const long last, pcg32_random_t* pcg_rng) {
+int RandUniIntRange(const long first, const long last, sw_random_t* pcg_rng) {
 /* History:
 	Return a randomly selected integer between
 	first and last, inclusive.
@@ -158,7 +162,7 @@ int RandUniIntRange(const long first, const long last, pcg32_random_t* pcg_rng) 
     res = pcg32_boundedrand_r(pcg_rng, r) + f;
 
   #else
-    if (pcg_rng == NULL) {} // silence compile warnings [-Wunused-parameter]
+    (void) pcg_rng; // silence compile warnings [-Wunused-parameter]
 
     GetRNGstate();
     res = (long) runif(f, l);
@@ -180,7 +184,7 @@ int RandUniIntRange(const long first, const long last, pcg32_random_t* pcg_rng) 
 
 	\return Random number between first and last, inclusive.
 */
-float RandUniFloatRange(const float min, const float max, pcg32_random_t* pcg_rng) {
+float RandUniFloatRange(const float min, const float max, sw_random_t* pcg_rng) {
 /* History:
 
 	cwb - 12/5/00
@@ -235,7 +239,7 @@ float RandUniFloatRange(const float min, const float max, pcg32_random_t* pcg_rn
   \param[in] LogInfo Holds information dealing with logfile output
 */
 void RandUniList(long count, long first, long last, RandListType list[],
-                 pcg32_random_t* pcg_rng, LOG_INFO* LogInfo) {
+                 sw_random_t* pcg_rng, LOG_INFO* LogInfo) {
 
 	long i, j, c, range, *klist;
 
@@ -318,7 +322,7 @@ void RandUniList(long count, long first, long last, RandListType list[],
 	\param stddev Standard deviation of the distribution.
 	\param[in,out] *pcg_rng The random number generator to use.
 */
-double RandNorm(double mean, double stddev, pcg32_random_t* pcg_rng) {
+double RandNorm(double mean, double stddev, sw_random_t* pcg_rng) {
 /* History:
 	 cwb - 6/20/00
 	 This routine is
@@ -374,7 +378,7 @@ double RandNorm(double mean, double stddev, pcg32_random_t* pcg_rng) {
 
 
 	#else
-		if (pcg_rng == NULL) {} // silence compile warnings [-Wunused-parameter]
+		(void) pcg_rng; // silence compile warnings [-Wunused-parameter]
 
 		GetRNGstate();
 		res = rnorm(mean, stddev);
@@ -408,7 +412,7 @@ double RandNorm(double mean, double stddev, pcg32_random_t* pcg_rng) {
   \param[in,out] *pcg_rng The random number generator to use.
   \return A random variate of a beta distribution.
 */
-float RandBeta ( float aa, float bb, pcg32_random_t* pcg_rng) {
+float RandBeta ( float aa, float bb, sw_random_t* pcg_rng) {
   float a;
   float alpha;
   float b;

--- a/tests/gtests/test_SW_Flow_Lib.cc
+++ b/tests/gtests/test_SW_Flow_Lib.cc
@@ -34,13 +34,12 @@
 #include "include/SW_Weather.h"
 #include "include/SW_Markov.h"
 #include "include/SW_Sky.h"
-#include "external/pcg/pcg_basic.h"
 
 #include "include/SW_Flow_lib.h"
 
 #include "tests/gtests/sw_testhelpers.h"
 
-pcg32_random_t flow_rng;
+sw_random_t flow_rng;
 //SW_SOILWAT_OUTPUTS *swo = NULL;
 
 int k;
@@ -220,7 +219,7 @@ namespace
     double *impermeability2 = new double[nlyrs];
     double *drain2 = new double[nlyrs];
 
-    pcg32_random_t infiltrate_rng;
+    sw_random_t infiltrate_rng;
     RandSeed(0u, 0u, &infiltrate_rng);
 
     for (i = 0; i < MAX_LAYERS; i++)

--- a/tests/gtests/test_SW_Flow_Lib_PET.cc
+++ b/tests/gtests/test_SW_Flow_Lib_PET.cc
@@ -36,7 +36,6 @@
 #include "include/SW_Weather.h"
 #include "include/SW_Markov.h"
 #include "include/SW_Sky.h"
-#include "external/pcg/pcg_basic.h"
 
 #include "include/SW_Flow_lib_PET.h"
 

--- a/tests/gtests/test_SW_Flow_lib_temp.cc
+++ b/tests/gtests/test_SW_Flow_lib_temp.cc
@@ -34,14 +34,13 @@
 #include "include/SW_Weather.h"
 #include "include/SW_Markov.h"
 #include "include/SW_Sky.h"
-#include "external/pcg/pcg_basic.h"
 
 #include "include/SW_Flow_lib.h"
 
 #include "tests/gtests/sw_testhelpers.h"
 
 
-pcg32_random_t flowTemp_rng;
+sw_random_t flowTemp_rng;
 
 namespace {
 
@@ -95,7 +94,7 @@ namespace {
     double deltaX = 15.0, theMaxDepth = 990.0, sTconst = 4.15;
     unsigned int nlyrs, nRgr = 65;
     Bool ptr_stError = swFALSE;
-    pcg32_random_t STInit_rng;
+    sw_random_t STInit_rng;
     RandSeed(0u, 0u, &STInit_rng);
 
     // *****  Test when nlyrs = 1  ***** //
@@ -181,7 +180,7 @@ namespace {
     double *bDensity2 = new double[nlyrs];
     double *fc2 = new double[nlyrs];
     double *wp2 = new double[nlyrs];
-    pcg32_random_t STInitDeath_rng;
+    sw_random_t STInitDeath_rng;
     RandSeed(0u, 0u, &STInitDeath_rng);
 
     for (i = 0; i < nlyrs; i++) {
@@ -221,7 +220,7 @@ namespace {
     unsigned int nlyrs, nRgr = 65;
     Bool ptr_stError = swFALSE;
 
-    pcg32_random_t SLIF_rng;
+    sw_random_t SLIF_rng;
     RandSeed(0u, 0u, &SLIF_rng);
 
     // *****  Test when nlyrs = 1  ***** //
@@ -377,7 +376,7 @@ namespace {
     unsigned int nRgr =65, year = 1980, doy = 1;
     Bool ptr_stError = swFALSE;
 
-    pcg32_random_t STTF_rng;
+    sw_random_t STTF_rng;
     RandSeed(0u, 0u, &STTF_rng);
 
     // declare input in for loop for non-error causing conditions;
@@ -614,7 +613,7 @@ namespace {
 
 
     // *****  Test when nlyrs = MAX_LAYERS  ***** //
-    pcg32_random_t soilTemp_rng;
+    sw_random_t soilTemp_rng;
     RandSeed(0u, 0u, &soilTemp_rng);
 
 

--- a/tests/gtests/test_SW_Markov.cc
+++ b/tests/gtests/test_SW_Markov.cc
@@ -38,7 +38,7 @@
 
 
 extern void (*test_mvnorm)(RealD *, RealD *, RealD, RealD, RealD, RealD, RealD,
-                           pcg32_random_t*, LOG_INFO*);
+                           sw_random_t*, LOG_INFO*);
 extern void (*test_temp_correct_wetdry)(RealD *, RealD *, RealD, RealD, RealD, RealD, RealD);
 
 

--- a/tests/gtests/test_rands.cc
+++ b/tests/gtests/test_rands.cc
@@ -18,7 +18,6 @@
 #include "include/myMemory.h"
 #include "include/filefuncs.h"
 #include "include/rands.h"
-#include "external/pcg/pcg_basic.h"
 
 #include "tests/gtests/sw_testhelpers.h"
 
@@ -26,7 +25,7 @@
 namespace {
   // This tests the uniform random number generator
   TEST(RNGTest, RNGUnifZeroToOneOutput) {
-    pcg32_random_t rng71, rng71b, rng11, rng12;
+    sw_random_t rng71, rng71b, rng11, rng12;
     int i, n = 10;
     double min = 0., max = 1.;
     double x71, x71b, x11, x12;
@@ -68,7 +67,7 @@ namespace {
   }
 
   TEST(RNGTest, RNGUnifFloatRangeOutput) {
-    pcg32_random_t rng71, rng71b, rng11, rng12;
+    sw_random_t rng71, rng71b, rng11, rng12;
     int i, n = 10;
     float min = 7.5, max = 77.7;
     double x71, x71b, x11, x12, x0;
@@ -120,7 +119,7 @@ namespace {
 
 
   TEST(RNGTest, RNGUnifIntRangeOutput) {
-    pcg32_random_t rng71, rng71b, rng11, rng12;
+    sw_random_t rng71, rng71b, rng11, rng12;
     int i, n = 10;
     int min = 7, max = 123;
     double x71, x71b, x11, x12, x0;
@@ -175,7 +174,7 @@ namespace {
 
   // This tests the normal random number generator
   TEST(RNGTest, RNGNormMeanSD) {
-    pcg32_random_t rng71, rng71b, rng11, rng12;
+    sw_random_t rng71, rng71b, rng11, rng12;
     int i, n = 10, f = 9999;
     double
       mean = 0., sd = 1.,
@@ -240,7 +239,7 @@ namespace {
 
   // This tests the beta random number generator
   TEST(RNGTest, RNGBetaZeroToOneOutput) {
-    pcg32_random_t ZeroToOne_rng;
+    sw_random_t ZeroToOne_rng;
     RandSeed(0u, 0u, &ZeroToOne_rng);
     EXPECT_LT(RandBeta(0.5, 2, &ZeroToOne_rng), 1);
     EXPECT_LT(RandBeta(1, 3, &ZeroToOne_rng), 1);
@@ -248,7 +247,7 @@ namespace {
     EXPECT_GT(RandBeta(0.25, 1, &ZeroToOne_rng), 0);
 
 
-    pcg32_random_t rng71, rng71b, rng11, rng12;
+    sw_random_t rng71, rng71b, rng11, rng12;
     int i, n = 10;
     double
       a = 0.25, b = 2.,
@@ -292,7 +291,7 @@ namespace {
   }
 
   TEST(RNGDeathTest, RNGBetaErrorsDeathTest) {
-    pcg32_random_t error_rng;
+    sw_random_t error_rng;
     RandSeed(0u, 0u, &error_rng);
     EXPECT_DEATH_IF_SUPPORTED(RandBeta(-0.5, 2, &error_rng), "AA <= 0.0");
     EXPECT_DEATH_IF_SUPPORTED(RandBeta(1, -3, &error_rng), "BB <= 0.0");


### PR DESCRIPTION
- new type "sw_random_t"
** for rSOILWAT2 defined as "int" (but unused)
** for SOILWAT2 and STEPWAT2 defined as "pcg32_random_t" (as previously)

- "pcg_basic.h" header now only included by "SW_Defines.h" (for typedef) and by "rands.c" (function calls) -- and only if not rSOILWAT2 -> makefile has new target "libr" to build library without pcg (for rSOILWAT2)

- close #373 "rSOILWAT2 does not use PCG for random numbers - remove requirement on its presence"