### PR TITLE
Bugfix test memory leak

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -98,6 +98,8 @@
   The code gracefully ends early if the wall time reaches a limit of
   `X - SW_WRAPUPTIME` seconds; if the option `"-t X"` is absent,
   then there is (practically) no wall time limit.
+* New command line option `"-r"` to rename netCDF domain template file
+  to file name provided in `"Input_nc/files_nc.in"`.
 
 ## Changes to outputs
 * Output of establishment/recruitment for two species is now

--- a/include/SW_Main_lib.h
+++ b/include/SW_Main_lib.h
@@ -25,6 +25,7 @@ void sw_init_args(
     char **_firstfile,
     unsigned long *userSUID,
     double *wallTimeLimit,
+    Bool *renameDomainTemplateNC,
     LOG_INFO *LogInfo
 );
 

--- a/include/SW_datastructs.h
+++ b/include/SW_datastructs.h
@@ -1250,6 +1250,10 @@ typedef struct {
     char *varNC[SW_NVARNC];
     char *InFilesNC[SW_NVARNC];
 
+    /** Should a domain template netCDF file be automatically renamed
+    to provided file name for domain? */
+    Bool renameDomainTemplateNC;
+
     int ncFileIDs[SW_NVARNC];
     int ncVarIDs[SW_NVARNC];
 

--- a/include/SW_netCDF.h
+++ b/include/SW_netCDF.h
@@ -93,7 +93,9 @@ void SW_NC_check(
     SW_DOMAIN *SW_Domain, int ncFileID, const char *fileName, LOG_INFO *LogInfo
 );
 
-void SW_NC_create_domain_template(SW_DOMAIN *SW_Domain, LOG_INFO *LogInfo);
+void SW_NC_create_domain_template(
+    SW_DOMAIN *SW_Domain, char *fileName, LOG_INFO *LogInfo
+);
 
 void SW_NC_create_template(
     const char *domType,

--- a/src/SW_Control.c
+++ b/src/SW_Control.c
@@ -447,22 +447,30 @@ void SW_CTL_setup_domain(
 
 #if defined(SWNETCDF)
     // Create domain template if it does not exist (and exit)
+    char *fnameDomainTemplateNC;
+
+    fnameDomainTemplateNC = (SW_Domain->netCDFInfo.renameDomainTemplateNC) ?
+                                SW_Domain->netCDFInfo.InFilesNC[vNCdom] :
+                                NULL;
+
     if (!FileExists(SW_Domain->netCDFInfo.InFilesNC[vNCdom])) {
-        SW_NC_create_domain_template(SW_Domain, LogInfo);
+        SW_NC_create_domain_template(SW_Domain, fnameDomainTemplateNC, LogInfo);
         if (LogInfo->stopRun) {
             return; // Exit prematurely due to error
         }
 
-        LogError(
-            LogInfo,
-            LOGERROR,
-            "Domain netCDF template has been created. "
-            "Please modify it and rename it to "
-            "'domain.nc' when done and try again. "
-            "The template path is: %s",
-            DOMAIN_TEMP
-        );
-        return; // Exit prematurely so the user can modify the domain template
+        if (!SW_Domain->netCDFInfo.renameDomainTemplateNC) {
+            LogError(
+                LogInfo,
+                LOGERROR,
+                "Domain netCDF template has been created. "
+                "Please modify it and rename it to "
+                "'domain.nc' when done and try again. "
+                "The template path is: %s",
+                DOMAIN_TEMP
+            );
+            return; // Exit prematurely: user modifies the domain template
+        }
     }
 
     // Open necessary netCDF input files and check for consistency with domain

--- a/src/SW_Main.c
+++ b/src/SW_Main.c
@@ -74,6 +74,7 @@ int main(int argc, char **argv) {
         &SW_Domain.PathInfo.InFiles[eFirst],
         &userSUID,
         &SW_WallTime.wallTimeLimit,
+        &SW_Domain.netCDFInfo.renameDomainTemplateNC,
         &LogInfo
     );
     if (LogInfo.stopRun) {

--- a/src/SW_Main_lib.c
+++ b/src/SW_Main_lib.c
@@ -42,7 +42,7 @@ static void sw_print_usage(void) {
         "Ecosystem water simulation model SOILWAT2\n"
         "More details at https://github.com/Burke-Lauenroth-Lab/SOILWAT2\n"
         "Usage: ./SOILWAT2 [-d startdir] [-f files.in] [-e] [-q] [-v] [-h] "
-        "[-s 1] [-t 10]\n"
+        "[-s 1] [-t 10] [-r]\n"
         "  -d : operate (chdir) in startdir (default=.)\n"
         "  -f : name of main input file (default=files.in)\n"
         "       a preceeding path applies to all input files\n"
@@ -54,6 +54,8 @@ static void sw_print_usage(void) {
         "  -s : simulate all (0) or one (> 0) simulation unit from the domain\n"
         "       (default = 0)\n"
         "  -t : wall time limit in seconds\n"
+        "  -r : rename netCDF domain template file "
+        "[name provided in 'Input_nc/files_nc.in']\n"
     );
 }
 
@@ -89,6 +91,8 @@ void sw_print_version(void) {
 @param[out] wallTimeLimit Terminate simulations early when
             wall time limit is reached
             (default value is set by SW_WT_StartTime())
+@param[out] renameDomainTemplateNC Should a domain template netCDF file be
+            automatically renamed to provided file name for domain?
 @param[out] LogInfo Holds information on warnings and errors
 */
 void sw_init_args(
@@ -98,6 +102,7 @@ void sw_init_args(
     char **_firstfile,
     unsigned long *userSUID,
     double *wallTimeLimit,
+    Bool *renameDomainTemplateNC,
     LOG_INFO *LogInfo
 ) {
 
@@ -117,10 +122,10 @@ void sw_init_args(
     char str[1024];
 
     /* valid options */
-    char const *opts[] = {"-d", "-f", "-e", "-q", "-v", "-h", "-s", "-t"};
+    char const *opts[] = {"-d", "-f", "-e", "-q", "-v", "-h", "-s", "-t", "-r"};
 
     /* indicates options with values: 0=none, 1=required, -1=optional */
-    int valopts[] = {1, 1, 0, 0, 0, 0, 1, 1};
+    int valopts[] = {1, 1, 0, 0, 0, 0, 1, 1, 0};
 
     int i,  /* looper through all cmdline arguments */
         a,  /* current valid argument-value position */
@@ -134,6 +139,7 @@ void sw_init_args(
     }
 
     *EchoInits = swFALSE;
+    *renameDomainTemplateNC = swFALSE;
     *userSUID = 0; // Default (if no input) is 0 (i.e., all suids)
 
     a = 1;
@@ -246,6 +252,10 @@ void sw_init_args(
 
             case 7: /* -t */
                 *wallTimeLimit = atof(str);
+                break;
+
+            case 8: /* -r */
+                *renameDomainTemplateNC = swTRUE;
                 break;
 
             default:

--- a/src/SW_netCDF.c
+++ b/src/SW_netCDF.c
@@ -4108,9 +4108,13 @@ wrapUp:
 
 @param[in] SW_Domain Struct of type SW_DOMAIN holding constant
     temporal/spatial information for a set of simulation runs
+@param[in] fileName File name of the domain template netCDF file;
+    if NULL, then use the default domain template file name.
 @param[out] LogInfo Holds information on warnings and errors
 */
-void SW_NC_create_domain_template(SW_DOMAIN *SW_Domain, LOG_INFO *LogInfo) {
+void SW_NC_create_domain_template(
+    SW_DOMAIN *SW_Domain, char *fileName, LOG_INFO *LogInfo
+) {
 
     SW_NETCDF *SW_netCDF = &SW_Domain->netCDFInfo;
     int *domFileID = &SW_Domain->netCDFInfo.ncFileIDs[vNCdom];
@@ -4119,7 +4123,11 @@ void SW_NC_create_domain_template(SW_DOMAIN *SW_Domain, LOG_INFO *LogInfo) {
     int nDomainDims, domVarID = 0, YVarID = 0, XVarID = 0, sVarID = 0;
     int YBndsID = 0, XBndsID = 0;
 
-    if (FileExists(DOMAIN_TEMP)) {
+    if (isnull(fileName)) {
+        fileName = (char *) DOMAIN_TEMP;
+    }
+
+    if (FileExists(fileName)) {
         LogError(
             LogInfo,
             LOGERROR,
@@ -4136,7 +4144,7 @@ void SW_NC_create_domain_template(SW_DOMAIN *SW_Domain, LOG_INFO *LogInfo) {
     }
 #endif
 
-    if (nc_create(DOMAIN_TEMP, NC_NETCDF4, domFileID) != NC_NOERR) {
+    if (nc_create(fileName, NC_NETCDF4, domFileID) != NC_NOERR) {
         LogError(
             LogInfo,
             LOGERROR,

--- a/tests/gtests/sw_maintest.cc
+++ b/tests/gtests/sw_maintest.cc
@@ -44,7 +44,12 @@ int main(int argc, char **argv) {
         sw_printf("Invalid project directory (%s)", dir_test);
     }
 
-    setup_testGlobalSoilwatTemplate();
+    res = setup_testGlobalSoilwatTemplate();
+
+    if (res != 0) {
+        // Setup failed
+        goto finishProgram; // Exit function prematurely due to error
+    }
 
 
     //--- Setup unit tests
@@ -61,9 +66,12 @@ int main(int argc, char **argv) {
     // Run unit tests
     res = RUN_ALL_TESTS();
 
+
+finishProgram:
     teardown_testGlobalSoilwatTemplate();
 
     //--- Return output of 'RUN_ALL_TESTS()'
     // (https://google.github.io/googletest/primer.html#writing-the-main-function)
+    // It returns 0 if all tests are successful, or 1 otherwise.
     return res;
 }

--- a/tests/gtests/sw_testhelpers.cc
+++ b/tests/gtests/sw_testhelpers.cc
@@ -161,6 +161,8 @@ int setup_testGlobalSoilwatTemplate() {
     SW_DOM_init_ptrs(&template_SW_Domain);
     SW_CTL_init_ptrs(&template_SW_All);
 
+    template_SW_Domain.netCDFInfo.renameDomainTemplateNC = swTRUE;
+
     template_SW_Domain.PathInfo.InFiles[eFirst] =
         Str_Dup(DFLT_FIRSTFILE, &LogInfo);
     if (LogInfo.stopRun) {

--- a/tests/gtests/sw_testhelpers.h
+++ b/tests/gtests/sw_testhelpers.h
@@ -41,7 +41,7 @@ void create_test_soillayers(
 
 void setup_SW_Site_for_tests(SW_SITE *SW_Site);
 
-void setup_testGlobalSoilwatTemplate();
+int setup_testGlobalSoilwatTemplate();
 void teardown_testGlobalSoilwatTemplate();
 
 /* AllTestFixture is our base test fixture class inheriting from


### PR DESCRIPTION
- Fix memory leak in nc-based test program: test's `main()` now checks for success of setup and, on failure, skips running tests and cleans up resources

- Option for automatic naming of domain template netCDF file (and avoiding early end of program)
    - Simulation program via command line option `"-r"`
    - Test program activates this option (and no longer fails if compiled with `SWNETCDF` flag if "domain.nc" didn't previously exist on path)