### PR TITLE
Close open files on error within `SW_netCDF.c`

### DIFF
--- a/src/SW_Control.c
+++ b/src/SW_Control.c
@@ -1082,14 +1082,6 @@ void SW_CTL_run_sw(
     }
 
 #if defined(SWNETCDF)
-    SW_WALLTIME wallTime;
-    WallTimeSpec toutput;
-    Bool ok;
-
-    SW_WT_StartTime(&wallTime);
-
-    set_walltime(&toutput, &ok);
-
     SW_NC_write_output(
         &SW_Domain->OutDom,
         local_sw.OutRun.p_OUT,
@@ -1099,14 +1091,6 @@ void SW_CTL_run_sw(
         SW_Domain->DomainType,
         LogInfo
     );
-
-    SW_WT_TimeRun(toutput, ok, &wallTime);
-
-    SW_WT_ReportTime(wallTime, LogInfo);
-
-    printf("\n=====================");
-
-    // printf("DONE\n");
 #endif
 
 // Clear local instance of SW_RUN

--- a/src/SW_Control.c
+++ b/src/SW_Control.c
@@ -1082,6 +1082,14 @@ void SW_CTL_run_sw(
     }
 
 #if defined(SWNETCDF)
+    SW_WALLTIME wallTime;
+    WallTimeSpec toutput;
+    Bool ok;
+
+    SW_WT_StartTime(&wallTime);
+
+    set_walltime(&toutput, &ok);
+
     SW_NC_write_output(
         &SW_Domain->OutDom,
         local_sw.OutRun.p_OUT,
@@ -1091,6 +1099,14 @@ void SW_CTL_run_sw(
         SW_Domain->DomainType,
         LogInfo
     );
+
+    SW_WT_TimeRun(toutput, ok, &wallTime);
+
+    SW_WT_ReportTime(wallTime, LogInfo);
+
+    printf("\n=====================");
+
+    // printf("DONE\n");
 #endif
 
 // Clear local instance of SW_RUN

--- a/src/SW_netCDF.c
+++ b/src/SW_netCDF.c
@@ -3608,7 +3608,7 @@ void SW_NC_write_output(
                 // Get size of the "time" dimension
                 get_dimlen_from_dimname(currFileID, "time", &timeSize, LogInfo);
                 if (LogInfo->stopRun) {
-                    return; // Exit function prematurely due to error
+                    goto closeFile; // Exit function prematurely due to error
                 }
 
 
@@ -3622,7 +3622,8 @@ void SW_NC_write_output(
                     // Locate correct slice in netCDF to write to
                     get_var_identifier(currFileID, varName, &varID, LogInfo);
                     if (LogInfo->stopRun) {
-                        return; // Exit function prematurely due to error
+                        /* Exit function prematurely due to error */
+                        goto closeFile;
                     }
 
                     get_vardim_write_counts(
@@ -3639,7 +3640,8 @@ void SW_NC_write_output(
                         fileName, varName, currFileID, varID, count, LogInfo
                     );
                     if (LogInfo->stopRun) {
-                        return; // Exit function prematurely due to error
+                        /* Exit function prematurely due to error*/
+                        goto closeFile;
                     }
 #endif // SWDEBUG
 
@@ -3690,7 +3692,8 @@ void SW_NC_write_output(
                         LogInfo
                     );
                     if (LogInfo->stopRun) {
-                        return; // Exit function prematurely due to error
+                        goto closeFile; // Exit function prematurely due to
+                                        // error
                     }
                 }
 
@@ -3701,6 +3704,8 @@ void SW_NC_write_output(
             }
         }
     }
+
+closeFile: { nc_close(currFileID); }
 }
 
 /**
@@ -4955,7 +4960,7 @@ void SW_NC_read_out_vars(
 
     SW_NC_alloc_output_var_info(OutDom, LogInfo);
     if (LogInfo->stopRun) {
-        return; // Exit prematurely due to error
+        goto closeFile; // Exit prematurely due to error
     }
 
     GetALine(f, inbuf, MAX_FILENAMESIZE); // Ignore the first row (column names)
@@ -4993,7 +4998,7 @@ void SW_NC_read_out_vars(
                 scanRes,
                 NOUT_VAR_INPUTS
             );
-            return; // Exit function prematurely due to error
+            goto closeFile; // Exit function prematurely due to error
         }
 
         // Check if the variable was requested to be output
@@ -5001,7 +5006,7 @@ void SW_NC_read_out_vars(
 
         doOutputVal = sw_strtoi(input[doOutInd], MyFileName, LogInfo);
         if (LogInfo->stopRun) {
-            return; // Exit function prematurely due to error
+            goto closeFile; // Exit function prematurely due to error
         }
 
         if (doOutputVal) {
@@ -5020,7 +5025,7 @@ void SW_NC_read_out_vars(
                     "nc-output variable name '%s' is too long.",
                     varKey
                 );
-                return; // Exit function prematurely due to error
+                goto closeFile; // Exit function prematurely due to error
             }
 
             get_2d_output_key(varKey, &currOutKey, &varNum, OutDom->nvar_OUT);
@@ -5152,14 +5157,16 @@ void SW_NC_read_out_vars(
                         }
 
                         if (LogInfo->stopRun) {
-                            return; // Exit function prematurely due to error
+                            /* Exit function prematurely due to error */
+                            goto closeFile;
                         }
                     }
                 } else {
                     OutDom->outputVarInfo[currOutKey][varNum][index] =
                         Str_Dup(copyStr, LogInfo);
                     if (LogInfo->stopRun) {
-                        return; // Exit function prematurely due to error
+                        /* Exit function prematurely due to error */
+                        goto closeFile;
                     }
                 }
             }
@@ -5172,14 +5179,15 @@ void SW_NC_read_out_vars(
                     OutDom->units_sw[currOutKey][estVar] =
                         Str_Dup(SWVarUnits[currOutKey][varNumUnits], LogInfo);
                     if (LogInfo->stopRun) {
-                        return; // Exit function prematurely due to error
+                        /* Exit function prematurely due to error */
+                        goto closeFile;
                     }
                 }
             } else {
                 OutDom->units_sw[currOutKey][varNum] =
                     Str_Dup(SWVarUnits[currOutKey][varNumUnits], LogInfo);
                 if (LogInfo->stopRun) {
-                    return; // Exit function prematurely due to error
+                    goto closeFile; // Exit function prematurely due to error
                 }
             }
         }
@@ -5192,6 +5200,8 @@ void SW_NC_read_out_vars(
             OutDom->use[index] = swFALSE;
         }
     }
+
+closeFile: { CloseFile(&f, LogInfo); }
 }
 
 /** Create unit converters for output variables


### PR DESCRIPTION
- In SOILWAT2 v8.0.0, there is a bug where the two functions - `SW_NC_write_output()` & `SW_NC_read_out_vars()` - upon error, the open file does not get closed

- The mentioned two functions now close files upon failure before leaving the function
- See #424 and #426 