### PR TITLE
Derived metrics as new output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,10 @@
 * Transpiration regions no longer require roots of every plant functional type
   (@dschlaep).
 
+* Derived metrics including climatic water deficit, dry degree-days,
+  wet degree-days, and total profile available soil moisture can now be
+  requested as output (#466; @dschlaep).
+
 ## Bugfixes
 * The KD-tree algorithm is now correctly calculating index positions for
   lookup netCDFs also when the domain is a subset of the inputs (@N1ckP3rsl3y).
@@ -51,6 +55,11 @@
   for CMIP5 and CMIP6.
 * New inputs via `"weathsetup.in"` to request corrections for problematic
   weather inputs (turned off by default).
+* New inputs via `"outsetup.in"` and, for nc-based SOILWAT2, via
+  `"SW2_netCDF_input_variables.tsv"` to request derived metrics as output.
+
+## Changes to outputs
+* Several derived metrics in output groups `"DERIVEDSUM"` and `"DERIVEDSAVG"`.
 
 
 # SOILWAT2 v8.1.1

--- a/include/SW_Defines.h
+++ b/include/SW_Defines.h
@@ -229,12 +229,23 @@ typedef enum {
 // macro `ForEachOutPeriod` --> instead, define as type unsigned int
 typedef unsigned short OutPeriod;
 
-/*
-  * Number of output keys
+/** Number of output keys
 
-  * Must match number of items in output enum (minus eSW_NoKey and eSW_LastKey)
+    Update the following if \ref SW_OUTNKEYS is changed
+        - tests/example/Input/outsetup.in
+        - tests/example/Input_nc/SW2_netCDF_output_variables.tsv
+        - SWVarUnits
+        - possKeys
+        - key2obj
+        - key2str
+        - SW_OUT_set_ncol()
+        - SW_OUT_set_colnames()
+        - average_for()
+        - sumof_XXX()
+
+    See also the (outdated) \ref out_algo "output algorithm documentation"
 */
-#define SW_OUTNKEYS 32
+#define SW_OUTNKEYS 34
 
 #define SW_OUTNMAXVARS 8 // maximum number of output variables per OutKey
 

--- a/include/SW_DerivedMetrics.h
+++ b/include/SW_DerivedMetrics.h
@@ -1,0 +1,45 @@
+#ifndef SW_DERIVEDMETRICS_H
+#define SW_DERIVEDMETRICS_H
+
+#include "include/SW_Defines.h" // for LyrIndex
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+double metric_CWD(double pet, double aet);
+
+double metric_totalSWA(
+    double const swcBulk[],
+    double const baseSWC[],
+    double const layerWeights[],
+    LyrIndex n_layers
+);
+
+double metric_DDD(
+    double tmean,
+    double baseTmean,
+    double swe,
+    double baseSWE,
+    double const swcBulk[],
+    double const baseSWC[],
+    double const layerWeights[],
+    LyrIndex n_layers
+);
+
+double metric_WDD(
+    double tmean,
+    double baseTmean,
+    double swe,
+    double baseSWE,
+    double const swcBulk[],
+    double const baseSWC[],
+    double const layerWeights[],
+    LyrIndex n_layers
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/SW_Output.h
+++ b/include/SW_Output.h
@@ -126,6 +126,8 @@ extern "C" {
 #define SW_ESTAB "ESTABL"          // 29	5		0
 #define SW_CO2EFFECTS "CO2EFFECTS" // 30	?		?
 #define SW_BIOMASS "BIOMASS"       // 31	?		?
+#define SW_DERIVEDSUM "DERIVEDSUM"
+#define SW_DERIVEDAVG "DERIVEDAVG"
 
 /* summary methods */
 #define SW_SUM_OFF "OFF"       /* don't output */
@@ -356,6 +358,8 @@ void get_soiltemp_text(OutPeriod pd, SW_RUN *sw, LOG_INFO *LogInfo);
 void get_frozen_text(OutPeriod pd, SW_RUN *sw, LOG_INFO *LogInfo);
 void get_co2effects_text(OutPeriod pd, SW_RUN *sw, LOG_INFO *LogInfo);
 void get_biomass_text(OutPeriod pd, SW_RUN *sw, LOG_INFO *LogInfo);
+void get_derivedsum_text(OutPeriod pd, SW_RUN *sw, LOG_INFO *LogInfo);
+void get_derivedavg_text(OutPeriod pd, SW_RUN *sw, LOG_INFO *LogInfo);
 #endif
 
 #if defined(RSOILWAT) || defined(SWNETCDF)
@@ -387,6 +391,8 @@ void get_soiltemp_mem(OutPeriod pd, SW_RUN *sw, SW_OUT_DOM *OutDom);
 void get_frozen_mem(OutPeriod pd, SW_RUN *sw, SW_OUT_DOM *OutDom);
 void get_co2effects_mem(OutPeriod pd, SW_RUN *sw, SW_OUT_DOM *OutDom);
 void get_biomass_mem(OutPeriod pd, SW_RUN *sw, SW_OUT_DOM *OutDom);
+void get_derivedsum_mem(OutPeriod pd, SW_RUN *sw, SW_OUT_DOM *OutDom);
+void get_derivedavg_mem(OutPeriod pd, SW_RUN *sw, SW_OUT_DOM *OutDom);
 
 #elif defined(STEPWAT)
 void get_temp_agg(
@@ -471,6 +477,12 @@ void get_co2effects_agg(
     OutPeriod pd, SW_RUN *sw, SW_OUT_DOM *OutDom, LOG_INFO *LogInfo
 );
 void get_biomass_agg(
+    OutPeriod pd, SW_RUN *sw, SW_OUT_DOM *OutDom, LOG_INFO *LogInfo
+);
+void get_derivedsum_agg(
+    OutPeriod pd, SW_RUN *sw, SW_OUT_DOM *OutDom, LOG_INFO *LogInfo
+);
+void get_derivedavg_agg(
     OutPeriod pd, SW_RUN *sw, SW_OUT_DOM *OutDom, LOG_INFO *LogInfo
 );
 

--- a/include/SW_datastructs.h
+++ b/include/SW_datastructs.h
@@ -420,6 +420,18 @@ typedef struct {
     /** Array for plant functional types and soil layers with assigned
         transpiration region ID */
     LyrIndex my_transp_rgn[NVEGTYPES][MAX_LAYERS];
+
+    /** Soil layer weights for accumulation from 0 to 100 cm depth */
+    /* Used only by metric_xxx() */
+    double slWeight100[MAX_LAYERS];
+
+    /** Soil water content per layer held at a tension of -3.0 MPa */
+    /* Used only by metric_xxx() */
+    double baseSWC30bar[MAX_LAYERS];
+
+    /** Soil water content per layer held at a tension of -3.9 MPa */
+    /* Used only by metric_xxx() */
+    double baseSWC39bar[MAX_LAYERS];
 } SW_SITE_SIM;
 
 typedef struct {
@@ -1025,6 +1037,13 @@ typedef struct {
                                        // estimation of each layer
         maxLyrTemperature[MAX_LAYERS]; // Holds the maximum temperature
                                        // estimation of each layer
+
+    /* Derived output metrics */
+    double cwd;
+    double ddd5C30bar000to100cm;
+    double wdd5C15bar000to100cm;
+    double swa30bar000to100cm;
+    double swa39bar000to100cm;
 } SW_SOILWAT_OUTPUTS;
 
 #ifdef SWDEBUG
@@ -1358,9 +1377,12 @@ typedef enum {
     /* vegetation quantities */
     eSW_AllVeg,
     eSW_Estab,
-    // vegetation other */
+    /* vegetation other */
     eSW_CO2Effects,
     eSW_Biomass,
+    /* Derived output metrics */
+    eSW_DerivedSum,
+    eSW_DerivedAvg,
     eSW_LastKey /* make sure this is the last one */
 } OutKey;
 

--- a/makefile
+++ b/makefile
@@ -418,6 +418,7 @@ sources_core := \
 	$(dir_src)/SW_Flow.c \
 	$(dir_src)/SW_Carbon.c \
 	$(dir_src)/SW_Domain.c \
+	$(dir_src)/SW_DerivedMetrics.c \
 	$(dir_src)/SW_Output.c \
 	$(dir_src)/SW_Output_get_functions.c \
 	$(dir_src)/SW_Output_outarray.c \

--- a/src/SW_DerivedMetrics.c
+++ b/src/SW_DerivedMetrics.c
@@ -10,7 +10,8 @@
 /*             Global Function Definitions             */
 /* --------------------------------------------------- */
 
-/** Climatic water deficit
+/**
+@brief Climatic water deficit
 
 @param[in] pet Potential evapotranspiration
 @param[in] aet Actual evapotranspiration
@@ -19,7 +20,8 @@
 */
 double metric_CWD(double pet, double aet) { return pet - aet; }
 
-/** Available soil water
+/**
+@brief Available soil water
 
 @param[in] swcBulk Bulk soil water content
 @param[in] baseSWC Base bulk soil water content that is held at a fixed tension
@@ -46,7 +48,8 @@ double metric_totalSWA(
     return swa;
 }
 
-/** Dry degree-days
+/**
+@brief Dry degree-days
 
 @param[in] tmean Daily mean air temperature
 @param[in] baseTmean Base temperature above which degree-days accumulate
@@ -85,7 +88,8 @@ double metric_DDD(
     return ddd;
 }
 
-/** Wet degree-days
+/**
+@brief Wet degree-days
 
 @param[in] tmean Daily mean air temperature
 @param[in] baseTmean Base temperature above which degree-days accumulate

--- a/src/SW_DerivedMetrics.c
+++ b/src/SW_DerivedMetrics.c
@@ -1,0 +1,125 @@
+
+/* =================================================== */
+/*                INCLUDES / DEFINES                   */
+/* --------------------------------------------------- */
+#include "include/SW_DerivedMetrics.h"
+#include "include/SW_Defines.h"  // for LyrIndex, ForEachSoilLayer
+#include "include/generic.h"     // for fmax, GT, ZRO
+
+/* =================================================== */
+/*             Global Function Definitions             */
+/* --------------------------------------------------- */
+
+/** Climatic water deficit
+
+@param[in] pet Potential evapotranspiration
+@param[in] aet Actual evapotranspiration
+
+@return Climatic water deficit
+*/
+double metric_CWD(double pet, double aet) { return pet - aet; }
+
+/** Available soil water
+
+@param[in] swcBulk Bulk soil water content
+@param[in] baseSWC Base bulk soil water content that is held at a fixed tension
+@param[in] layerWeights Weights of how much each soil layer width (thickness)
+    contributes to the soil depth over which swa is summed
+@param[in] n_layers Number of soil layers
+
+@return Available soil water content that is held below a specified tension
+    and summed across a specified soil depth
+*/
+double metric_totalSWA(
+    double const swcBulk[],
+    double const baseSWC[],
+    double const layerWeights[],
+    LyrIndex n_layers
+) {
+    LyrIndex i;
+    double swa = 0.0;
+
+    ForEachSoilLayer(i, n_layers) {
+        swa += fmax(0., (swcBulk[i] - baseSWC[i]) * layerWeights[i]);
+    }
+
+    return swa;
+}
+
+/** Dry degree-days
+
+@param[in] tmean Daily mean air temperature
+@param[in] baseTmean Base temperature above which degree-days accumulate
+@param[in] swe Snow water equivalent of the snowpack
+@param[in] baseSWE Maximum amount of snow below which degree-days accumulate
+@param[in] swcBulk Bulk soil water content
+@param[in] baseSWC Base bulk soil water content that is held at a fixed tension
+@param[in] layerWeights Weights of how much each soil layer width (thickness)
+    contributes to the soil depth over which swa is summed
+@param[in] n_layers Number of soil layers
+
+@return Degrees above base temperature on days when
+    the soil across a specified soil depth is dry and
+    there is sufficiently little snowpack
+*/
+double metric_DDD(
+    double tmean,
+    double baseTmean,
+    double swe,
+    double baseSWE,
+    double const swcBulk[],
+    double const baseSWC[],
+    double const layerWeights[],
+    LyrIndex n_layers
+) {
+    double ddd = 0.0;
+    double swa = 0.0;
+
+    if (tmean > baseTmean && swe <= baseSWE) {
+        swa = metric_totalSWA(swcBulk, baseSWC, layerWeights, n_layers);
+        if (ZRO(swa)) {
+            ddd = fmax(0., tmean - baseTmean);
+        }
+    }
+
+    return ddd;
+}
+
+/** Wet degree-days
+
+@param[in] tmean Daily mean air temperature
+@param[in] baseTmean Base temperature above which degree-days accumulate
+@param[in] swe Snow water equivalent of the snowpack
+@param[in] baseSWE Maximum amount of snow below which degree-days accumulate
+@param[in] swcBulk Bulk soil water content
+@param[in] baseSWC Base bulk soil water content that is held at a fixed tension
+@param[in] layerWeights Weights of how much each soil layer width (thickness)
+    contributes to the soil depth over which swa is summed
+@param[in] n_layers Number of soil layers
+
+@return Degrees above base temperature on days when
+    the soil across a specified soil depth is wet and
+    there is sufficiently little snowpack
+*/
+double metric_WDD(
+    double tmean,
+    double baseTmean,
+    double swe,
+    double baseSWE,
+    double const swcBulk[],
+    double const baseSWC[],
+    double const layerWeights[],
+    LyrIndex n_layers
+) {
+    double wdd = 0.0;
+    double swa = 0.0;
+
+    if (tmean > baseTmean && swe <= baseSWE) {
+        swa = metric_totalSWA(swcBulk, baseSWC, layerWeights, n_layers);
+        if (GT(swa, 0.)) {
+            wdd = fmax(0., tmean - baseTmean);
+        }
+    }
+
+    return wdd;
+}

--- a/src/SW_netCDF_Output.c
+++ b/src/SW_netCDF_Output.c
@@ -94,7 +94,13 @@ static const char *const SWVarUnits[SW_OUTNKEYS][SW_OUTNMAXVARS] = {
     {"1", "1"},                                       /* CO2EFFECTS */
 
     /* BIOMASS */
-    {"1", "1", "g m-2", "g m-2", "g m-2", "g m-2", "g m-2", "m m-2"}
+    {"1", "1", "g m-2", "g m-2", "g m-2", "g m-2", "g m-2", "m m-2"},
+
+    /* DERIVEDSUM */
+    {"cm", "degC day", "degC day"},
+
+    /* DERIVEDAVG */
+    {"cm", "cm"}
 };
 
 static const char *const possKeys[SW_OUTNKEYS][SW_OUTNMAXVARS] = {
@@ -185,7 +191,13 @@ static const char *const possKeys[SW_OUTNKEYS][SW_OUTNMAXVARS] = {
      "BIOMASS__litter_total",
      "BIOMASS__biolive_total",
      "BIOMASS__veg.biolive_inveg",
-     "BIOMASS__LAI"}
+     "BIOMASS__LAI"},
+
+    {"DERIVEDSUM__cwd",
+     "DERIVEDSUM__ddd5C30bar000to100cm",
+     "DERIVEDSUM__wdd5C15bar000to100cm"},
+
+    {"DERIVEDAVG__swa30bar000to100cm", "DERIVEDAVG__swa39bar000to100cm"}
 };
 
 /* =================================================== */

--- a/tests/example/Input/outsetup.in
+++ b/tests/example/Input/outsetup.in
@@ -71,6 +71,9 @@ TIMESTEP dy wk mo yr # must be lowercase
        ESTABL     AVG       YR       1     end          estabs      /* yearly establishment results */
    CO2EFFECTS     AVG       DY       1     end      co2effects      /* vegetation CO2-effect (multiplier) for trees, shrubs, forbs, grasses; WUE CO2-effect (multiplier) for trees, shrubs, forbs, grasses */
       BIOMASS     AVG       DY       1     end      vegetation      /* vegetation: cover (%) for trees, shrubs, forbs, grasses; biomass (g/m2 as component of total) for total, trees, shrubs, forbs, grasses, and litter; live biomass (g/m2 as component of total) total, trees, shrubs, forbs, grasses; leaf area index LAI (m2/m2) */
+   DERIVEDSUM     SUM       DY       1     end      derivedsum      /* cumulative derived metrics: cwd, ddd5C30bar000to100cm, wdd5C15bar000to100cm */
+   DERIVEDAVG     AVG       DY       1     end      derivedavg      /* average derived metrics: swa30bar000to100cm, swa39bar000to100cm */
+
 
 # Simulation output directory/filenames
 Output/			# Path for output files: / for same directory, or e.g., Output/; PROGRAMMER NOTE: This is currently the 13th position; if this changes then update function SW_Files.c/SW_F_read()

--- a/tests/example/Input_nc/SW2_netCDF_output_variables.tsv
+++ b/tests/example/Input_nc/SW2_netCDF_output_variables.tsv
@@ -66,3 +66,8 @@ SOILTEMP	maxLyrTemperature	Lyr_<slyr>_max_C	degC	ZT	1	tslmax	daily maximum soil 
 SOILTEMP	minLyrTemperature	Lyr_<slyr>_min_C	degC	ZT	1	tslmin	daily minimum soil temperature	Minimum temperature of each soil layer	degC	time: minimum	Not standardized but see tsl
 SOILTEMP	avgLyrTemp	Lyr_<slyr>_avg_C	degC	ZT	1	tsl	daily mean soil temperature	Mean temperature of each soil layer	degC	time: mean	CMIP6/CMOR3
 FROZEN	lyrFrozen	Lyr_<slyr>	1	ZT	1	frozen	frozen soil	Count of days if soil layer has soil moisture in the solid phase	1	time: mean	Not standardized but see mrfsofr
+DERIVEDSUM	cwd	cwd	cm	T	1	cwd	climatic water deficit	Climatic water deficit (difference between potential evapotranspiration and evapotranspiration)	mm	time: sum	NA
+DERIVEDSUM	ddd5C30bar000to100cm	ddd5C30bar000to100cm	degC day	T	1	ddd5C30bar000to100cm	dry degree-days	Degrees above 5 degC on days when there is no snowpack and when all soil moisture is held at more than 3.0 MPa tension within 0-100 cm soil depth	degC day	time: sum	NA
+DERIVEDSUM	wdd5C15bar000to100cm	wdd5C15bar000to100cm	degC day	T	1	wdd5C15bar000to100cm	wet degree-days	Degrees above 5 degC on days when there is no snowpack and when soil moisture is held at less than 1.5 MPa tension within 0-100 cm soil depth	degC day	time: sum	NA
+DERIVEDAVG	swa30bar000to100cm	swa30bar000to100cm	cm	T	1	swa30bar000to100cm	available water content in soil	Water content of soil across 0 to 100 cm depth (or soil depth if shallower) held at a tension of 3.0 MPa	mm	vertical: sum time: mean	NA
+DERIVEDAVG	swa39bar000to100cm	swa39bar000to100cm	cm	T	1	swa39bar000to100cm	available water content in soil	Water content of soil across 0 to 100 cm depth (or soil depth if shallower) held at a tension of 3.9 MPa	mm	vertical: sum time: mean	NA

--- a/tests/gtests/test_SW_DerivedMetrics.cc
+++ b/tests/gtests/test_SW_DerivedMetrics.cc
@@ -5,8 +5,8 @@
 
 namespace {
 TEST(SWDerivedMetrics, CWD) {
-    double x1 = 1.5;
-    double x2 = 0.33;
+    double const x1 = 1.5;
+    double const x2 = 0.33;
 
     // Expect that CWD calculates the difference
     EXPECT_DOUBLE_EQ(metric_CWD(x1, x2), x1 - x2);
@@ -16,7 +16,7 @@ TEST(SWDerivedMetrics, TotalSWA) {
     double swcBulk[MAX_LAYERS] = {1.};
     double baseSWC[MAX_LAYERS];
     double layerWeights[MAX_LAYERS];
-    LyrIndex n_layers = 1;
+    LyrIndex const n_layers = 1;
     double totalSWC;
 
     // Expect that 0 <= TotalSWA <= sum(swcBulk)
@@ -46,14 +46,14 @@ TEST(SWDerivedMetrics, TotalSWA) {
 }
 
 TEST(SWDerivedMetrics, DDD) {
-    double tmean = 25.;
+    double const tmean = 25.;
     double baseTmean;
     double swe;
-    double baseSWE = 0.;
+    double const baseSWE = 0.;
     double swcBulk[MAX_LAYERS];
     double baseSWC[MAX_LAYERS] = {0.25};
     double layerWeights[MAX_LAYERS]{1.};
-    LyrIndex n_layers = 1;
+    LyrIndex const n_layers = 1;
     double gdd;
 
     // Expect that 0 <= ddd <= (total/growing) degree-days
@@ -145,14 +145,14 @@ TEST(SWDerivedMetrics, DDD) {
 }
 
 TEST(SWDerivedMetrics, WDD) {
-    double tmean = 25.;
+    double const tmean = 25.;
     double baseTmean;
     double swe;
-    double baseSWE = 0.;
+    double const baseSWE = 0.;
     double swcBulk[MAX_LAYERS];
     double baseSWC[MAX_LAYERS] = {0.25};
     double layerWeights[MAX_LAYERS]{1.};
-    LyrIndex n_layers = 1;
+    LyrIndex const n_layers = 1;
     double gdd;
 
     // Expect that 0 <= wdd <= (total/growing) degree-days

--- a/tests/gtests/test_SW_DerivedMetrics.cc
+++ b/tests/gtests/test_SW_DerivedMetrics.cc
@@ -1,0 +1,246 @@
+#include "include/SW_Defines.h"         // for MAX_LAYERS, LyrIndex
+#include "include/SW_DerivedMetrics.h"  // for metric_DDD, metric_WDD, metri...
+#include "gtest/gtest.h"                // for Message, Test, CmpHelperFloat...
+
+
+namespace {
+TEST(SWDerivedMetrics, CWD) {
+    double x1 = 1.5;
+    double x2 = 0.33;
+
+    // Expect that CWD calculates the difference
+    EXPECT_DOUBLE_EQ(metric_CWD(x1, x2), x1 - x2);
+}
+
+TEST(SWDerivedMetrics, TotalSWA) {
+    double swcBulk[MAX_LAYERS] = {1.};
+    double baseSWC[MAX_LAYERS];
+    double layerWeights[MAX_LAYERS];
+    LyrIndex n_layers = 1;
+    double totalSWC;
+
+    // Expect that 0 <= TotalSWA <= sum(swcBulk)
+    baseSWC[0] = swcBulk[0] / 4;
+    layerWeights[0] = 1.;
+    totalSWC = swcBulk[0];
+
+    EXPECT_GE(metric_totalSWA(swcBulk, baseSWC, layerWeights, n_layers), 0.);
+    EXPECT_LE(
+        metric_totalSWA(swcBulk, baseSWC, layerWeights, n_layers), totalSWC
+    );
+
+    // Expect that TotalSWC == 0 if baseSWC > swcBulk
+    baseSWC[0] = swcBulk[0] * 4;
+
+    EXPECT_DOUBLE_EQ(
+        metric_totalSWA(swcBulk, baseSWC, layerWeights, n_layers), 0.
+    );
+
+    // Expect that TotalSWC == 0 if layerWeights == 0
+    baseSWC[0] = swcBulk[0] / 4;
+    layerWeights[0] = 0.;
+
+    EXPECT_DOUBLE_EQ(
+        metric_totalSWA(swcBulk, baseSWC, layerWeights, n_layers), 0.
+    );
+}
+
+TEST(SWDerivedMetrics, DDD) {
+    double tmean = 25.;
+    double baseTmean;
+    double swe;
+    double baseSWE = 0.;
+    double swcBulk[MAX_LAYERS];
+    double baseSWC[MAX_LAYERS] = {0.25};
+    double layerWeights[MAX_LAYERS]{1.};
+    LyrIndex n_layers = 1;
+    double gdd;
+
+    // Expect that 0 <= ddd <= (total/growing) degree-days
+    baseTmean = 5.;
+    swe = 0.;
+    swcBulk[0] = baseSWC[0] / 2.;
+    gdd = tmean - baseTmean;
+
+    EXPECT_GE(
+        metric_DDD(
+            tmean,
+            baseTmean,
+            swe,
+            baseSWE,
+            swcBulk,
+            baseSWC,
+            layerWeights,
+            n_layers
+        ),
+        0.
+    );
+    EXPECT_LE(
+        metric_DDD(
+            tmean,
+            baseTmean,
+            swe,
+            baseSWE,
+            swcBulk,
+            baseSWC,
+            layerWeights,
+            n_layers
+        ),
+        gdd
+    );
+
+    // Expect that ddd == 0 if tmean < baseTmean
+    baseTmean = tmean + 1.;
+
+    EXPECT_DOUBLE_EQ(
+        metric_DDD(
+            tmean,
+            baseTmean,
+            swe,
+            baseSWE,
+            swcBulk,
+            baseSWC,
+            layerWeights,
+            n_layers
+        ),
+        0.
+    );
+
+    // Expect that ddd == 0 if swe > baseSWE
+    baseTmean = 5.;
+    swe = baseSWE + 1.;
+
+    EXPECT_DOUBLE_EQ(
+        metric_DDD(
+            tmean,
+            baseTmean,
+            swe,
+            baseSWE,
+            swcBulk,
+            baseSWC,
+            layerWeights,
+            n_layers
+        ),
+        0.
+    );
+
+    // Expect that ddd == 0 if swa > 0
+    baseTmean = 5.;
+    swe = 0.;
+    swcBulk[0] = baseSWC[0] * 2.;
+
+    EXPECT_DOUBLE_EQ(
+        metric_DDD(
+            tmean,
+            baseTmean,
+            swe,
+            baseSWE,
+            swcBulk,
+            baseSWC,
+            layerWeights,
+            n_layers
+        ),
+        0.
+    );
+}
+
+TEST(SWDerivedMetrics, WDD) {
+    double tmean = 25.;
+    double baseTmean;
+    double swe;
+    double baseSWE = 0.;
+    double swcBulk[MAX_LAYERS];
+    double baseSWC[MAX_LAYERS] = {0.25};
+    double layerWeights[MAX_LAYERS]{1.};
+    LyrIndex n_layers = 1;
+    double gdd;
+
+    // Expect that 0 <= wdd <= (total/growing) degree-days
+    baseTmean = 5.;
+    swe = 0.;
+    swcBulk[0] = baseSWC[0] * 2.;
+    gdd = tmean - baseTmean;
+
+    EXPECT_GE(
+        metric_WDD(
+            tmean,
+            baseTmean,
+            swe,
+            baseSWE,
+            swcBulk,
+            baseSWC,
+            layerWeights,
+            n_layers
+        ),
+        0.
+    );
+    EXPECT_LE(
+        metric_WDD(
+            tmean,
+            baseTmean,
+            swe,
+            baseSWE,
+            swcBulk,
+            baseSWC,
+            layerWeights,
+            n_layers
+        ),
+        gdd
+    );
+
+    // Expect that wdd == 0 if tmean < baseTmean
+    baseTmean = tmean + 1.;
+
+    EXPECT_DOUBLE_EQ(
+        metric_WDD(
+            tmean,
+            baseTmean,
+            swe,
+            baseSWE,
+            swcBulk,
+            baseSWC,
+            layerWeights,
+            n_layers
+        ),
+        0.
+    );
+
+    // Expect that wdd == 0 if swe > baseSWE
+    baseTmean = 5.;
+    swe = baseSWE + 1.;
+
+    EXPECT_DOUBLE_EQ(
+        metric_WDD(
+            tmean,
+            baseTmean,
+            swe,
+            baseSWE,
+            swcBulk,
+            baseSWC,
+            layerWeights,
+            n_layers
+        ),
+        0.
+    );
+
+    // Expect that wdd == 0 if swa == 0
+    baseTmean = 5.;
+    swe = 0.;
+    swcBulk[0] = baseSWC[0] / 2.;
+
+    EXPECT_DOUBLE_EQ(
+        metric_WDD(
+            tmean,
+            baseTmean,
+            swe,
+            baseSWE,
+            swcBulk,
+            baseSWC,
+            layerWeights,
+            n_layers
+        ),
+        0.
+    );
+}
+
+} // namespace

--- a/tests/gtests/test_SW_Site.cc
+++ b/tests/gtests/test_SW_Site.cc
@@ -888,7 +888,7 @@ TEST(SiteTest, SoilLayerWeights) {
     double depthLimit;
     double depths[MAX_LAYERS] = {5., 10., 20.};
     LyrIndex i;
-    LyrIndex n_layers = 3;
+    LyrIndex const n_layers = 3;
 
     // Expect w == 0 if index >= n_layers
     i = n_layers + 1;


### PR DESCRIPTION
- close #466 "Derived metrics as output"

- Derived metrics including can now be requested as output
- Currently implemented: climatic water deficit, dry degree-days, wet degree-days, and total profile available soil moisture
- two new output groups: DERIVEDSUM, DERIVEDAVG