### PR TITLE
Bugfix release v8.1.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 # SOILWAT2 v8.1.2-devel
 
+* Bugfix such that zero cover of one plant functional no longer directly affects
+  evaporation of intercepted water by other plant functional types or
+  evaporation from open surface water (#471; @dschlaep).
+
 
 # SOILWAT2 v8.1.1
 * Simulation output remains the same as the previous version.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 # NEWS
 
-# SOILWAT2 v8.1.2-devel
+# SOILWAT2 v8.1.2
+* Simulation output of the example remains the same as the previous version;
+  however, simulations set cover of at least one plant functional type to zero
+  may produce different output, particularly for cooler and wetter sites with
+  slightly reduced evaporation and slightly increased soil moisture.
 
 * Bugfix such that zero cover of one plant functional no longer directly affects
   evaporation of intercepted water by other plant functional types or

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # NEWS
 
+# SOILWAT2 v8.1.2-devel
+
+
 # SOILWAT2 v8.1.1
 * Simulation output remains the same as the previous version.
 

--- a/doc/SOILWAT2.bib
+++ b/doc/SOILWAT2.bib
@@ -159,33 +159,6 @@ institution = "Blackland Research Center, Texas Agricultural Experiment Station:
   pages = {130-132},
   }
 
-@Article{Parton1998,
-  author = "Parton, W.J. and Hartman, M. and Ojima, D. and Schimel, D.",
-  year = 1998,
-  title = "DAYCENT and its land surface submodel: description and testing.",
-  journal = "Global and Planetary Change",
-  volume = 19,
-  pages = {35-48},
-}
-
-@Article{Parton1978,
-  author = "Parton, W.J.",
-  year = 1978,
-  title = "Abiotic section of ELM.",
-  journal = "G. S. Innis, editor. Grassland simulation model.",
-  volume =,
-  pages = {31-53},
-}
-
-@Article{Parton1984,
-  author = "Parton, W.J.",
-  year = 1984,
-  title = "Predicting Soil Temperatures in A Shortgrass Steppe.",
-  journal = "Soil Science",
-  volume = 138,
-  pages = {93-101},
-}
-
 @phdthesis{Gerrits2010,
   title = {The role of interception in the hydrological cycle},
   ISBN = {9789065622488},

--- a/src/SW_Flow.c
+++ b/src/SW_Flow.c
@@ -685,9 +685,14 @@ void SW_Water_Flow(SW_RUN *sw, LOG_INFO *LogInfo) {
     /* Potential evaporation rates of intercepted and surface water */
     peti = pet2;
     ForEachVegType(k) {
-        surface_evap_veg_rate[k] =
-            fmax(0., fmin(peti * scale_veg[k], sw->SoilWat.veg_int_storage[k]));
-        peti -= surface_evap_veg_rate[k] / scale_veg[k];
+        if (GT(scale_veg[k], 0.)) {
+            surface_evap_veg_rate[k] = fmax(
+                0., fmin(peti * scale_veg[k], sw->SoilWat.veg_int_storage[k])
+            );
+            peti -= surface_evap_veg_rate[k] / scale_veg[k];
+        } else {
+            surface_evap_veg_rate[k] = 0.;
+        }
     }
 
     surface_evap_litter_rate =

--- a/tests/example/Input/siteparam.in
+++ b/tests/example/Input/siteparam.in
@@ -124,8 +124,9 @@ RCP85
 
 Campbell1974        # Specify soil water retention curve
 Cosby1984AndOthers  # Specify pedotransfer function
-                    #   * if not implemented, then provide SWRC parameters
-                    #     as inputs via "swrc_params.in" and/or "swrcp.nc")
+                    #   * Provide SWRC parameters as inputs
+                    #     (via "swrc_params.in" and/or "swrcp.nc") if no
+                    #     PTF for the selected SWRC is implemented
 
 0                   # Are SWRC parameters for the mineral soil component
                     # provided as inputs (see `has_swrcp`)?

--- a/tests/gtests/test_SW_VegProd.cc
+++ b/tests/gtests/test_SW_VegProd.cc
@@ -1569,4 +1569,100 @@ TEST_F(VegProdFixtureTest, EstimateVegInputGreaterThanOne2DeathTest) {
     // Free allocated data
     deallocateClimateStructs(&climateOutput, &climateAverages);
 }
+
+TEST_F(VegProdFixtureTest, VegetationTypeEquivalency) {
+    int k;
+    LyrIndex i;
+    double tc;
+    double transpiration[2] = {0., 0.};
+    double ecnw[2] = {0., 0.};
+    double swc[2] = {0., 0.};
+
+    Bool const copyWeather = swTRUE;
+
+    int const vt1 = SW_GRASS;
+    int const vt2 = SW_FORBS;
+
+    SW_RUN run_vt1;
+    SW_RUN run_vt2;
+
+    // Store default cover of vt1 and vt2 combined
+    tc =
+        SW_Run.VegProd.veg[vt1].cov.fCover + SW_Run.VegProd.veg[vt2].cov.fCover;
+
+    // Set cover of vt1 and vt2 to 0
+    SW_Run.VegProd.veg[vt1].cov.fCover = 0.;
+    SW_Run.VegProd.veg[vt2].cov.fCover = 0.;
+
+    // Set parameters of vt2 equal to parameters of vt1 (if not already)
+    SW_Run.VegProd.veg[vt2].SWPcrit = SW_Run.VegProd.veg[vt1].SWPcrit;
+    SW_Run.VegProd.veg[vt2].veg_kdead = SW_Run.VegProd.veg[vt1].veg_kdead;
+
+    ForEachSoilLayer(i, SW_Run.Site.n_layers) {
+        SW_Run.Site.soils.transp_coeff[vt2][i] =
+            SW_Run.Site.soils.transp_coeff[vt1][i];
+    }
+
+
+    // Run with vt1
+    SW_RUN_deepCopy(
+        &SW_Run, &run_vt1, &SW_Domain.OutDom, copyWeather, &LogInfo
+    );
+    sw_fail_on_error(&LogInfo);
+
+    run_vt1.VegProd.veg[vt1].cov.fCover = tc;
+
+    SW_CTL_init_run(&run_vt1, swTRUE, &LogInfo);
+    sw_fail_on_error(&LogInfo);
+
+    SW_CTL_main(&run_vt1, &SW_Domain.OutDom, &LogInfo);
+    sw_fail_on_error(&LogInfo);
+
+
+    // Run with vt2
+    SW_RUN_deepCopy(
+        &SW_Run, &run_vt2, &SW_Domain.OutDom, copyWeather, &LogInfo
+    );
+    sw_fail_on_error(&LogInfo);
+
+    run_vt2.VegProd.veg[vt2].cov.fCover = tc;
+
+    SW_CTL_init_run(&run_vt2, swTRUE, &LogInfo);
+    sw_fail_on_error(&LogInfo);
+
+    SW_CTL_main(&run_vt2, &SW_Domain.OutDom, &LogInfo);
+    sw_fail_on_error(&LogInfo);
+
+
+    // Expect that relevant simulation values of vt1 and vt2 are identical
+    // Note: we do not produce output (p_accu) during tests; thus, we can
+    // only check for the simulated values of the last time step
+    ForEachVegType(k) {
+        ecnw[0] += run_vt1.SoilWat.evap_veg[k];
+        ecnw[1] += run_vt1.SoilWat.evap_veg[k];
+
+        ForEachSoilLayer(i, SW_Run.Site.n_layers) {
+            transpiration[0] += run_vt1.SoilWat.transpiration[k][i];
+            transpiration[1] += run_vt2.SoilWat.transpiration[k][i];
+
+            swc[0] += run_vt1.SoilWat.swcBulk[0][i];
+            swc[1] += run_vt2.SoilWat.swcBulk[0][i];
+        }
+    }
+
+    EXPECT_DOUBLE_EQ(run_vt1.SoilWat.aet, run_vt2.SoilWat.aet);
+    EXPECT_DOUBLE_EQ(
+        run_vt1.SoilWat.surfaceWater_evap, run_vt2.SoilWat.surfaceWater_evap
+    );
+    EXPECT_DOUBLE_EQ(run_vt1.SoilWat.litter_evap, run_vt2.SoilWat.litter_evap);
+    EXPECT_DOUBLE_EQ(ecnw[0], ecnw[1]);
+    EXPECT_DOUBLE_EQ(transpiration[0], transpiration[1]);
+    EXPECT_DOUBLE_EQ(swc[0], swc[1]);
+
+
+    // Cleanup
+    SW_CTL_clear_model(swTRUE, &run_vt1);
+    SW_CTL_clear_model(swTRUE, &run_vt2);
+}
+
 } // namespace


### PR DESCRIPTION
## Summary of Pull Request

Patch to fix bug #471 Inconsistent impact if one plant functional type has zero cover

---

## Main Changes and Related Issues

- [x] #471
- [x] Explanation if output differs beyond tolerance from previous release

---

## Checklist

- [x] GHA checks pass

- [x] (Local) code checks: `tools/allCodeChecks.sh`
- [x] Documentation works without error
- [x] Code is formatted
- [x] Code is tidy for all modes of SOILWAT2 (`SWTXT`, `SWNC` and `SWMPI`)

- [x] (Local) output checks: `tools/allOutputChecks.sh`
- [x] Output checks are correct for `SWTXT`-mode SOILWAT2
- [x] Output checks are correct for `SWNC`-mode SOILWAT2
- [x] not applicable: Output checks are correct for `SWMPI`-mode SOILWAT2

- [x] deferred to v8.2.0: rSOILWAT2 updated (if needed)
- [x] deferred to v8.2.0: STEPWAT2 updated (if needed)

- [x] NEWS, README, user guide are updated
