### PR TITLE
Fix "extra" tests

### DIFF
--- a/src/SW_Control.c
+++ b/src/SW_Control.c
@@ -393,10 +393,11 @@ void SW_RUN_deepCopy(
         copyMKV(&dest->MarkovIn, &source->MarkovIn);
     }
 
+    /* Copy vegetation parameters */
     SW_VPD_init_ptrs(&dest->VegProdSim);
-    SW_VES_init_ptrs(&dest->VegEstabIn, dest->ves_p_accu, dest->ves_p_oagg);
 
     /* Copy vegetation establishment parameters */
+    SW_VES_init_ptrs(&dest->VegEstabIn, dest->ves_p_accu, dest->ves_p_oagg);
     dest->VegEstabIn.count = source->VegEstabIn.count;
     memcpy(
         &dest->VegEstabIn.parms,

--- a/tests/gtests/test_SW_Flow_Lib_PET.cc
+++ b/tests/gtests/test_SW_Flow_Lib_PET.cc
@@ -381,6 +381,7 @@ TEST(AtmDemSimTest, SolarPosHourAnglesByLatAndDoy) {
     FILE *fp;
     char *fname = NULL;
     char *outputPath = NULL;
+    bool dirExists;
 
     SW_ATMD_SIM SW_AtmDemSim;
     SW_PET_init_run(&SW_AtmDemSim); // Init radiation memoization
@@ -413,7 +414,9 @@ TEST(AtmDemSimTest, SolarPosHourAnglesByLatAndDoy) {
             outputPath = (char *) malloc(length_strnum + 1);
             DirName(fname, outputPath);
 
-            if (!DirExists(outputPath)) {
+            dirExists = (bool) DirExists(outputPath);
+
+            if (!dirExists) {
                 MkDir(outputPath, &LogInfo);
                 sw_fail_on_error(&LogInfo);
             }
@@ -538,6 +541,7 @@ TEST(AtmDemSimTest, SolarPosHourAnglesByLats) {
     FILE *fp;
     char fname[FILENAME_MAX];
     const char *outputPath = "Output/";
+    bool dirExists;
 
     SW_ATMD_SIM SW_AtmDemSim;
     SW_PET_init_run(&SW_AtmDemSim); // Init radiation memoization
@@ -553,8 +557,9 @@ TEST(AtmDemSimTest, SolarPosHourAnglesByLats) {
         outputPath,
         "Table__SW2_SolarPosition_Test__hourangles_by_lats.csv"
     );
+    dirExists = (bool) DirExists(outputPath);
 
-    if (!DirExists(outputPath)) {
+    if (!dirExists) {
         MkDir(outputPath, &LogInfo);
         sw_fail_on_error(&LogInfo); // exit test program if unexpected error
     }
@@ -1534,6 +1539,7 @@ TEST(AtmDemSimTest, PETPetfuncByTemps) {
     FILE *fp;
     char fname[FILENAME_MAX];
     const char *outputPath = "Output/";
+    bool dirExists;
 
     (void) snprintf(
         fname,
@@ -1542,8 +1548,9 @@ TEST(AtmDemSimTest, PETPetfuncByTemps) {
         outputPath,
         "Table__SW2_PET_Test__petfunc_by_temps.csv"
     );
+    dirExists = (bool) DirExists(outputPath);
 
-    if (!DirExists(outputPath)) {
+    if (!dirExists) {
         MkDir(outputPath, &LogInfo);
         sw_fail_on_error(&LogInfo); // exit test program if unexpected error
     }

--- a/tests/gtests/test_SW_Flow_Lib_PET.cc
+++ b/tests/gtests/test_SW_Flow_Lib_PET.cc
@@ -380,6 +380,7 @@ TEST(AtmDemSimTest, SolarPosHourAnglesByLatAndDoy) {
 
     FILE *fp;
     char *fname = NULL;
+    char *outputPath = NULL;
 
     SW_ATMD_SIM SW_AtmDemSim;
     SW_PET_init_run(&SW_AtmDemSim); // Init radiation memoization
@@ -409,7 +410,13 @@ TEST(AtmDemSimTest, SolarPosHourAnglesByLatAndDoy) {
             (void) fname_SolarPosHourAnglesByLatAndDoy(
                 fname, length_strnum + 1, slope, aspect
             );
+            outputPath = (char *) malloc(length_strnum + 1);
+            DirName(fname, outputPath);
 
+            if (!DirExists(outputPath)) {
+                MkDir(outputPath, &LogInfo);
+                sw_fail_on_error(&LogInfo);
+            }
             fp = OpenFile(fname, "w", &LogInfo);
             sw_fail_on_error(&LogInfo); // exit test program if unexpected error
 
@@ -484,6 +491,8 @@ TEST(AtmDemSimTest, SolarPosHourAnglesByLatAndDoy) {
             CloseFile(&fp, &LogInfo);
             free(fname);
             fname = NULL;
+            free(outputPath);
+            outputPath = NULL;
             sw_fail_on_error(&LogInfo); // exit test program if unexpected error
 
             if (isl == 0) {
@@ -528,6 +537,7 @@ TEST(AtmDemSimTest, SolarPosHourAnglesByLats) {
 
     FILE *fp;
     char fname[FILENAME_MAX];
+    const char *outputPath = "Output/";
 
     SW_ATMD_SIM SW_AtmDemSim;
     SW_PET_init_run(&SW_AtmDemSim); // Init radiation memoization
@@ -539,9 +549,15 @@ TEST(AtmDemSimTest, SolarPosHourAnglesByLats) {
     (void) snprintf(
         fname,
         sizeof fname,
-        "%s",
-        "Output/Table__SW2_SolarPosition_Test__hourangles_by_lats.csv"
+        "%s%s",
+        outputPath,
+        "Table__SW2_SolarPosition_Test__hourangles_by_lats.csv"
     );
+
+    if (!DirExists(outputPath)) {
+        MkDir(outputPath, &LogInfo);
+        sw_fail_on_error(&LogInfo); // exit test program if unexpected error
+    }
     fp = OpenFile(fname, "w", &LogInfo);
     sw_fail_on_error(&LogInfo); // exit test program if unexpected error
 
@@ -1517,13 +1533,20 @@ TEST(AtmDemSimTest, PETPetfuncByTemps) {
 
     FILE *fp;
     char fname[FILENAME_MAX];
+    const char *outputPath = "Output/";
 
     (void) snprintf(
         fname,
         sizeof fname,
-        "%s",
-        "Output/Table__SW2_PET_Test__petfunc_by_temps.csv"
+        "%s%s",
+        outputPath,
+        "Table__SW2_PET_Test__petfunc_by_temps.csv"
     );
+
+    if (!DirExists(outputPath)) {
+        MkDir(outputPath, &LogInfo);
+        sw_fail_on_error(&LogInfo); // exit test program if unexpected error
+    }
     fp = OpenFile(fname, "w", &LogInfo);
     sw_fail_on_error(&LogInfo); // exit test program if unexpected error
 

--- a/tests/gtests/test_SW_SpinUp.cc
+++ b/tests/gtests/test_SW_SpinUp.cc
@@ -338,13 +338,13 @@ TEST_F(SpinUpFixtureTest, Mode2WithScopeLessThanDuration) {
 #ifdef SW2_SpinupEvaluation
 // Run SOILWAT2 unit tests with flag
 // ```
-//   CPPFLAGS=-DSW2_SpinupEvaluation make test && bin/sw_test
-//   --gtest_filter=*SpinupEvaluation*
+//   CPPFLAGS=-DSW2_SpinupEvaluation make test
+//   bin/sw_test --gtest_filter=*SpinupEvaluation*
 // ```
 //
 // Produce plots based on output generated above
 // ```
-//   Rscript tools/plot__SW2_SpinupEvaluation.R
+//   Rscript tools/rscripts/Rscript__SW2_SpinupEvaluation.R
 // ```
 
 TEST_F(SpinUpFixtureTest, SpinupEvaluation) {
@@ -367,10 +367,7 @@ TEST_F(SpinUpFixtureTest, SpinupEvaluation) {
         {-2, -1.5, -1.25, -0.75, -0.5, 0.5, 1.5, 2},
         {2, 2, 2, 2, 2, 2, 2, 2}
     };
-
-    SW_VPD_init_run(&SW_Run, &LogInfo);
-    sw_fail_on_error(&LogInfo);
-
+    const TimeInt endyr = SW_Run.ModelIn.startyr;
 
     // Output file
     (void) snprintf(
@@ -451,6 +448,9 @@ TEST_F(SpinUpFixtureTest, SpinupEvaluation) {
                         test_tsInit[k3][i];
                 }
 
+                // Allocate and calculate CO2-effects
+                SW_VPD_init_run(&local_sw, &local_LogInfo);
+                sw_fail_on_error(&local_LogInfo);
 
                 // Print initial values
                 for (i = 0; i < n; i++) {
@@ -503,9 +503,9 @@ TEST_F(SpinUpFixtureTest, SpinupEvaluation) {
 
 
                 // Run (a short) simulation
-                local_sw.ModelIn.startyr = 1980;
-                local_sw.ModelIn.endyr = 1980;
+                local_sw.ModelIn.endyr = local_sw.ModelIn.startyr;
                 SW_CTL_main(&local_sw, &SW_Domain.OutDom, &LogInfo);
+                local_sw.ModelIn.endyr = endyr;
                 // exit test program if unexpected error
                 sw_fail_on_error(&local_LogInfo);
 
@@ -529,14 +529,13 @@ TEST_F(SpinUpFixtureTest, SpinupEvaluation) {
                 }
                 (void) fflush(fp);
 
+                SW_CTL_clear_model(swTRUE, &local_sw);
             } // end of loop over test_tsInit
         } // end of loop over test_swcInit
     } // end of loop over test_duration
 
     CloseFile(&fp, &LogInfo);
     sw_fail_on_error(&LogInfo); // exit test program if unexpected error
-
-    SW_VPD_deconstruct(&SW_Run.VegProdSim);
 }
 #endif // end of SW2_SpinupEvaluation_Test
 

--- a/tests/gtests/test_SW_SpinUp.cc
+++ b/tests/gtests/test_SW_SpinUp.cc
@@ -381,6 +381,10 @@ TEST_F(SpinUpFixtureTest, SpinupEvaluation) {
         "Table__SW2_SpinupEvaluation.csv"
     );
 
+    if (!DirExists(SW_Domain.SW_PathInputs.outputPrefix)) {
+        MkDir(SW_Domain.SW_PathInputs.outputPrefix, &LogInfo);
+        sw_fail_on_error(&LogInfo);
+    }
     fp = OpenFile(fname, "w", &LogInfo);
     sw_fail_on_error(&LogInfo); // exit test program if unexpected error
 

--- a/tests/gtests/test_SW_SpinUp.cc
+++ b/tests/gtests/test_SW_SpinUp.cc
@@ -368,6 +368,7 @@ TEST_F(SpinUpFixtureTest, SpinupEvaluation) {
         {2, 2, 2, 2, 2, 2, 2, 2}
     };
     const TimeInt endyr = SW_Run.ModelIn.startyr;
+    bool dirExists;
 
     // Output file
     (void) snprintf(
@@ -377,8 +378,9 @@ TEST_F(SpinUpFixtureTest, SpinupEvaluation) {
         SW_Domain.SW_PathInputs.outputPrefix,
         "Table__SW2_SpinupEvaluation.csv"
     );
+    dirExists = (bool) DirExists(SW_Domain.SW_PathInputs.outputPrefix);
 
-    if (!DirExists(SW_Domain.SW_PathInputs.outputPrefix)) {
+    if (!dirExists) {
         MkDir(SW_Domain.SW_PathInputs.outputPrefix, &LogInfo);
         sw_fail_on_error(&LogInfo);
     }


### PR DESCRIPTION
Fix "extra" tests

- close #493

`tools/check_extras.sh` runs the "extra" tests.
These tests are part of the googleTest set of tests but they write output to dedicated spreadsheets which are then analyzed by R scripts.

- writing output to spreadsheets no longer fails if there is no output directory
- SpinUpFixtureTest.SpinupEvaluation no longer causes a segmentation fault - dynamic memory for the CO2-fertilization effects is now correctly allocated and freed