### PR TITLE
Fix Markov generator

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,9 @@
 * NetCDF-enabled modes (SWNC/SWNETCDF/SWMPI) properly generate weather data
   when the weather generator method is 2 (markov) (#498, @N1ckP3rsl3y).
 
+* Script `"tools/ncTestRuns.sh"` produces reference output and detects log file
+  when in mpi mode (#500, @N1ckP3rsl3y)
+
 ## Changes to inputs
 * New input via `"siteparam.in"` to select the input option for potential
   evaporation coefficients: either provided as inputs by `"soils.in"` or

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,13 @@
   period too early; the bug occurred only for events on the first day of an
   output time period (#494; @N1ckP3rsl3y).
 
+* Program run no longer reports a segmentation fault or deallocation of a
+  freed pointer when the weather generator method is 2 (markov) (#497;
+  @N1ckP3rsl3y).
+
+* NetCDF-enabled modes (SWNC/SWNETCDF/SWMPI) properly generate weather data
+  when the weather generator method is 2 (markov) (#498, @N1ckP3rsl3y).
+
 ## Changes to inputs
 * New input via `"siteparam.in"` to select the input option for potential
   evaporation coefficients: either provided as inputs by `"soils.in"` or

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,20 +14,17 @@
 * Potential evaporation coefficients can now be estimated from soil properties
   (#409; @dschlaep).
 
+* The weather generator is now functional for all modes
+  (#497, #498; @N1ckP3rsl3y). However, nc-based SOILWAT2 cannot input
+  site-based coefficients and is restricted to domain-wide coefficients.
+
 ## Bugfixes
 * Output of vegetation establishment is no longer reported one output time
   period too early; the bug occurred only for events on the first day of an
   output time period (#494; @N1ckP3rsl3y).
 
-* Program run no longer reports a segmentation fault or deallocation of a
-  freed pointer when the weather generator method is 2 (markov) (#497;
-  @N1ckP3rsl3y).
-
-* NetCDF-enabled modes (SWNC/SWNETCDF/SWMPI) properly generate weather data
-  when the weather generator method is 2 (markov) (#498, @N1ckP3rsl3y).
-
-* Script `"tools/ncTestRuns.sh"` produces reference output and detects log file
-  when in mpi mode (#500, @N1ckP3rsl3y)
+* The mpi-mode of `"ncTestRuns"` now works again also for the reference run
+  (#500, @N1ckP3rsl3y).
 
 ## Changes to inputs
 * New input via `"siteparam.in"` to select the input option for potential

--- a/include/SW_Weather.h
+++ b/include/SW_Weather.h
@@ -46,6 +46,16 @@
 extern "C" {
 #endif
 
+/* Weather generation methods */
+
+/** No weather generation, only historical data */
+static const unsigned int wgHist = 0;
+
+/** Weather generation method LOCF, see generateMissingWeather() */
+static const unsigned int wgLOCF = 1;
+
+/** Markov weather generator method, see generateMissingWeather() */
+static const unsigned int wgMKV = 2;
 
 /*  all temps are in degrees C, all precip is in cm */
 /*  in fact, all water variables are in cm throughout

--- a/src/SW_Control.c
+++ b/src/SW_Control.c
@@ -532,7 +532,7 @@ void SW_CTL_RunSimSet(
 ) {
     size_t suid;
     size_t nSims = 0;
-    size_t ncSuid[2]; // 2 -> [y, x] or [s, 0]
+    size_t ncSuid[2] = {0, 0}; // 2 -> [y, x] or [s, 0]
 
     double *tempVals = NULL;
     SW_SOIL_RUN_INPUTS *tempSoils = NULL;
@@ -681,6 +681,8 @@ void SW_CTL_RunSimSet(
 
 #if defined(SWMPI)
             siteLog = &siteLogs[suid];
+            ncSuid[0] = simSuids[eSW_InDomain][suid][0];
+            ncSuid[1] = simSuids[eSW_InDomain][suid][1];
 #else
         sw_init_logs(main_LogInfo->logfp, &local_LogInfo);
 
@@ -708,7 +710,7 @@ void SW_CTL_RunSimSet(
                     &inputs[suid],
                     sw_template,
                     SW_Domain,
-                    NULL,
+                    ncSuid,
                     copyWeather,
                     NULL,
                     tempVals,
@@ -1613,6 +1615,9 @@ void SW_CTL_run_sw(
 
     SW_RUN local_sw;
 
+    Bool sDom = swFALSE; // Does not matter for text
+    size_t *finalWeatherSuid = NULL;
+
 #if defined(SWNETCDF) && !defined(SWMPI)
     SW_SOIL_RUN_INPUTS newSoil;
     size_t starts[SW_NINKEYSNC][N_SUID_ASSIGN][2] = {{{0}}};
@@ -1630,6 +1635,9 @@ void SW_CTL_run_sw(
 #else
     WallTimeSpec tsr;
     Bool ok_tsr = swFALSE;
+
+    sDom = SW_Domain->netCDFInput.siteDoms[eSW_InDomain];
+    finalWeatherSuid = ncSuid;
 #endif
 
 #ifdef SWDEBUG
@@ -1698,6 +1706,18 @@ void SW_CTL_run_sw(
         );
     }
 #endif
+
+    SW_WTH_finalize_all_weather(
+        &local_sw.MarkovIn,
+        &local_sw.WeatherIn,
+        local_sw.RunIn.weathRunAllHist,
+        local_sw.ModelSim.cum_monthdays,
+        local_sw.ModelSim.days_in_month,
+        finalWeatherSuid,
+        sDom,
+        LogInfo
+    );
+    checkJumpToLabel(LogInfo->stopRun, freeMem);
 
     // Initialize run-time variables
     SW_CTL_init_run(&local_sw, LogInfo);

--- a/src/SW_Control.c
+++ b/src/SW_Control.c
@@ -389,7 +389,7 @@ void SW_RUN_deepCopy(
     }
 
     /* Copy weather generator parameters */
-    if (dest->WeatherIn.generateWeatherMethod == 2) {
+    if (dest->WeatherIn.generateWeatherMethod == wgMKV) {
         allocateMKV(&dest->MarkovIn, LogInfo);
         if (LogInfo->stopRun) {
             return;
@@ -1391,7 +1391,7 @@ void SW_CTL_read_inputs_from_disk(
     }
 #endif
 
-    if (sw->WeatherIn.generateWeatherMethod == 2) {
+    if (sw->WeatherIn.generateWeatherMethod == wgMKV) {
         SW_MKV_setup(
             &sw->MarkovIn,
             sw->WeatherIn.rng_seed,

--- a/src/SW_Control.c
+++ b/src/SW_Control.c
@@ -390,6 +390,11 @@ void SW_RUN_deepCopy(
 
     /* Copy weather generator parameters */
     if (dest->WeatherIn.generateWeatherMethod == 2) {
+        allocateMKV(&dest->MarkovIn, LogInfo);
+        if (LogInfo->stopRun) {
+            return;
+        }
+
         copyMKV(&dest->MarkovIn, &source->MarkovIn);
     }
 

--- a/src/SW_Main.c
+++ b/src/SW_Main.c
@@ -140,25 +140,6 @@ int main(int argc, char **argv) {
     checkJumpToLabel(LogInfo.stopRun, finishProgram);
 #endif
 
-    // finalize daily weather
-#if defined(SWNETCDF)
-    if (!SW_Domain.netCDFInput.readInVars[eSW_InWeather][0] && !prepareFiles) {
-#endif
-        SW_WTH_finalize_all_weather(
-            &sw_template.MarkovIn,
-            &sw_template.WeatherIn,
-            sw_template.RunIn.weathRunAllHist,
-            sw_template.ModelSim.cum_monthdays,
-            sw_template.ModelSim.days_in_month,
-            NULL,
-            swFALSE, // Does not matter
-            &LogInfo
-        );
-        checkJumpToLabel(LogInfo.stopRun, finishProgram);
-#if defined(SWNETCDF)
-    }
-#endif
-
     // identify domain-wide soil profile information
     SW_DOM_soilProfile(
         &SW_Domain.netCDFInput,

--- a/src/SW_Markov.c
+++ b/src/SW_Markov.c
@@ -28,6 +28,7 @@
 #include "include/SW_datastructs.h" // for SW_MARKOV_INPUTS, LOG_INFO
 #include "include/SW_Defines.h"     // for MAX_DAYS, MAX_FILENAMESIZE, TimeInt
 #include "include/SW_Files.h"       // for eMarkovCov, eMarkovProb
+#include "include/SW_Weather.h"     // for wgMKV
 #include "include/Times.h"          // for doy2week
 #include <math.h>                   // for isfinite
 #include <stdio.h>                  // for NULL, sscanf, FILE, size_t
@@ -909,7 +910,7 @@ void SW_MKV_setup(
         return; // Exit function prematurely due to error
     }
 
-    if (!read_prob && Weather_genWeathMethod == 2) {
+    if (!read_prob && Weather_genWeathMethod == wgMKV) {
         LogError(
             LogInfo,
             LOGERROR,
@@ -924,7 +925,7 @@ void SW_MKV_setup(
         return; // Exit function prematurely due to error
     }
 
-    if (!read_cov && Weather_genWeathMethod == 2) {
+    if (!read_cov && Weather_genWeathMethod == wgMKV) {
         LogError(
             LogInfo,
             LOGERROR,

--- a/src/SW_Weather.c
+++ b/src/SW_Weather.c
@@ -1723,7 +1723,7 @@ void generateMissingWeather(
 
 
     // Error out if method not implemented
-    if (method > 2) {
+    if (method != wgLOCF && method != wgMKV) {
         LogErrorSuid(
             LogInfo,
             LOGERROR,

--- a/src/SW_Weather.c
+++ b/src/SW_Weather.c
@@ -96,14 +96,6 @@
 #include <stdlib.h>                  // for free
 #include <string.h>                  // for memset, NULL
 
-
-/* Weather generation methods */
-/** Markov weather generator method, see generateMissingWeather() */
-static const unsigned int wgMKV = 2;
-
-/** Weather generation method LOCF, see generateMissingWeather() */
-static const unsigned int wgLOCF = 1;
-
 /* =================================================== */
 /*             Local Function Definitions              */
 /* --------------------------------------------------- */
@@ -2452,7 +2444,7 @@ void SW_WTH_setup(
             switch (inBufintRes) {
             case 0:
                 // As is
-                SW_WeatherIn->generateWeatherMethod = 0;
+                SW_WeatherIn->generateWeatherMethod = wgHist;
                 break;
 
             case 1:

--- a/src/SW_Weather.c
+++ b/src/SW_Weather.c
@@ -1390,19 +1390,21 @@ void finalizeAllWeather(
     unsigned int yearIndex;
 
     // Impute missing values
-    generateMissingWeather(
-        SW_MarkovIn,
-        allHist,
-        w->startYear,
-        w->n_years,
-        w->generateWeatherMethod,
-        3, // optLOCF_nMax (TODO: make this user input)
-        ncSuid,
-        sDom,
-        LogInfo
-    );
-    if (LogInfo->stopRun) {
-        return; // Prematurely exit function
+    if (w->generateWeatherMethod != wgHist) {
+        generateMissingWeather(
+            SW_MarkovIn,
+            allHist,
+            w->startYear,
+            w->n_years,
+            w->generateWeatherMethod,
+            3, // optLOCF_nMax (TODO: make this user input)
+            ncSuid,
+            sDom,
+            LogInfo
+        );
+        if (LogInfo->stopRun) {
+            return; // Prematurely exit function
+        }
     }
 
     // Check to see if actual vapor pressure needs to be calculated
@@ -1634,9 +1636,9 @@ SOILWAT2 handles three scenarios of missing data:
 absent)
     3. No daily weather input files are available
 
-Available methods to generate weather:
-    1. Pass through (`method` = 0)
-    2. Imputation by last-value-carried forward "LOCF" (`method` = 1)
+Available methods to generate weather (function is not called when
+weather generator method is 0):
+    1. Imputation by last-value-carried forward "LOCF" (`method` = 1)
         - affected variables (all implemented):
             - minimum and maximum temperature
             - precipitation (which is set to 0 instead of "LOCF")
@@ -1648,7 +1650,7 @@ Available methods to generate weather:
         - missing values are imputed individually
         - error if more than `optLOCF_nMax` days per calendar year are
 missing
-    3. First-order Markov weather generator (`method` = 2)
+    2. First-order Markov weather generator (`method` = 2)
         - affected variables (others are passed through as is):
             - minimum and maximum temperature
             - precipitation
@@ -1714,13 +1716,6 @@ void generateMissingWeather(
     Bool missing_RelHum = swFALSE;
     Bool missing_ActVP = swFALSE;
     Bool missing_ShortWR = swFALSE;
-
-
-    // Pass through method: return early
-    if (method == 0) {
-        return;
-    }
-
 
     // Error out if method not implemented
     if (method != wgLOCF && method != wgMKV) {

--- a/src/SW_netCDF_Input.c
+++ b/src/SW_netCDF_Input.c
@@ -8579,25 +8579,6 @@ void SW_NCIN_read_inputs(
         checkReturn(mainLogInfo->stopRun);
     }
 
-    if (runSims && readWeather) {
-        for (input = 0; input < numInputs; input++) {
-            SW_WTH_finalize_all_weather(
-                &sw->MarkovIn,
-                &sw->WeatherIn,
-                inputs[input].weathRunAllHist,
-                sw->ModelSim.cum_monthdays,
-                sw->ModelSim.days_in_month,
-                domSuids[input],
-                SW_Domain->netCDFInput.siteDoms[eSW_InDomain],
-                mainLogInfo
-            );
-            if (mainLogInfo->stopRun) {
-                break;
-            }
-        }
-        checkReturn(mainLogInfo->stopRun);
-    }
-
     if (runSims && readVeg) {
         read_veg_inputs(
             SW_Domain,

--- a/src/SW_netCDF_Input.c
+++ b/src/SW_netCDF_Input.c
@@ -8577,7 +8577,9 @@ void SW_NCIN_read_inputs(
             mainLogInfo
         );
         checkReturn(mainLogInfo->stopRun);
+    }
 
+    if (runSims && readWeather) {
         for (input = 0; input < numInputs; input++) {
             SW_WTH_finalize_all_weather(
                 &sw->MarkovIn,

--- a/tests/gtests/test_SW_Markov.cc
+++ b/tests/gtests/test_SW_Markov.cc
@@ -5,6 +5,7 @@
 #include "include/SW_Files.h"       // for SW_F_deconstruct, eMarkovCov
 #include "include/SW_Main_lib.h"    // for sw_fail_on_error, sw_init_logs
 #include "include/SW_Markov.h"      // for SW_MKV_deconstruct, SW_MKV_init_...
+#include "include/SW_Weather.h"     // for wgMKV
 #include "gmock/gmock.h"            // for HasSubstr, MakePredicateFormatte...
 #include "gtest/gtest.h"            // for Test, Message, TestPartResult, Po...
 #include <stdio.h>                  // for NULL, size_t
@@ -81,7 +82,7 @@ TEST(WeatherGeneratorTest, WeatherGeneratorRNGSeeding) {
 
     size_t rng_seed;
     // Turn on Markov weather generator
-    unsigned int const generateWeatherMethod = 2;
+    unsigned int const generateWeatherMethod = wgMKV;
 
     short const n = 18;
     short const seed = 42;

--- a/tests/gtests/test_SW_Weather.cc
+++ b/tests/gtests/test_SW_Weather.cc
@@ -97,7 +97,7 @@ TEST_F(WeatherFixtureTest, WeatherNoMemoryLeakIfDecreasedNumberOfYears) {
 
 TEST_F(WeatherFixtureTest, WeatherSomeMissingValuesDays) {
 
-    SW_Run.WeatherIn.generateWeatherMethod = 2;
+    SW_Run.WeatherIn.generateWeatherMethod = wgMKV;
 
     // Change directory to get input files with some missing data
     (void) snprintf(
@@ -169,7 +169,7 @@ TEST_F(WeatherFixtureTest, WeatherSomeMissingValuesYears) {
 
     int year;
     int day;
-    SW_Run.WeatherIn.generateWeatherMethod = 2;
+    SW_Run.WeatherIn.generateWeatherMethod = wgMKV;
 
     // Change directory to get input files with some missing data
     (void) snprintf(
@@ -232,7 +232,7 @@ TEST_F(WeatherFixtureTest, WeatherWeatherGeneratorOnly) {
     int year;
     int day;
 
-    SW_Run.WeatherIn.generateWeatherMethod = 2;
+    SW_Run.WeatherIn.generateWeatherMethod = wgMKV;
     SW_Run.WeatherIn.use_weathergenerator_only = swTRUE;
 
     SW_MKV_setup(
@@ -300,7 +300,7 @@ TEST_F(WeatherFixtureTest, ReadAllWeatherTooManyMissingForLOCFDeathTest) {
     );
 
     // Set LOCF (temp) + 0 (PPT) method
-    SW_Run.WeatherIn.generateWeatherMethod = 1;
+    SW_Run.WeatherIn.generateWeatherMethod = wgLOCF;
 
     SW_Run.ModelIn.startyr = 1981;
     SW_Run.ModelIn.endyr = 1981;
@@ -2002,7 +2002,7 @@ TEST_F(WeatherFixtureTest, WeatherDailyLOCFInputValues) {
     sw_fail_on_error(&LogInfo); // exit test program if unexpected error
 
     // Setup values/flags for `generateMissingWeather()` to deal with
-    SW_Run.WeatherIn.generateWeatherMethod = 1;
+    SW_Run.WeatherIn.generateWeatherMethod = wgLOCF;
     SW_Run.RunIn.weathRunAllHist[yearIndex].cloudcov_daily[0] = cloudCovTestVal;
     SW_Run.RunIn.weathRunAllHist[yearIndex].actualVaporPressure[0] =
         actVapPressTestVal;

--- a/tests/gtests/test_WaterBalance.cc
+++ b/tests/gtests/test_WaterBalance.cc
@@ -128,7 +128,7 @@ TEST_F(WaterBalanceFixtureTest, WaterBalanceWithWeatherGeneratorOnly) {
     SW_VPD_init_run(&SW_Run, &LogInfo);
 
     // Turn on Markov weather generator (and turn off use of historical weather)
-    SW_Run.WeatherIn.generateWeatherMethod = 2;
+    SW_Run.WeatherIn.generateWeatherMethod = wgMKV;
     SW_Run.WeatherIn.use_weathergenerator_only = swTRUE;
 
     // Read Markov weather generator input files (they are not normally read)
@@ -198,7 +198,7 @@ TEST_F(
     SW_VPD_init_run(&SW_Run, &LogInfo);
 
     // Turn on Markov weather generator
-    SW_Run.WeatherIn.generateWeatherMethod = 2;
+    SW_Run.WeatherIn.generateWeatherMethod = wgMKV;
 
     // Point to partial weather data
     (void) snprintf(

--- a/tests/ncTestRuns/R/Functions_ncTestRuns.R
+++ b/tests/ncTestRuns/R/Functions_ncTestRuns.R
@@ -879,7 +879,7 @@ colorTestReport <- function(x) {
 
 printColoredDF <- function(x, vars) {
   res <- apply(
-    rbind(vars, res[, vars, drop = FALSE]),
+    rbind(vars, x[, vars, drop = FALSE]),
     MARGIN = 2L,
     FUN = format,
     justify = "right"
@@ -892,6 +892,12 @@ printColoredDF <- function(x, vars) {
     )
   }
 }
+
+printReportRow <- function(x, colored = FALSE) {
+  x <- do.call(sprintf, args = c(fmt = "%13s%12s%9s%18s%14s", as.list(x)))
+  cat(msg = if (isTRUE(colored)) colorTestReport(x) else x, fill = TRUE)
+}
+
 
 findExampleSiteIndex <- function(id, domain) {
   which(domain == id, arr.ind = length(dim(domain)) == 2L)

--- a/tests/ncTestRuns/data-raw/metadata_testRuns.csv
+++ b/tests/ncTestRuns/data-raw/metadata_testRuns.csv
@@ -33,17 +33,17 @@ id,testrun,tag,comment,expectation,reference,domainType,domainCRS,domainSize,dom
 32,32,dom-xy-3x2-geog_in-xy-geog-3x2-soildepths,variable soil layer thickness,success,example,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,0,sw2,standard,1980,2010,dim,double,standard,variableSoilLayerThickness,no,yes,yes,no
 33,33,dom-xy-3x2-geog_in-xy-geog-3x2-swrcp,input SWRCp,success,example,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,0,sw2,standard,1980,2010,dim,double,standard,standard,yes,yes,yes,no
 34,34,dom-xy-3x2-geog_in-xy-geog-3x2-wGen,"gridded geographic, weather generator",success,example-wGen,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,0,wGen,standard,1980,2010,dim,double,standard,standard,no,yes,yes,yes
-35,38,dom-s-6-geog_in-s-geog-6,site geographic,success,example,s,geographic,6,NA,180,NA,s,geographic,6,0,sw2,standard,1980,2010,dim,double,standard,standard,no,yes,yes,yes
+35,39,dom-s-6-geog_in-s-geog-6,site geographic,success,example,s,geographic,6,NA,180,NA,s,geographic,6,0,sw2,standard,1980,2010,dim,double,standard,standard,no,yes,yes,yes
 36,40,dom-s-6-geog_in-s-geog-6-pftvar,pft as variable instead dimension,success,example,s,geographic,6,NA,180,NA,s,geographic,6,0,sw2,standard,1980,2010,var,double,standard,standard,no,yes,yes,yes
 37,41,dom-s-6-geog_in-s-geog-6-mixdim,"site geographic, mixed order of input dimensions",success,example,s,geographic,6,NA,180,NA,s,geographic,6,0,sw2,standard,1980,2010,dim,double,mix,standard,no,yes,yes,yes
 38,42,dom-s-6-geog_in-s-geog-6-soillayers,variable number of soil layers,success,example,s,geographic,6,NA,180,NA,s,geographic,6,0,sw2,standard,1980,2010,dim,double,standard,variableSoilLayerNumber,no,yes,yes,yes
 39,43,dom-s-6-geog_in-s-geog-6-soildepths,variable soil layer thickness,success,example,s,geographic,6,NA,180,NA,s,geographic,6,0,sw2,standard,1980,2010,dim,double,standard,variableSoilLayerThickness,no,yes,yes,yes
 40,44,dom-s-6-geog_in-s-geog-6-swrcp,input SWRCp,success,example,s,geographic,6,NA,180,NA,s,geographic,6,0,sw2,standard,1980,2010,dim,double,standard,standard,yes,yes,yes,yes
 41,45,dom-s-6-geog_in-s-geog-6-wGen,"site geographic, weather generator",success,example-wGen,s,geographic,6,NA,180,NA,s,geographic,6,0,wGen,standard,1980,2010,dim,double,standard,standard,no,yes,yes,yes
-42,36,dom-s-6-geog_in-xy-geog-3x2,site-gridded geographic,success,example,s,geographic,6,NA,180,NA,xy,geographic,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,yes,yes,no
-43,37,dom-s-6-geog-shifted_in-xy-geog-3x2,site-gridded geographic shifted out-of-inputs,error,example,s,geographic,6,NA,180,10;5,xy,geographic,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,no,yes,no
-44,38,dom-s-6-geog-subset_in-xy-geog-3x2,site-gridded geographic subset,success,example,s,geographic,6,3;5,180,NA,xy,geographic,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,no,yes,no
-45,40,dom-s-6-proj_in-xy-proj-3x2,site-gridded projected,success,example,s,projected,6,NA,NA,NA,xy,projected,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,yes,yes,no
+42,35,dom-s-6-geog_in-xy-geog-3x2,site-gridded geographic,success,example,s,geographic,6,NA,180,NA,xy,geographic,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,yes,yes,no
+43,36,dom-s-6-geog-shifted_in-xy-geog-3x2,site-gridded geographic shifted out-of-inputs,error,example,s,geographic,6,NA,180,10;5,xy,geographic,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,no,yes,no
+44,37,dom-s-6-geog-subset_in-xy-geog-3x2,site-gridded geographic subset,success,example,s,geographic,6,3;5,180,NA,xy,geographic,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,no,yes,no
+45,38,dom-s-6-proj_in-xy-proj-3x2,site-gridded projected,success,example,s,projected,6,NA,NA,NA,xy,projected,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,yes,yes,no
 46,46,dom-xy-3x2-geog_in-xy-geog-gridMET-3x2,gridMET,success,example,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,1,gridMET,NA,1980,2010,dim,double,standard,standard,no,no,no,no
 47,47,dom-xy-3x2-geog_in-xy-geog-MACAv2METDATA-3x2,MACAv2METDATA,success,example,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,1,MACAv2METDATA,NA,1980,2005,dim,double,standard,standard,no,no,no,no
 48,48,dom-xy-3x2-geog_in-xy-geog-Daymet-3x2,Daymet-geographic,success,example,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,1,Daymet,NA,1980,2010,dim,double,standard,standard,no,no,no,no

--- a/tests/ncTestRuns/data-raw/metadata_testRuns.csv
+++ b/tests/ncTestRuns/data-raw/metadata_testRuns.csv
@@ -1,47 +1,50 @@
-id,testrun,tag,comment,expectation,domainType,domainCRS,domainSize,domainSubset,domainLonConvention,domainShift,inputType,inputCRS,inputSize,expectIndexLookup,inWeather,calendarWeather,simStartYear,simEndYear,pft,inputVarType,inputDimOrder,inputSoilProfile,inputsProvideSWRCp,StopRestart,EstimateEvCo,EstimateTrCo
-1,1,dom-s-1-geog_in-s-geog-1,example,success,s,geographic,1,NA,180,NA,s,geographic,1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
-2,5,dom-s-1-proj_in-s-geog-1,SpatialCombination-5,success,s,projected,1,NA,NA,NA,s,geographic,1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
-3,11,dom-xy-1x1-geog_in-xy-geog-1x1,SpatialCombination-11,success,xy,geographic,1x1,NA,180,NA,xy,geographic,1x1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
-4,15,dom-xy-1x1-proj_in-xy-geog-1x1,SpatialCombination-15,success,xy,projected,1x1,NA,NA,NA,xy,geographic,1x1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
-5,2,dom-s-1-geog_in-s-proj,SpatialCombination-2,error,s,geographic,1,NA,180,NA,s,projected,1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
-6,3,dom-s-1-geog_in-xy-geog-1x1,SpatialCombination-3,success,s,geographic,1,NA,180,NA,xy,geographic,1x1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
-7,4,dom-s-1-geog_in-xy-proj-1x1,SpatialCombination-4,error,s,geographic,1,NA,180,NA,xy,projected,1x1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
-8,6,dom-s-1-proj_in-s-proj,SpatialCombination-6,success,s,projected,1,NA,NA,NA,s,projected,1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
-9,7,dom-s-1-proj_in-xy-geog-1x1,SpatialCombination-7,success,s,projected,1,NA,NA,NA,xy,geographic,1x1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
-10,8,dom-s-1-proj_in-xy-proj-1x1,SpatialCombination-8,success,s,projected,1,NA,NA,NA,xy,projected,1x1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
-11,9,dom-xy-1x1-geog_in-s-geog,SpatialCombination-9,error,xy,geographic,1x1,NA,180,NA,s,geographic,1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
-12,10,dom-xy-1x1-geog_in-s-proj,SpatialCombination-10,error,xy,geographic,1x1,NA,180,NA,s,projected,1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
-13,12,dom-xy-1x1-geog_in-xy-proj-1x1,SpatialCombination-12,error,xy,geographic,1x1,NA,180,NA,xy,projected,1x1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
-14,13,dom-xy-1x1-proj_in-s-geog,SpatialCombination-13,error,xy,projected,1x1,NA,NA,NA,s,geographic,1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
-15,14,dom-xy-1x1-proj_in-s-proj,SpatialCombination-14,error,xy,projected,1x1,NA,NA,NA,s,projected,1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
-16,16,dom-xy-1x1-proj_in-xy-proj-1x1,SpatialCombination-16,success,xy,projected,1x1,NA,NA,NA,xy,projected,1x1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
-17,17,dom-s-1-geog_in-s-geog-1-noleap,noleap calendar,success,s,geographic,1,NA,180,NA,s,geographic,1,0,sw2,noleap,1980,2010,dim,double,standard,standard,no,no,no,no
-18,18,dom-s-1-geog_in-s-geog-1-allleap,allleap calendar,success,s,geographic,1,NA,180,NA,s,geographic,1,0,sw2,allleap,1980,2010,dim,double,standard,standard,no,no,no,no
-19,19,dom-s-1-geog_in-s-geog-1-float,float instead of double as input,success,s,geographic,1,NA,180,NA,s,geographic,1,0,sw2,standard,1980,2010,dim,float,standard,standard,no,no,no,no
-20,24,dom-xy-3x2-geog_in-xy-geog-3x2,gridded geographic,success,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,0,sw2,standard,1980,2010,dim,double,standard,standard,no,yes,yes,yes
-21,25,dom-xy-3x2-geog-shifted_in-xy-geog-3x2,gridded geographic shifted out-of-inputs,error,xy,geographic,3x2,NA,180,10;5,xy,geographic,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,no,yes,yes
-22,26,dom-xy-3x2-proj_in-xy-proj-3x2,gridded projected,success,xy,projected,3x2,NA,NA,NA,xy,projected,3x2,0,sw2,standard,1980,2010,dim,double,standard,standard,no,yes,yes,yes
-23,27,dom-xy-3x2-proj-subset_in-xy-proj-3x2,gridded projected subset,success,xy,projected,3x2,3;5,NA,NA,xy,projected,3x2,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,yes
-24,20,dom-xy-1x2-geog_in-xy-geog-3x2,gridded+lookup geographic,success,xy,geographic,1x2,NA,180,NA,xy,geographic,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,yes
-25,21,dom-xy-1x2-geog-lon360_in-xy-geog-3x2,gridded+lookup geographic lon0-360,success,xy,geographic,1x2,NA,360,NA,xy,geographic,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,yes
-26,22,dom-xy-1x2-proj_in-xy-proj-3x2,gridded+lookup projected,success,xy,projected,1x2,NA,NA,NA,xy,projected,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,yes
-27,23,dom-xy-1x2-proj-lon360_in-xy-geog-3x2,gridded+lookup projected lon0-360,success,xy,projected,1x2,NA,360,NA,xy,geographic,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,yes
-28,28,dom-xy-3x2-geog_in-xy-geog-3x2-pftvar,pft as variable instead dimension,success,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,0,sw2,standard,1980,2010,var,double,standard,standard,no,yes,yes,no
-29,29,dom-xy-3x2-geog_in-xy-geog-3x2-mixdim,"gridded geographic, mixed order of input dimensions",success,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,0,sw2,standard,1980,2010,dim,double,mix,standard,no,yes,yes,no
-30,30,dom-xy-3x2-geog_in-xy-geog-3x2-soillayers,variable number of soil layers,success,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,0,sw2,standard,1980,2010,dim,double,standard,variableSoilLayerNumber,no,yes,yes,no
-31,31,dom-xy-3x2-geog_in-xy-geog-3x2-soildepths,variable soil layer thickness,success,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,0,sw2,standard,1980,2010,dim,double,standard,variableSoilLayerThickness,no,yes,yes,no
-32,32,dom-xy-3x2-geog_in-xy-geog-3x2-swrcp,input SWRCp,success,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,0,sw2,standard,1980,2010,dim,double,standard,standard,yes,yes,yes,no
-33,36,dom-s-6-geog_in-s-geog-6,site geographic,success,s,geographic,6,NA,180,NA,s,geographic,6,0,sw2,standard,1980,2010,dim,double,standard,standard,no,yes,yes,yes
-34,38,dom-s-6-geog_in-s-geog-6-pftvar,pft as variable instead dimension,success,s,geographic,6,NA,180,NA,s,geographic,6,0,sw2,standard,1980,2010,var,double,standard,standard,no,yes,yes,yes
-35,39,dom-s-6-geog_in-s-geog-6-mixdim,"site geographic, mixed order of input dimensions",success,s,geographic,6,NA,180,NA,s,geographic,6,0,sw2,standard,1980,2010,dim,double,mix,standard,no,yes,yes,yes
-36,40,dom-s-6-geog_in-s-geog-6-soillayers,variable number of soil layers,success,s,geographic,6,NA,180,NA,s,geographic,6,0,sw2,standard,1980,2010,dim,double,standard,variableSoilLayerNumber,no,yes,yes,yes
-37,41,dom-s-6-geog_in-s-geog-6-soildepths,variable soil layer thickness,success,s,geographic,6,NA,180,NA,s,geographic,6,0,sw2,standard,1980,2010,dim,double,standard,variableSoilLayerThickness,no,yes,yes,yes
-38,42,dom-s-6-geog_in-s-geog-6-swrcp,input SWRCp,success,s,geographic,6,NA,180,NA,s,geographic,6,0,sw2,standard,1980,2010,dim,double,standard,standard,yes,yes,yes,yes
-39,33,dom-s-6-geog_in-xy-geog-3x2,site-gridded geographic,success,s,geographic,6,NA,180,NA,xy,geographic,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,yes,yes,no
-40,34,dom-s-6-geog-shifted_in-xy-geog-3x2,site-gridded geographic shifted out-of-inputs,error,s,geographic,6,NA,180,10;5,xy,geographic,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,no,yes,no
-41,35,dom-s-6-geog-subset_in-xy-geog-3x2,site-gridded geographic subset,success,s,geographic,6,3;5,180,NA,xy,geographic,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,no,yes,no
-42,37,dom-s-6-proj_in-xy-proj-3x2,site-gridded projected,success,s,projected,6,NA,NA,NA,xy,projected,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,yes,yes,no
-43,43,dom-xy-3x2-geog_in-xy-geog-gridMET-3x2,gridMET,success,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,1,gridMET,NA,1980,2010,dim,double,standard,standard,no,no,no,no
-44,44,dom-xy-3x2-geog_in-xy-geog-MACAv2METDATA-3x2,MACAv2METDATA,success,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,1,MACAv2METDATA,NA,1980,2005,dim,double,standard,standard,no,no,no,no
-45,45,dom-xy-3x2-geog_in-xy-geog-Daymet-3x2,Daymet-geographic,success,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,1,Daymet,NA,1980,2010,dim,double,standard,standard,no,no,no,no
-46,46,dom-xy-3x2-proj_in-xy-proj-Daymet-3x2,Daymet-projected,success,xy,projected,3x2,NA,NA,NA,xy,projected,3x2,1,Daymet,NA,1980,2010,dim,double,standard,standard,no,no,no,no
+id,testrun,tag,comment,expectation,reference,domainType,domainCRS,domainSize,domainSubset,domainLonConvention,domainShift,inputType,inputCRS,inputSize,expectIndexLookup,inWeather,calendarWeather,simStartYear,simEndYear,pft,inputVarType,inputDimOrder,inputSoilProfile,inputsProvideSWRCp,StopRestart,EstimateEvCo,EstimateTrCo
+1,1,dom-s-1-geog_in-s-geog-1,example,success,example,s,geographic,1,NA,180,NA,s,geographic,1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
+2,2,dom-s-1-geog_in-s-geog-1-wGen,example-wGen,success,example-wGen,s,geographic,1,NA,180,NA,s,geographic,1,0,wGen,standard,1980,2010,dim,double,standard,standard,no,no,no,no
+3,6,dom-s-1-proj_in-s-geog-1,SpatialCombination-5,success,example,s,projected,1,NA,NA,NA,s,geographic,1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
+4,12,dom-xy-1x1-geog_in-xy-geog-1x1,SpatialCombination-11,success,example,xy,geographic,1x1,NA,180,NA,xy,geographic,1x1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
+5,16,dom-xy-1x1-proj_in-xy-geog-1x1,SpatialCombination-15,success,example,xy,projected,1x1,NA,NA,NA,xy,geographic,1x1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
+6,3,dom-s-1-geog_in-s-proj,SpatialCombination-2,error,example,s,geographic,1,NA,180,NA,s,projected,1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
+7,4,dom-s-1-geog_in-xy-geog-1x1,SpatialCombination-3,success,example,s,geographic,1,NA,180,NA,xy,geographic,1x1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
+8,5,dom-s-1-geog_in-xy-proj-1x1,SpatialCombination-4,error,example,s,geographic,1,NA,180,NA,xy,projected,1x1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
+9,7,dom-s-1-proj_in-s-proj,SpatialCombination-6,success,example,s,projected,1,NA,NA,NA,s,projected,1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
+10,8,dom-s-1-proj_in-xy-geog-1x1,SpatialCombination-7,success,example,s,projected,1,NA,NA,NA,xy,geographic,1x1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
+11,9,dom-s-1-proj_in-xy-proj-1x1,SpatialCombination-8,success,example,s,projected,1,NA,NA,NA,xy,projected,1x1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
+12,10,dom-xy-1x1-geog_in-s-geog,SpatialCombination-9,error,example,xy,geographic,1x1,NA,180,NA,s,geographic,1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
+13,11,dom-xy-1x1-geog_in-s-proj,SpatialCombination-10,error,example,xy,geographic,1x1,NA,180,NA,s,projected,1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
+14,13,dom-xy-1x1-geog_in-xy-proj-1x1,SpatialCombination-12,error,example,xy,geographic,1x1,NA,180,NA,xy,projected,1x1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
+15,14,dom-xy-1x1-proj_in-s-geog,SpatialCombination-13,error,example,xy,projected,1x1,NA,NA,NA,s,geographic,1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
+16,15,dom-xy-1x1-proj_in-s-proj,SpatialCombination-14,error,example,xy,projected,1x1,NA,NA,NA,s,projected,1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
+17,17,dom-xy-1x1-proj_in-xy-proj-1x1,SpatialCombination-16,success,example,xy,projected,1x1,NA,NA,NA,xy,projected,1x1,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,no
+18,18,dom-s-1-geog_in-s-geog-1-noleap,noleap calendar,success,example,s,geographic,1,NA,180,NA,s,geographic,1,0,sw2,noleap,1980,2010,dim,double,standard,standard,no,no,no,no
+19,19,dom-s-1-geog_in-s-geog-1-allleap,allleap calendar,success,example,s,geographic,1,NA,180,NA,s,geographic,1,0,sw2,allleap,1980,2010,dim,double,standard,standard,no,no,no,no
+20,20,dom-s-1-geog_in-s-geog-1-float,float instead of double as input,success,example,s,geographic,1,NA,180,NA,s,geographic,1,0,sw2,standard,1980,2010,dim,float,standard,standard,no,no,no,no
+21,25,dom-xy-3x2-geog_in-xy-geog-3x2,gridded geographic,success,example,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,0,sw2,standard,1980,2010,dim,double,standard,standard,no,yes,yes,yes
+22,26,dom-xy-3x2-geog-shifted_in-xy-geog-3x2,gridded geographic shifted out-of-inputs,error,example,xy,geographic,3x2,NA,180,10;5,xy,geographic,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,no,yes,yes
+23,27,dom-xy-3x2-proj_in-xy-proj-3x2,gridded projected,success,example,xy,projected,3x2,NA,NA,NA,xy,projected,3x2,0,sw2,standard,1980,2010,dim,double,standard,standard,no,yes,yes,yes
+24,28,dom-xy-3x2-proj-subset_in-xy-proj-3x2,gridded projected subset,success,example,xy,projected,3x2,3;5,NA,NA,xy,projected,3x2,0,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,yes
+25,21,dom-xy-1x2-geog_in-xy-geog-3x2,gridded+lookup geographic,success,example,xy,geographic,1x2,NA,180,NA,xy,geographic,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,yes
+26,22,dom-xy-1x2-geog-lon360_in-xy-geog-3x2,gridded+lookup geographic lon0-360,success,example,xy,geographic,1x2,NA,360,NA,xy,geographic,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,yes
+27,23,dom-xy-1x2-proj_in-xy-proj-3x2,gridded+lookup projected,success,example,xy,projected,1x2,NA,NA,NA,xy,projected,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,yes
+28,24,dom-xy-1x2-proj-lon360_in-xy-geog-3x2,gridded+lookup projected lon0-360,success,example,xy,projected,1x2,NA,360,NA,xy,geographic,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,no,no,yes
+29,29,dom-xy-3x2-geog_in-xy-geog-3x2-pftvar,pft as variable instead dimension,success,example,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,0,sw2,standard,1980,2010,var,double,standard,standard,no,yes,yes,no
+30,30,dom-xy-3x2-geog_in-xy-geog-3x2-mixdim,"gridded geographic, mixed order of input dimensions",success,example,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,0,sw2,standard,1980,2010,dim,double,mix,standard,no,yes,yes,no
+31,31,dom-xy-3x2-geog_in-xy-geog-3x2-soillayers,variable number of soil layers,success,example,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,0,sw2,standard,1980,2010,dim,double,standard,variableSoilLayerNumber,no,yes,yes,no
+32,32,dom-xy-3x2-geog_in-xy-geog-3x2-soildepths,variable soil layer thickness,success,example,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,0,sw2,standard,1980,2010,dim,double,standard,variableSoilLayerThickness,no,yes,yes,no
+33,33,dom-xy-3x2-geog_in-xy-geog-3x2-swrcp,input SWRCp,success,example,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,0,sw2,standard,1980,2010,dim,double,standard,standard,yes,yes,yes,no
+34,34,dom-xy-3x2-geog_in-xy-geog-3x2-wGen,"gridded geographic, weather generator",success,example-wGen,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,0,wGen,standard,1980,2010,dim,double,standard,standard,no,yes,yes,yes
+35,38,dom-s-6-geog_in-s-geog-6,site geographic,success,example,s,geographic,6,NA,180,NA,s,geographic,6,0,sw2,standard,1980,2010,dim,double,standard,standard,no,yes,yes,yes
+36,40,dom-s-6-geog_in-s-geog-6-pftvar,pft as variable instead dimension,success,example,s,geographic,6,NA,180,NA,s,geographic,6,0,sw2,standard,1980,2010,var,double,standard,standard,no,yes,yes,yes
+37,41,dom-s-6-geog_in-s-geog-6-mixdim,"site geographic, mixed order of input dimensions",success,example,s,geographic,6,NA,180,NA,s,geographic,6,0,sw2,standard,1980,2010,dim,double,mix,standard,no,yes,yes,yes
+38,42,dom-s-6-geog_in-s-geog-6-soillayers,variable number of soil layers,success,example,s,geographic,6,NA,180,NA,s,geographic,6,0,sw2,standard,1980,2010,dim,double,standard,variableSoilLayerNumber,no,yes,yes,yes
+39,43,dom-s-6-geog_in-s-geog-6-soildepths,variable soil layer thickness,success,example,s,geographic,6,NA,180,NA,s,geographic,6,0,sw2,standard,1980,2010,dim,double,standard,variableSoilLayerThickness,no,yes,yes,yes
+40,44,dom-s-6-geog_in-s-geog-6-swrcp,input SWRCp,success,example,s,geographic,6,NA,180,NA,s,geographic,6,0,sw2,standard,1980,2010,dim,double,standard,standard,yes,yes,yes,yes
+41,45,dom-s-6-geog_in-s-geog-6-wGen,"site geographic, weather generator",success,example-wGen,s,geographic,6,NA,180,NA,s,geographic,6,0,wGen,standard,1980,2010,dim,double,standard,standard,no,yes,yes,yes
+42,36,dom-s-6-geog_in-xy-geog-3x2,site-gridded geographic,success,example,s,geographic,6,NA,180,NA,xy,geographic,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,yes,yes,no
+43,37,dom-s-6-geog-shifted_in-xy-geog-3x2,site-gridded geographic shifted out-of-inputs,error,example,s,geographic,6,NA,180,10;5,xy,geographic,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,no,yes,no
+44,38,dom-s-6-geog-subset_in-xy-geog-3x2,site-gridded geographic subset,success,example,s,geographic,6,3;5,180,NA,xy,geographic,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,no,yes,no
+45,40,dom-s-6-proj_in-xy-proj-3x2,site-gridded projected,success,example,s,projected,6,NA,NA,NA,xy,projected,3x2,1,sw2,standard,1980,2010,dim,double,standard,standard,no,yes,yes,no
+46,46,dom-xy-3x2-geog_in-xy-geog-gridMET-3x2,gridMET,success,example,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,1,gridMET,NA,1980,2010,dim,double,standard,standard,no,no,no,no
+47,47,dom-xy-3x2-geog_in-xy-geog-MACAv2METDATA-3x2,MACAv2METDATA,success,example,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,1,MACAv2METDATA,NA,1980,2005,dim,double,standard,standard,no,no,no,no
+48,48,dom-xy-3x2-geog_in-xy-geog-Daymet-3x2,Daymet-geographic,success,example,xy,geographic,3x2,NA,180,NA,xy,geographic,3x2,1,Daymet,NA,1980,2010,dim,double,standard,standard,no,no,no,no
+49,49,dom-xy-3x2-proj_in-xy-proj-Daymet-3x2,Daymet-projected,success,example,xy,projected,3x2,NA,NA,NA,xy,projected,3x2,1,Daymet,NA,1980,2010,dim,double,standard,standard,no,no,no,no

--- a/tests/ncTestRuns/scripts/Rscript__ncTestRuns_00_createReferenceRun.R
+++ b/tests/ncTestRuns/scripts/Rscript__ncTestRuns_00_createReferenceRun.R
@@ -140,7 +140,7 @@ res <- runSW2(
   renameDomainTemplate = TRUE
 )
 
-fname_logfile <- file.path(dir_refRun, "logs", "logfile.log")
+fname_logfile <- file.path(dir_refRun, "logs", "rank_0_logfile.log")
 has_logfile <- file.exists(fname_logfile)
 
 logfile <- if (has_logfile) readLines(fname_logfile)

--- a/tests/ncTestRuns/scripts/Rscript__ncTestRuns_00_createReferenceRun.R
+++ b/tests/ncTestRuns/scripts/Rscript__ncTestRuns_00_createReferenceRun.R
@@ -14,7 +14,7 @@
 #       --path-to-sw2=<...> \
 #       --swMode=<...> \
 #       --ntasks=<...> \
-#       --path-to-referenceOutput=<...>
+#       --path-to-references=<...>
 # ```
 #------------------------------------------------------------------------------#
 
@@ -66,18 +66,20 @@ fname_sw2 <- if (any(ids)) {
 
 stopifnot(file.exists(fname_sw2))
 
-ids <- grepl("--path-to-referenceOutput", args, fixed = TRUE)
-frefOutput <- if (any(ids)) {
-  sub("--path-to-referenceOutput", "", args[ids], fixed = TRUE) |>
+ids <- grepl("--path-to-references", args, fixed = TRUE)
+path_refFolder <- if (any(ids)) {
+  sub("--path-to-references", "", args[ids], fixed = TRUE) |>
     sub("=", "", x = _, fixed = TRUE) |>
     trimws()
 } else {
-  file.path("tests", "ncTestRuns", "results", "referenceRun", "Output")
+  file.path("tests", "ncTestRuns", "results", "referenceRuns")
 }
 
-dir_refRun <- dirname(file.path(dir_prj, "..", "..", frefOutput))
 dir_refRunTemplate <- file.path(dir_prj, "..", "..", "tests", "example")
 stopifnot(dir.exists(dir_refRunTemplate))
+
+dir_dataraw <- file.path(dir_prj, "data-raw")
+stopifnot(dir.exists(dir_dataraw))
 
 dir_R <- file.path(dir_prj, "R")
 stopifnot(dir.exists(dir_R))
@@ -87,6 +89,7 @@ stopifnot(dir.exists(dir_R))
 #------ Load functions ------
 copyDir <- NULL
 toggleNCInputTSV <- NULL
+setTxtInput <- NULL
 runSW2 <- NULL
 
 res <- lapply(
@@ -96,60 +99,92 @@ res <- lapply(
 
 
 #------ . ------
-#------ Create reference run ------
+#------ Create reference runs ------
 
-#--- * Create temporary run from reference template ------
-unlink(dir_refRun, recursive = TRUE)
-dir.create(dir_refRun, recursive = TRUE, showWarnings = FALSE)
+implementedReferences <- c("example", "example-wGen")
 
-stopifnot(
-  copyDir(
-    from = file.path(dir_refRunTemplate, "Input"),
-    to = file.path(dir_refRun, "Input")
-  ),
-  copyDir(
-    from = file.path(dir_refRunTemplate, "Input_nc"),
-    to = file.path(dir_refRun, "Input_nc")
-  ),
-  file.copy(
-    from = file.path(dir_refRunTemplate, "files.in"),
-    to = dir_refRun
+
+#--- * Specifications of test runs ------
+listTestRuns <- utils::read.csv(
+  file = file.path(dir_dataraw, "metadata_testRuns.csv")
+)
+
+refRuns <- unique(listTestRuns[["reference"]])
+stopifnot(refRuns %in% implementedReferences)
+
+dir_refRuns <- file.path(dir_prj, "..", "..", path_refFolder, refRuns)
+
+
+for (k0 in seq_along(dir_refRuns)) {
+
+  #--- * Create temporary run from reference template ------
+  unlink(dir_refRuns[[k0]], recursive = TRUE)
+  dir.create(dir_refRuns[[k0]], recursive = TRUE, showWarnings = FALSE)
+
+  stopifnot(
+    copyDir(
+      from = file.path(dir_refRunTemplate, "Input"),
+      to = file.path(dir_refRuns[[k0]], "Input")
+    ),
+    copyDir(
+      from = file.path(dir_refRunTemplate, "Input_nc"),
+      to = file.path(dir_refRuns[[k0]], "Input_nc")
+    ),
+    file.copy(
+      from = file.path(dir_refRunTemplate, "files.in"),
+      to = dir_refRuns[[k0]]
+    )
   )
-)
 
 
-#--- * Turn off nc-inputs ------
-fname_ncintsv <- file.path(
-  dir_refRun, "Input_nc", "SW2_netCDF_input_variables.tsv"
-)
+  #--- * Turn off nc-inputs ------
+  fname_ncintsv <- file.path(
+    dir_refRuns[[k0]], "Input_nc", "SW2_netCDF_input_variables.tsv"
+  )
 
-toggleNCInputTSV(
-  filename = fname_ncintsv,
-  inkeys = c("inTopo", "inClimate", "inSoil", "inVeg", "inWeather"),
-  sw2vars = NULL,
-  value = 0L
-)
-
-
-#--- * Execute refRun ------
-res <- runSW2(
-  sw2 = fname_sw2,
-  path_inputs = dir_refRun,
-  mode = swMode,
-  nTasks = nTasks,
-  renameDomainTemplate = TRUE
-)
-
-fname_logfile <- file.path(dir_refRun, "logs", "rank_0_logfile.log")
-has_logfile <- file.exists(fname_logfile)
-
-logfile <- if (has_logfile) readLines(fname_logfile)
-has_logContent <- nzchar(paste(logfile, collapse = " "))
+  toggleNCInputTSV(
+    filename = fname_ncintsv,
+    inkeys = c("inTopo", "inClimate", "inSoil", "inVeg", "inWeather"),
+    sw2vars = NULL,
+    value = 0L
+  )
 
 
-if (!is.null(res[["msg"]]) || has_logContent) {
-  cat("Reference run failed.", fill = TRUE)
-  quit(status = 1L)
+  #--- * Turn on weather generator (wGen) ------
+  if (grepl("wGen", basename(dir_refRuns[[k0]]), fixed = TRUE)) {
+    fname <- file.path(dir_refRuns[[k0]], "Input", "weathsetup.in")
+    setTxtInput(
+      filename = fname,
+      tag = "# 0 = use historical data only$",
+      value = 2L,
+      classic = TRUE
+    )
+  }
+
+
+  #--- * Execute refRun ------
+  res <- runSW2(
+    sw2 = fname_sw2,
+    path_inputs = dir_refRuns[[k0]],
+    mode = swMode,
+    nTasks = nTasks,
+    renameDomainTemplate = TRUE
+  )
+
+  fname_logfile <- file.path(dir_refRuns[[k0]], "logs", "rank_0_logfile.log")
+  has_logfile <- file.exists(fname_logfile)
+
+  logfile <- if (has_logfile) readLines(fname_logfile)
+  has_logContent <- nzchar(paste(logfile, collapse = " "))
+
+
+  if (!is.null(res[["msg"]]) || has_logContent) {
+    cat(
+      "Reference run", shQuote(basename(dir_refRuns[[k0]])), "failed.",
+      fill = TRUE
+    )
+    quit(status = 1L)
+  }
 }
 
 #------ . ------

--- a/tests/ncTestRuns/scripts/Rscript__ncTestRuns_01_createTestRuns.R
+++ b/tests/ncTestRuns/scripts/Rscript__ncTestRuns_01_createTestRuns.R
@@ -403,16 +403,23 @@ pb <- utils::txtProgressBar(max = nrow(listTestRuns), style = 3L)
 for (k0 in seq_len(nrow(listTestRuns))) {
 
   #------ . ------
-  # Skip a testRun if no external weather data
-  if (isFALSE(hasWeather[[listTestRuns[k0, "inWeather"]]])) {
+  useWeatherGenerator <- identical(listTestRuns[k0, "inWeather"], "wGen")
+
+  # Skip a testRun if weather inputs and no weather data available
+  if (
+    !useWeatherGenerator &&
+      isFALSE(hasWeather[[listTestRuns[k0, "inWeather"]]])
+  ) {
     utils::setTxtProgressBar(pb, value = k0)
     next
   }
 
 
   #--- * Create testRun ------
-  isSW2ExampleRun <- identical(
-    listTestRuns[k0, "tag"], "dom-s-1-geog_in-s-geog-1"
+  isSW2ExampleRun <- grepl(
+    "dom-s-1-geog_in-s-geog-1",
+    listTestRuns[k0, "tag"],
+    fixed = TRUE
   )
 
   tagk <- paste0(
@@ -2447,10 +2454,12 @@ for (k0 in seq_len(nrow(listTestRuns))) {
 
   stopifnot(
     listTestRuns[k0, "inWeather"] %in%
-      c("sw2", "gridMET", "MACAv2METDATA", "Daymet")
+      c("sw2", "wGen", "gridMET", "MACAv2METDATA", "Daymet")
   )
 
-  useWeatherDatasets <- !identical(listTestRuns[k0, "inWeather"], "sw2")
+  useWeatherDatasets <- !any(
+    useWeatherGenerator, identical(listTestRuns[k0, "inWeather"], "sw2")
+  )
 
   ids1 <- which(inputWeatherTSV[["dataset"]] == listTestRuns[k0, "inWeather"])
   tmp <- sw_crs[[listTestRuns[k0, "inputCRS"]]][["grid_mapping_name"]]
@@ -2612,6 +2621,13 @@ for (k0 in seq_len(nrow(listTestRuns))) {
 
       RNetCDF::close.nc(nc)
     }
+  }
+
+
+  if (identical(listTestRuns[k0, "inWeather"], "wGen")) {
+    #--- ..** inWeather weather generator ------
+    impute_weather <- 2L
+    vars_weather <- NULL
   }
 
 

--- a/tests/ncTestRuns/scripts/Rscript__ncTestRuns_01_createTestRuns.R
+++ b/tests/ncTestRuns/scripts/Rscript__ncTestRuns_01_createTestRuns.R
@@ -158,6 +158,8 @@ listTestRuns <- utils::read.csv(
   file = file.path(dir_dataraw, "metadata_testRuns.csv")
 )
 
+stopifnot(anyDuplicated(listTestRuns[["testrun"]]) == 0L)
+
 nTotalTestRuns <- nrow(listTestRuns)
 
 if (reqTestRuns > 0L) {

--- a/tests/ncTestRuns/scripts/Rscript__ncTestRuns_02_checkTestRuns.R
+++ b/tests/ncTestRuns/scripts/Rscript__ncTestRuns_02_checkTestRuns.R
@@ -145,8 +145,7 @@ compareNC <- NULL
 compareNCWeather <- NULL
 listInputWeather <- NULL
 listOutputWeather <- NULL
-colorTestReport <- NULL
-printColoredDF <- NULL
+printReportRow <- NULL
 
 res <- lapply(
   list.files(path = dir_R, pattern = ".R$", full.names = TRUE),
@@ -216,9 +215,14 @@ stopifnot(any(lengths(fnames_ref) > 0L))
 
 
 #------ . ------
-#------ Execute nc-testRuns ------
+#------ Prepare test outcome report ------
 resTestRuns <- data.frame(
   TestName = testRunTags,
+  TestNameShort = vapply(
+    strsplit(testRunTags, split = "__", fixed = TRUE),
+    function(x) x[[1L]],
+    FUN.VALUE = NA_character_
+  ),
   Expectation = NA,
   CheckRun = "not run",
   MessageRun = "",
@@ -227,18 +231,32 @@ resTestRuns <- data.frame(
   stringsAsFactors = FALSE
 )
 
+rownames(resTestRuns) <- NULL
+
+nTestRuns <- nrow(resTestRuns)
+
+hasCCLI <- isTRUE(requireNamespace("cli", quietly = TRUE))
+
+vars_report <- c(
+  "TestNameShort", "Expectation", "CheckRun", "CompToRef", "CompToWeather"
+)
+stopifnot(vars_report %in% colnames(resTestRuns))
+
+cat("\nExecute and check", nTestRuns, "ncTestRuns ...", fill = TRUE)
+msg <- "\nSummary of test outcomes:"
+cat(if (hasCCLI) cli::style_bold(msg) else msg, fill = TRUE)
+printReportRow(vars_report, colored = hasCCLI)
+
+
+#------ . ------
+#------ Execute nc-testRuns ------
 
 #--- Loop over testRuns ------
-pb <- utils::txtProgressBar(max = nrow(listTestRuns), style = 3L)
 
-for (k0 in seq_len(nrow(listTestRuns))) {
+for (k0 in seq_len(nTestRuns)) {
 
   kt <- which(testRunTags[[k0]] == basename(testRunsTemplates))
-
-  if (length(kt) != 1L) {
-    utils::setTxtProgressBar(pb, value = k0)
-    next
-  }
+  if (length(kt) != 1L) next
 
   resTestRuns[k0, "Expectation"] <- tolower(listTestRuns[k0, "expectation"])
 
@@ -540,10 +558,11 @@ for (k0 in seq_len(nrow(listTestRuns))) {
     }
   }
 
-  utils::setTxtProgressBar(pb, value = k0)
+  printReportRow(resTestRuns[k0, vars_report], colored = hasCCLI)
 }
 
-close(pb)
+cat("\n")
+
 
 tmp <- summary(warnings())
 if (length(tmp) > 0L) {
@@ -552,32 +571,8 @@ if (length(tmp) > 0L) {
 
 
 #------ . ------
-#------ Report test outcomes ------
-has_cli <- isTRUE(requireNamespace("cli", quietly = TRUE))
-
-#--- * Overall report ------
-vars_report <- c(
-  "TestNameShort", "Expectation", "CheckRun", "CompToRef", "CompToWeather"
-)
+#------ Finalize test outcome report ------
 res <- resTestRuns
-rownames(res) <- NULL
-
-res[["TestNameShort"]] <- vapply(
-  strsplit(res[["TestName"]], split = "__", fixed = TRUE),
-  function(x) x[[1L]],
-  FUN.VALUE = NA_character_
-)
-
-msg <- "\nSummary of test outcomes:"
-if (has_cli) {
-  cat(cli::style_bold(msg), fill = TRUE)
-  printColoredDF(res, vars = vars_report)
-
-} else {
-  cat(msg, fill = TRUE)
-  print(res[, vars_report, drop = FALSE])
-}
-cat("\n")
 
 ids_failed <- c(
   grep("failed", res[["CheckRun"]], fixed = TRUE),
@@ -600,7 +595,7 @@ if (reportWarnings) {
 
   if (length(ids_okWithMsg) > 0L) {
     msg <- "Messages produced by successful tests:"
-    cat(if (has_cli) cli::style_bold(msg) else msg, fill = TRUE)
+    cat(if (hasCCLI) cli::style_bold(msg) else msg, fill = TRUE)
 
     for (kr in ids_okWithMsg) {
       tmp <- paste0(
@@ -618,7 +613,7 @@ if (reportWarnings) {
 #--- * Failures details ------
 if (length(ids_failed) > 0L) {
   msg <- "Failed tests:"
-  cat(if (has_cli) cli::style_bold(msg) else msg, fill = TRUE)
+  cat(if (hasCCLI) cli::style_bold(msg) else msg, fill = TRUE)
 
   for (kr in ids_failed) {
     tmp <- paste0(
@@ -629,7 +624,7 @@ if (length(ids_failed) > 0L) {
       "\n\t** Comparison to weather inputs: ", res[kr, "CompToWeather"]
     )
 
-    if (has_cli) {
+    if (hasCCLI) {
       tmp <- colorTestReport(tmp)
     }
 

--- a/tests/ncTestRuns/scripts/Rscript__ncTestRuns_02_checkTestRuns.R
+++ b/tests/ncTestRuns/scripts/Rscript__ncTestRuns_02_checkTestRuns.R
@@ -29,7 +29,7 @@
 #       --path-to-sw2=<...> \
 #       --swMode=<...> \
 #       --ntasks=<...> \
-#       --path-to-referenceOutput=<...> \
+#       --path-to-references=<...> \
 #       --testRuns=<...>
 # ```
 #------------------------------------------------------------------------------#
@@ -106,19 +106,15 @@ fname_sw2 <- if (any()) {
 
 stopifnot(file.exists(fname_sw2))
 
-ids <- grepl("--path-to-referenceOutput", args, fixed = TRUE)
-frefOutput <- if (any(ids)) {
-  sub("--path-to-referenceOutput", "", args[ids], fixed = TRUE) |>
+ids <- grepl("--path-to-references", args, fixed = TRUE)
+path_refFolder <- if (any(ids)) {
+  sub("--path-to-references", "", args[ids], fixed = TRUE) |>
     sub("=", "", x = _, fixed = TRUE) |>
     trimws()
 } else {
-  file.path("tests", "ncTestRuns", "results", "referenceRun", "Output")
+  file.path("tests", "ncTestRuns", "results", "referenceRuns")
 }
 
-dir_refOutput <- file.path(dir_prj, "..", "..", frefOutput)
-fnames_ref <- list.files(
-  path = dir_refOutput, pattern = ".nc$", full.names = TRUE
-)
 
 dir_dataraw <- file.path(dir_prj, "data-raw")
 stopifnot(dir.exists(dir_dataraw))
@@ -202,6 +198,23 @@ listExclusionPatterns <- if (file.exists(fep)) {
   readLines(fep)
 }
 
+
+#--- * Specifications of reference runs ------
+refRuns <- unique(listTestRuns[["reference"]])
+
+tmp <- file.path(dir_prj, "..", "..", path_refFolder)
+
+hasRefRuns <- list.dirs(tmp, full.names = FALSE, recursive = FALSE)
+stopifnot(refRuns %in% hasRefRuns)
+
+dir_refOutput <- stats::setNames(file.path(tmp, refRuns, "Output"), refRuns)
+
+fnames_ref <- lapply(
+  dir_refOutput, list.files, pattern = ".nc$", full.names = TRUE
+)
+stopifnot(any(lengths(fnames_ref) > 0L))
+
+
 #------ . ------
 #------ Execute nc-testRuns ------
 resTestRuns <- data.frame(
@@ -213,6 +226,7 @@ resTestRuns <- data.frame(
   CompToWeather = "missing",
   stringsAsFactors = FALSE
 )
+
 
 #--- Loop over testRuns ------
 pb <- utils::txtProgressBar(max = nrow(listTestRuns), style = 3L)
@@ -364,9 +378,12 @@ for (k0 in seq_len(nrow(listTestRuns))) {
         double = sqrt(.Machine[["double.eps"]])
       )
 
+      refName <- listTestRuns[k0, "reference"]
+
+
       #--- Identify simulation run corresponding to example site
       idSimExampleSite <-
-        file.path(dir_testRunOutput, basename(fnames_ref[[1L]])) |>
+        file.path(dir_testRunOutput, basename(fnames_ref[[refName]][[1L]])) |>
         getSitesFromNC() |>
         locateExampleSite()
 
@@ -374,12 +391,14 @@ for (k0 in seq_len(nrow(listTestRuns))) {
 
 
       #--- ....*** Comparisons to reference simulation output ------
-      if (length(fnames_ref) > 0L) {
+      usedFnamesRef <- fnames_ref[[refName]]
+
+      if (length(usedFnamesRef) > 0L) {
         ok <- TRUE
         outkeysWithMsg <- NULL
 
         checkValues <-
-          identical(listTestRuns[k0, "inWeather"], "sw2") &&
+          listTestRuns[k0, "inWeather"] %in% c("sw2", "wGen") &&
           isTRUE(
             listTestRuns[k0, "calendarWeather"] %in% comparableInputCalendars
           )
@@ -392,16 +411,16 @@ for (k0 in seq_len(nrow(listTestRuns))) {
           ftmp <- list.files(
             path = dir_testRunOutput, pattern = ".nc$", full.names = TRUE
           )
-          ids <- basename(fnames_ref) %in% basename(ftmp)
-          fnames_ref <- fnames_ref[ids]
+          ids <- basename(usedFnamesRef) %in% basename(ftmp)
+          usedFnamesRef <- usedFnamesRef[ids]
         }
 
 
         #--- ....**** Compare example simulation subset to reference ------
-        for (kr in seq_along(fnames_ref)) {
+        for (kr in seq_along(usedFnamesRef)) {
           msg <- try(
             compareNC(
-              fn = fnames_ref[[kr]],
+              fn = usedFnamesRef[[kr]],
               path = dir_testRunOutput,
               vars_required = vars_required,
               vars_other = vars_other,
@@ -420,7 +439,7 @@ for (k0 in seq_len(nrow(listTestRuns))) {
 
           if (!thisok && nzchar(msg)) {
             tmp <- strsplit(
-              basename(fnames_ref[[kr]]), split = "_", fixed = TRUE
+              basename(usedFnamesRef[[kr]]), split = "_", fixed = TRUE
             )[[1L]][[1L]]
 
             if (!tmp %in% outkeysWithMsg) {
@@ -433,11 +452,15 @@ for (k0 in seq_len(nrow(listTestRuns))) {
         }
 
 
-        #--- ....**** Compare testRun01 to reference simulation output ------
-        # testRun01 is supposed to be exactly equal to the reference
-        if (testRunTags[[k0]] == "testRun-01__dom-s-1-geog_in-s-geog-1") {
+        #--- ....**** Compare select runs for equality to references ------
+        # testRun01 is supposed to be exactly equal to "example"
+        # testRun02 is supposed to be exactly equal to "example-wGen"
+        if (
+          k0 <= length(dir_refOutput) &&
+            grepl("dom-s-1-geog_in-s-geog-1", testRunTags[[k0]], fixed = TRUE)
+        ) {
           msg <- compareEqualityNCs(
-            dir1 = dir_refOutput,
+            dir1 = dir_refOutput[[refName]],
             dir2 = dir_testRunOutput,
             tolerance = testTolerance
           )
@@ -464,50 +487,56 @@ for (k0 in seq_len(nrow(listTestRuns))) {
 
 
       #--- ....*** Compare daily weather between input/output ------
-      intsv <- utils::read.delim(
-        file.path(dir_testRun, "Input_nc", "SW2_netCDF_input_variables.tsv"),
-        check.names = FALSE
-      )
+      if (identical(listTestRuns[k0, "inWeather"], "wGen")) {
+        resTestRuns[k0, "CompToWeather"] <- "skipped"
 
-      listCompToWeather <- list(
-        tasmax = list(
-          input = listInputWeather("temp_max", intsv, dir_testRun),
-          output = listOutputWeather("tasmax", "TEMP", dir_testRunOutput)
-        ),
-        tasmin = list(
-          input = listInputWeather("temp_min", intsv, dir_testRun),
-          output = listOutputWeather("tasmin", "TEMP", dir_testRunOutput)
-        ),
-        pr = list(
-          input = listInputWeather("ppt", intsv, dir_testRun),
-          output = listOutputWeather("pr", "PRECIP", dir_testRunOutput)
+      } else {
+
+        intsv <- utils::read.delim(
+          file.path(dir_testRun, "Input_nc", "SW2_netCDF_input_variables.tsv"),
+          check.names = FALSE
         )
-      )
 
-      ok <- TRUE
-
-      for (kr in seq_along(listCompToWeather)) {
-        msg <- try(
-          compareNCWeather(
-            input = listCompToWeather[[kr]][["input"]],
-            output = listCompToWeather[[kr]][["output"]],
-            idExampleSite = idSimExampleSite,
-            tolerance = sqrt(.Machine[["double.eps"]])
+        listCompToWeather <- list(
+          tasmax = list(
+            input = listInputWeather("temp_max", intsv, dir_testRun),
+            output = listOutputWeather("tasmax", "TEMP", dir_testRunOutput)
           ),
-          silent = TRUE
+          tasmin = list(
+            input = listInputWeather("temp_min", intsv, dir_testRun),
+            output = listOutputWeather("tasmin", "TEMP", dir_testRunOutput)
+          ),
+          pr = list(
+            input = listInputWeather("ppt", intsv, dir_testRun),
+            output = listOutputWeather("pr", "PRECIP", dir_testRunOutput)
+          )
         )
 
-        thisok <- !inherits(msg, "try-error") && !nzchar(msg)
-        ok <- ok && thisok
+        ok <- TRUE
 
-        if (!thisok && nzchar(msg)) {
-          resTestRuns[k0, "MessageRun"] <- appendToMessage(
-            hasMsg = resTestRuns[k0, "MessageRun"], newMsg = msg
+        for (kr in seq_along(listCompToWeather)) {
+          msg <- try(
+            compareNCWeather(
+              input = listCompToWeather[[kr]][["input"]],
+              output = listCompToWeather[[kr]][["output"]],
+              idExampleSite = idSimExampleSite,
+              tolerance = sqrt(.Machine[["double.eps"]])
+            ),
+            silent = TRUE
           )
-        }
-      }
 
-      resTestRuns[k0, "CompToWeather"] <- if (ok) "ok" else "failed"
+          thisok <- !inherits(msg, "try-error") && !nzchar(msg)
+          ok <- ok && thisok
+
+          if (!thisok && nzchar(msg)) {
+            resTestRuns[k0, "MessageRun"] <- appendToMessage(
+              hasMsg = resTestRuns[k0, "MessageRun"], newMsg = msg
+            )
+          }
+        }
+
+        resTestRuns[k0, "CompToWeather"] <- if (ok) "ok" else "failed"
+      }
     }
   }
 

--- a/tools/check_ncTestRuns.sh
+++ b/tools/check_ncTestRuns.sh
@@ -298,7 +298,7 @@ if [ ! -d "${dirOutRef}" ] && [ "${dirOutRef}" = "${dirOutRefDefault}" ]; then
         --path-to-ncTestRuns="${dir_ncTestRuns}" \
         --path-to-sw2="${sw2}" \
         --swMode="${withMode}" \
-        --ntasks=2 \
+        --ntasks=1 \
         --path-to-referenceOutput="${dirOutRef}"
     status=$?
 

--- a/tools/check_ncTestRuns.sh
+++ b/tools/check_ncTestRuns.sh
@@ -338,7 +338,6 @@ fi
 
 
 if [ "${doCheck}" = "true" ]; then
-    echo $'\n'"Execute and check ncTestRuns ..."
     Rscript \
         "${dir_ncTestRuns}"/scripts/Rscript__ncTestRuns_02_checkTestRuns.R \
         --path-to-ncTestRuns="${dir_ncTestRuns}" \

--- a/tools/check_ncTestRuns.sh
+++ b/tools/check_ncTestRuns.sh
@@ -21,18 +21,19 @@ Actions:
     check               Execute SOILWAT2 and check selected test run(s).
     clean               Remove selected test setup and run(s).
     cleanTestRuns       Remove selected test run(s).
-    cleanReference      Remove the default reference run.
+    cleanReference      Remove the default reference runs.
     downloadExternalWeatherData Runs 'wget' scripts to download daily inputs
                         from external data sources including
                         Daymet, gridMET, and MACAv2METDATA
 
 Options:
-    -ref, --reference <path/to/reference/output>
-    --reference=<path/to/reference/output>
-                        Path to reference run output. If the default is
-                        selected as reference and output is missing, then
-                        SOILWAT2 will be run to create reference output.
-                        Default is 'tests/ncTestRuns/results/referenceRun/Output'
+    -ref, --reference <path/to/referenceRuns>
+    --reference=<path/to/referenceRuns>
+                        Path to folder with the reference run(s). If the default
+                        is selected as reference and output is missing, then
+                        SOILWAT2 will be run to create the reference outputs.
+                        Default is 'tests/ncTestRuns/results/referenceRuns' with
+                        'example/Output/' and 'example-wGen/Output/'
 
     -t, --testRun <test number>
     --testRun=<test number>
@@ -81,8 +82,8 @@ doCleanReference=false
 doCreate=false
 doCheck=false
 doExternalDownload=false
-dirOutRefDefault="${dir_ncTestRuns}""/results/referenceRun/Output"
-dirOutRef="${dirOutRefDefault}"
+dirRefDefaults="${dir_ncTestRuns}""/results/referenceRuns"
+dirReferences="${dirRefDefaults}"
 testRun=-1
 withMode="nc"
 nTasks=""
@@ -104,8 +105,8 @@ while [ $# -gt 0 ]; do
 
         downloadExternalWeatherData) doExternalDownload=true ;;
 
-        --reference=*) dirOutRef="${1#*=}" ;;
-        -ref|--reference) dirOutRef="$2"; shift ;;
+        --reference=*) dirReferences="${1#*=}" ;;
+        -ref|--reference) dirReferences="$2"; shift ;;
 
         --testRun=*) testRun="${1#*=}" ;;
         -t|--testRun) testRun="$2"; shift ;;
@@ -181,7 +182,7 @@ if [ "${doCleanTestRuns}" = "true" ] || [ "${doCleanTests}" = "true" ]; then
 fi
 
 if [ "${doCleanReference}" = "true" ]; then
-    rm -rf "${dir_ncTestRuns}"/results/referenceRun > /dev/null 2>&1
+    rm -rf "${dirRefDefaults}" > /dev/null 2>&1
 fi
 
 
@@ -289,7 +290,7 @@ if ! hasSW2 "${sw2}" "${withMode}"; then
 fi
 
 
-if [ ! -d "${dirOutRef}" ] && [ "${dirOutRef}" = "${dirOutRefDefault}" ]; then
+if [ ! -d "${dirReferences}" ] && [ "${dirReferences}" = "${dirRefDefaults}" ]; then
     echo $'\n'"Run SOILWAT2 to create default reference output ..."
     make clean_example
 
@@ -299,7 +300,7 @@ if [ ! -d "${dirOutRef}" ] && [ "${dirOutRef}" = "${dirOutRefDefault}" ]; then
         --path-to-sw2="${sw2}" \
         --swMode="${withMode}" \
         --ntasks=1 \
-        --path-to-referenceOutput="${dirOutRef}"
+        --path-to-references="${dirReferences}"
     status=$?
 
     if [ $status -ne 0 ]; then
@@ -308,8 +309,8 @@ if [ ! -d "${dirOutRef}" ] && [ "${dirOutRef}" = "${dirOutRefDefault}" ]; then
     fi
 fi
 
-if [ -d "${dirOutRef}" ]; then
-    echo $'\n'"Values from '""${dirOutRef}""' will be used as reference."
+if [ -d "${dirReferences}" ]; then
+    echo $'\n'"Values from '""${dirReferences}""' will be used as reference."
 else
     echo $'\n'"Failed to locate reference output ..."
     exit 1
@@ -344,7 +345,7 @@ if [ "${doCheck}" = "true" ]; then
         --path-to-sw2="${sw2}" \
         --swMode="${withMode}" \
         --ntasks="${nTasks}" \
-        --path-to-referenceOutput="${dirOutRef}" \
+        --path-to-references="${dirReferences}" \
         --testRuns="${testRun}"
 fi
 


### PR DESCRIPTION
A few bugs have been found that deal with the markov weather generator which need to be fixed

- When the weather generator method is 2 (markov), dynamic memory is not allocated within `SW_RUN_deepCopy()` resulting in a possible segmentation fault or attempting to free a pointer that's already been freed (see #497)
- In SWNETCDF mode, we do not finalize the weather if weather is not read in (see #498)