### PR TITLE
Feature informative messages (2nd attempt)

### DIFF
--- a/include/SW_MPI.h
+++ b/include/SW_MPI.h
@@ -136,7 +136,7 @@ void SW_MPI_write_outputs(
     double *temp_p_OUT[][SW_OUTNPERIODS],
     size_t distSUIDs[][2],
     size_t numSuids,
-    Bool siteDom,
+    Bool isSimDomDiscrete,
     SW_OUT_DOM *OutDom,
     Bool succFlags[],
     size_t starts[][2],

--- a/include/SW_datastructs.h
+++ b/include/SW_datastructs.h
@@ -1609,8 +1609,9 @@ typedef struct {
        domain information - domain and progress variables */
     int ncDomVarIDs[SW_NVARDOM];
 
-    /* Flags specifying each domain's type */
-    Bool siteDoms[SW_NINKEYSNC];
+    /** Flags specifying each domain's type:
+        FALSE (gridded), TRUE (discrete sites) */
+    Bool isInDomDiscrete[SW_NINKEYSNC];
 
     /** Indicates which variables are provided by netCDF inputs
 
@@ -1796,22 +1797,28 @@ typedef struct {
     // Spatial domain information
     // SUID = simulation unit identifier
 
-    /** Type of domain: 'xy' (grid), 's' (sites) (3 = 2 characters + '\0') */
-    char DomainType[3];
+    /** Type of simulation domain:
+        FALSE ('xy' grid), TRUE ('s' discrete sites) */
+    Bool isSimDomDiscrete;
 
-    size_t      // to clarify, "long" = "long int", not double
-        nDimX,  /**< Number of grid cells along x dimension (used if domainType
-                   is 'xy') */
-        nDimY,  /**< Number of grid cells along y dimension (used if domainType
-                   is 'xy') */
-        nDimS,  /**< Number of sites (used if domainType is 's') */
-        nSUIDs, /**< Total size of domain, i.e., total number of grid cells (if
-                   domainType is 'xy') or number of sites (if domainType is 's')
-                 */
+    /** Number of grid cells along x dimension (gridded simulation domains) */
+    size_t nDimX;
 
-        startSimSet, /**< First SUID in simulation set within domain to simulate
-                      */
-        endSimSet; /**< Last SUID in simulation set within domain to simulate */
+    /** Number of grid cells along y dimension (gridded simulation domains) */
+    size_t nDimY;
+
+    /** Number of discrete sites (site-based simulation domains) */
+    size_t nDimS;
+
+    /** Total size of domain, i.e., total number of grid cells or
+    number of sites */
+    size_t nSUIDs;
+
+    /** First SUID in simulation set within domain to simulate */
+    size_t startSimSet;
+
+    /** Last SUID in simulation set within domain to simulate */
+    size_t endSimSet;
 
     char crs_bbox[27]; /**< Input name/CRS type (domain.in) - holds up to "World
                           Geodetic System 1984" (26) */
@@ -2007,7 +2014,7 @@ void SW_DATA_create_tree(
     double *xCoords,
     size_t ySize,
     size_t xSize,
-    Bool inIsGridded,
+    Bool isInDomDiscrete,
     Bool has2DCoordVars,
     Bool inPrimCRSIsGeo,
     sw_converter_t *yxConvs[],

--- a/include/SW_datastructs.h
+++ b/include/SW_datastructs.h
@@ -1227,18 +1227,28 @@ typedef struct {
         warningMsgs[MAX_MSGS][MAX_LOG_SIZE]; // Holds up to MAX_MSGS warning
                                              // messages to report
 
+    /** Stage of program to be prefixed to messages.
+    Possible values: setup; input; spinup; simulation; wrapup */
+    char logStage[11];
+
     /** Simulation unit to be prefixed to messages */
     /* 49 = 9 character for "suid [, ]" +
             40 character for 2 * ULONG_MAX + '\0'
     */
     char logSUID[49];
 
-    /** Stage of program to be prefixed to messages.
-    Possible values: setup; spinup; simulation; wrapup */
-    char logStage[11];
+    /* Helper information for #LOG_INFO.logSUID. */
+    Bool hasLogSUID;
+    size_t ncSUID[2];
+    Bool isSimDomDiscrete;
 
     /** Simulation time YYYY-DDD to be prefixed to messages */
     char logDate[9];
+
+    /* Helper information for #LOG_INFO.logDate. */
+    Bool hasLogDate;
+    TimeInt logYear;
+    TimeInt logDOY;
 
     int numWarnings;          // Number of total warnings thrown
     size_t numDomainWarnings, /**< Number of suids with at least one warning */

--- a/include/SW_netCDF_General.h
+++ b/include/SW_netCDF_General.h
@@ -144,7 +144,7 @@ void SW_NC_get_dimlen_from_dimname(
 
 void SW_NC_create_full_var(
     int *ncFileID,
-    const char *domType,
+    Bool isSimDomDiscrete,
     int newVarType,
     size_t timeSize,
     size_t vertSize,
@@ -184,7 +184,7 @@ void SW_NC_create_netCDF_var(
 );
 
 void SW_NC_create_template(
-    const char *domType,
+    Bool isSimDomDiscrete,
     const char *domFile,
     const char *fileName,
     int *newFileID,

--- a/include/SW_netCDF_Input.h
+++ b/include/SW_netCDF_Input.h
@@ -130,7 +130,7 @@ void SW_NCIN_alloc_weather_indices_years(
 void SW_NCIN_read_inputs(
     SW_RUN *sw,
     SW_DOMAIN *SW_Domain,
-    const size_t ncSUID[],
+    const size_t ncSUIDs[][2],
     size_t starts[][N_SUID_ASSIGN][2],
     size_t counts[][N_SUID_ASSIGN][2],
     int **openNCFileIDs[],

--- a/include/SW_netCDF_Input.h
+++ b/include/SW_netCDF_Input.h
@@ -130,7 +130,7 @@ void SW_NCIN_alloc_weather_indices_years(
 void SW_NCIN_read_inputs(
     SW_RUN *sw,
     SW_DOMAIN *SW_Domain,
-    const size_t ncSUIDs[][2],
+    size_t ncSUIDs[][2],
     size_t starts[][N_SUID_ASSIGN][2],
     size_t counts[][N_SUID_ASSIGN][2],
     int **openNCFileIDs[],

--- a/include/SW_netCDF_Input.h
+++ b/include/SW_netCDF_Input.h
@@ -130,7 +130,7 @@ void SW_NCIN_alloc_weather_indices_years(
 void SW_NCIN_read_inputs(
     SW_RUN *sw,
     SW_DOMAIN *SW_Domain,
-    size_t ncSUIDs[][2],
+    const size_t ncSUIDs[][2],
     size_t starts[][N_SUID_ASSIGN][2],
     size_t counts[][N_SUID_ASSIGN][2],
     int **openNCFileIDs[],

--- a/include/SW_netCDF_Output.h
+++ b/include/SW_netCDF_Output.h
@@ -99,7 +99,7 @@ void SW_NCOUT_write_output(
     double *p_OUT[][SW_OUTNPERIODS],
     unsigned int numFilesPerKey,
     char **ncOutFileNames[][SW_OUTNPERIODS],
-    const size_t ncSUIDs[][2],
+    size_t ncSUIDs[][2],
     size_t numWritesGroup,
     size_t numWritesProc,
     size_t starts[][2],

--- a/include/SW_netCDF_Output.h
+++ b/include/SW_netCDF_Output.h
@@ -99,7 +99,7 @@ void SW_NCOUT_write_output(
     double *p_OUT[][SW_OUTNPERIODS],
     unsigned int numFilesPerKey,
     char **ncOutFileNames[][SW_OUTNPERIODS],
-    size_t ncSUIDs[][2],
+    const size_t ncSUIDs[][2],
     size_t numWritesGroup,
     size_t numWritesProc,
     size_t starts[][2],

--- a/include/SW_netCDF_Output.h
+++ b/include/SW_netCDF_Output.h
@@ -99,7 +99,7 @@ void SW_NCOUT_write_output(
     double *p_OUT[][SW_OUTNPERIODS],
     unsigned int numFilesPerKey,
     char **ncOutFileNames[][SW_OUTNPERIODS],
-    const size_t ncSuid[],
+    const size_t ncSUIDs[][2],
     size_t numWritesGroup,
     size_t numWritesProc,
     size_t starts[][2],

--- a/include/SW_netCDF_Output.h
+++ b/include/SW_netCDF_Output.h
@@ -74,7 +74,7 @@ void SW_NCOUT_close_out_files(
 void SW_NCOUT_create_output_files(
     int rank,
     const char *domFile,
-    const char *domType,
+    Bool isSimDomDiscrete,
     const char *outputPrefix,
     SW_DOMAIN *SW_Domain,
     OutPeriod timeSteps[][SW_OUTNPERIODS],
@@ -106,7 +106,7 @@ void SW_NCOUT_write_output(
     size_t counts[][2],
     int *openOutFileIDs[][SW_OUTNPERIODS],
     int *outVarIDs[],
-    Bool siteDom,
+    Bool isSimDomDiscrete,
     const Bool succFlags[],
     size_t *timeSizes[],
     LOG_INFO *LogInfo

--- a/include/filefuncs.h
+++ b/include/filefuncs.h
@@ -61,13 +61,9 @@ Bool CopyFile(const char *from, const char *to, LOG_INFO *LogInfo);
 
 void LogError(LOG_INFO *LogInfo, const int mode, const char *fmt, ...);
 
-void formatLogSUID(
-    char *buffer, size_t sizeBuffer, size_t ncSuid[], Bool isSimDomDiscrete
-);
+void updateLogSUID(LOG_INFO *LogInfo, const size_t ncSUID[]);
 
-void formatLogDate(
-    char *buffer, size_t sizeBuffer, unsigned int year, unsigned int doy
-);
+void updateLogDate(LOG_INFO *LogInfo, unsigned int year, unsigned int doy);
 
 void formatLogStage(char *buffer, size_t sizeBuffer, const char *stage);
 

--- a/include/filefuncs.h
+++ b/include/filefuncs.h
@@ -61,7 +61,9 @@ Bool CopyFile(const char *from, const char *to, LOG_INFO *LogInfo);
 
 void LogError(LOG_INFO *LogInfo, const int mode, const char *fmt, ...);
 
-void formatLogSUID(char *buffer, size_t sizeBuffer, size_t ncSuid[], Bool sDom);
+void formatLogSUID(
+    char *buffer, size_t sizeBuffer, size_t ncSuid[], Bool isSimDomDiscrete
+);
 
 void formatLogDate(
     char *buffer, size_t sizeBuffer, unsigned int year, unsigned int doy

--- a/src/SW_Control.c
+++ b/src/SW_Control.c
@@ -495,7 +495,6 @@ void SW_CTL_RunSimSet(
     Bool ok_suid = swTRUE;
     size_t startSim;
     size_t endSim;
-    Bool sDom;
     Bool copyWeather = swTRUE;
     Bool *succRun = NULL;
 
@@ -505,12 +504,11 @@ void SW_CTL_RunSimSet(
 #if defined(SWTXT)
     WallTimeSpec tsr;
     Bool ok_tsr = swFALSE;
-    sDom = (strcmp(SW_Domain->DomainType, "s") == 0) ? swTRUE : swFALSE;
-#else
-    sDom = SW_Domain->netCDFInput.siteDoms[eSW_InDomain];
 #endif
 
-    size_t count[N_SUID_ASSIGN][2] = {{1, (size_t) ((sDom) ? 0 : 1)}};
+    size_t count[N_SUID_ASSIGN][2] = {
+        {1, (size_t) ((SW_Domain->isSimDomDiscrete) ? 0 : 1)}
+    };
 
 #if !defined(SWMPI)
     startSim = SW_Domain->startSimSet;
@@ -668,7 +666,10 @@ void SW_CTL_RunSimSet(
 
                 /* Simulate suid */
                 formatLogSUID(
-                    siteLog->logSUID, sizeof siteLog->logSUID, ncSuid, sDom
+                    siteLog->logSUID,
+                    sizeof siteLog->logSUID,
+                    ncSuid,
+                    SW_Domain->isSimDomDiscrete
                 );
 #if defined(SWTXT)
                 set_walltime(&tsr, &ok_tsr);
@@ -753,7 +754,7 @@ void SW_CTL_RunSimSet(
             tempOut.p_OUT,
             simSuids[eSW_InDomain],
             numSiteSimed,
-            sDom,
+            SW_Domain->isSimDomDiscrete,
             &SW_Domain->OutDom,
             succFlags,
             starts[eSW_InDomain],
@@ -1637,7 +1638,7 @@ void SW_CTL_run_sw(
 
 #ifdef SWDEBUG
     if (debug) {
-        if (SW_Domain->netCDFInput.siteDoms[eSW_InDomain]) {
+        if (SW_Domain->isSimDomDiscrete) {
             sw_printf("SW_CTL_run_sw(): suid = %zu", ncSuid[0] + 1);
         } else {
             sw_printf(
@@ -1782,7 +1783,7 @@ void SW_CTL_run_sw(
         count,
         local_sw.SW_PathOutputs.openOutFileIDs,
         local_sw.SW_PathOutputs.ncOutVarIDs,
-        SW_Domain->netCDFInput.siteDoms[eSW_InDomain],
+        SW_Domain->isSimDomDiscrete,
         NULL,
         local_sw.SW_PathOutputs.outTimeSizes,
         LogInfo

--- a/src/SW_Control.c
+++ b/src/SW_Control.c
@@ -1619,7 +1619,7 @@ void SW_CTL_run_sw(
 
 #if defined(SWNETCDF) && !defined(SWMPI)
     SW_SOIL_RUN_INPUTS newSoil;
-    size_t ncSUIDs[N_SUID_ASSIGN][2] = {{ncSuid[0], ncSuid[1]}};
+    const size_t ncSUIDs[N_SUID_ASSIGN][2] = {{ncSuid[0], ncSuid[1]}};
     size_t starts[SW_NINKEYSNC][N_SUID_ASSIGN][2] = {{{0}}};
     size_t counts[SW_NINKEYSNC][N_SUID_ASSIGN][2] = {{{0}}};
     size_t numReads[SW_NINKEYSNC] = {1, 1, 1, 1, 1, 1, 1, 1};

--- a/src/SW_Control.c
+++ b/src/SW_Control.c
@@ -510,6 +510,8 @@ void SW_CTL_RunSimSet(
         {1, (size_t) ((SW_Domain->isSimDomDiscrete) ? 0 : 1)}
     };
 
+    LOG_INFO *siteLog;
+
 #if !defined(SWMPI)
     startSim = SW_Domain->startSimSet;
     endSim = SW_Domain->endSimSet;
@@ -519,6 +521,7 @@ void SW_CTL_RunSimSet(
 #if defined(SWNETCDF)
 #if defined(SWMPI)
     SW_RUN_INPUTS inputs[N_SUID_ASSIGN];
+    /* Array of logs for each site: each site needs its own stopRun */
     LOG_INFO siteLogs[N_SUID_ASSIGN];
     SW_OUT_RUN tempOut;
     size_t simSuids[SW_NINKEYSNC][N_SUID_ASSIGN][2] = {{{0}}};
@@ -535,21 +538,22 @@ void SW_CTL_RunSimSet(
     unsigned int numInputs = 1;
     size_t domReadIndex = 0;
     int logIndex;
-    LOG_INFO *siteLog;
 
     copyWeather =
         (Bool) (!SW_Domain->netCDFInput.readInVars[eSW_InWeather][0] &&
                 !SW_Domain->netCDFInput.readInVars[eSW_InClimate][0]);
     Bool readWeather = SW_Domain->netCDFInput.readInVars[eSW_InWeather][0];
-#else
-    LOG_INFO *siteLog = &local_LogInfo;
 
+#else  // not SWMPI
+    siteLog = &local_LogInfo;
     copyWeather = (Bool) (!SW_Domain->netCDFInput.readInVars[eSW_InWeather][0]);
-#endif // SWMPI
+#endif // end of not SWMPI
+
     Bool allocSoils = SW_Domain->netCDFInput.readInVars[eSW_InSoil][0];
-#else
-    LOG_INFO *siteLog = main_LogInfo;
-#endif // SWNETCDF
+
+#else  // not SWNETCDF
+    siteLog = main_LogInfo;
+#endif // end of not SWNETCDF
 
     int progFileID = 0; // Value does not matter if SWNETCDF is not defined
     int progVarID = 0;  // Value does not matter if SWNETCDF is not defined
@@ -595,10 +599,11 @@ void SW_CTL_RunSimSet(
 
         for (logIndex = 0; logIndex < N_SUID_ASSIGN; logIndex++) {
             sw_init_logs(main_LogInfo->logfp, &siteLogs[logIndex]);
+            siteLogs[logIndex].isSimDomDiscrete = SW_Domain->isSimDomDiscrete;
             formatLogStage(
                 siteLogs[logIndex].logStage,
                 sizeof siteLogs[logIndex].logStage,
-                "setup"
+                "input"
             );
         }
 
@@ -643,13 +648,15 @@ void SW_CTL_RunSimSet(
 
 #if defined(SWMPI)
             siteLog = &siteLogs[suid];
+            formatLogStage(
+                siteLog->logStage, sizeof siteLog->logStage, "setup"
+            );
             ncSuid[0] = simSuids[eSW_InDomain][suid][0];
             ncSuid[1] = simSuids[eSW_InDomain][suid][1];
 #else
-        sw_init_logs(main_LogInfo->logfp, &local_LogInfo);
-        formatLogStage(
-            local_LogInfo.logStage, sizeof local_LogInfo.logStage, "setup"
-        );
+        sw_init_logs(main_LogInfo->logfp, siteLog);
+        siteLog->isSimDomDiscrete = SW_Domain->isSimDomDiscrete;
+        formatLogStage(siteLog->logStage, sizeof siteLog->logStage, "setup");
 
         /* Check if suid needs to be simulated */
         SW_DOM_calc_ncSuid(SW_Domain, suid, ncSuid);
@@ -665,12 +672,8 @@ void SW_CTL_RunSimSet(
                 nSims++;
 
                 /* Simulate suid */
-                formatLogSUID(
-                    siteLog->logSUID,
-                    sizeof siteLog->logSUID,
-                    ncSuid,
-                    SW_Domain->isSimDomDiscrete
-                );
+                updateLogSUID(siteLog, ncSuid);
+
 #if defined(SWTXT)
                 set_walltime(&tsr, &ok_tsr);
 #endif
@@ -722,8 +725,6 @@ void SW_CTL_RunSimSet(
             }
 
 #if defined(SWMPI)
-            ncSuid[0] = simSuids[eSW_InDomain][suid][0];
-            ncSuid[1] = simSuids[eSW_InDomain][suid][1];
             succRun = &succFlags[suid];
 #endif
 
@@ -1127,9 +1128,7 @@ void SW_CTL_run_current_year(
             sw_printf("\t: begin doy = %d ... ", *doy);
         }
 #endif
-        formatLogDate(
-            LogInfo->logDate, sizeof LogInfo->logDate, sw->ModelSim.year, *doy
-        );
+        updateLogDate(LogInfo, sw->ModelSim.year, *doy);
 
         begin_day(sw, LogInfo);
         if (LogInfo->stopRun) {
@@ -1185,7 +1184,7 @@ void SW_CTL_run_current_year(
 #endif
     }
 
-    LogInfo->logDate[0] = '\0';
+    LogInfo->hasLogDate = swFALSE;
 
 #ifdef SWDEBUG
     if (debug) {
@@ -1620,6 +1619,7 @@ void SW_CTL_run_sw(
 
 #if defined(SWNETCDF) && !defined(SWMPI)
     SW_SOIL_RUN_INPUTS newSoil;
+    size_t ncSUIDs[N_SUID_ASSIGN][2] = {{ncSuid[0], ncSuid[1]}};
     size_t starts[SW_NINKEYSNC][N_SUID_ASSIGN][2] = {{{0}}};
     size_t counts[SW_NINKEYSNC][N_SUID_ASSIGN][2] = {{{0}}};
     size_t numReads[SW_NINKEYSNC] = {1, 1, 1, 1, 1, 1, 1, 1};
@@ -1664,12 +1664,14 @@ void SW_CTL_run_sw(
     }
 
 #if defined(SWNETCDF) && !defined(SWMPI)
+    formatLogStage(LogInfo->logStage, sizeof LogInfo->logStage, "input");
+
     set_walltime(&tsr, &ok_tsr);
     // Obtain suid-specific inputs
     SW_NCIN_read_inputs(
         &local_sw,
         SW_Domain,
-        ncSuid,
+        ncSUIDs,
         starts,
         counts,
         SW_Domain->SW_PathInputs.openInFileIDs,
@@ -1685,6 +1687,7 @@ void SW_CTL_run_sw(
     if (LogInfo->stopRun || !runSims) {
         goto freeMem;
     }
+    formatLogStage(LogInfo->logStage, sizeof LogInfo->logStage, "setup");
 #endif
 
 #if defined(SWNETCDF)
@@ -1776,7 +1779,7 @@ void SW_CTL_run_sw(
         local_sw.OutRun.p_OUT,
         local_sw.SW_PathOutputs.numOutFiles,
         local_sw.SW_PathOutputs.ncOutFiles,
-        ncSuid,
+        ncSUIDs,
         numReads[0],
         numReads[0],
         NULL,

--- a/src/SW_Domain.c
+++ b/src/SW_Domain.c
@@ -55,7 +55,7 @@
 */
 void SW_DOM_calc_ncSuid(SW_DOMAIN *SW_Domain, size_t suid, size_t ncSuid[]) {
 
-    if (strcmp(SW_Domain->DomainType, "s") == 0) {
+    if (SW_Domain->isSimDomDiscrete) {
         ncSuid[0] = suid;
         ncSuid[1] = 0;
     } else {
@@ -71,7 +71,7 @@ void SW_DOM_calc_ncSuid(SW_DOMAIN *SW_Domain, size_t suid, size_t ncSuid[]) {
     temporal/spatial information for a set of simulation runs
 */
 void SW_DOM_calc_nSUIDs(SW_DOMAIN *SW_Domain) {
-    SW_Domain->nSUIDs = (strcmp(SW_Domain->DomainType, "s") == 0) ?
+    SW_Domain->nSUIDs = (SW_Domain->isSimDomDiscrete) ?
                             SW_Domain->nDimS :
                             SW_Domain->nDimX * SW_Domain->nDimY;
 }
@@ -319,9 +319,7 @@ void SW_DOM_read(SW_DOMAIN *SW_Domain, LOG_INFO *LogInfo) {
                 );
                 goto closeFile;
             }
-            (void) sw_memccpy(
-                SW_Domain->DomainType, value, '\0', sizeof SW_Domain->DomainType
-            );
+            SW_Domain->isSimDomDiscrete = (Bool) (strcmp(value, "s") == 0);
             break;
         case 1: // Number of X slots
             SW_Domain->nDimX = (size_t) intRes;

--- a/src/SW_Flow_lib.c
+++ b/src/SW_Flow_lib.c
@@ -216,10 +216,6 @@ calls to surface_temperature_under_snow to account for the new parameters
 #include "include/SW_SoilWater.h"   // for SW_SWRC_SWCtoSWP
 #include <math.h>                   // for fabs, exp, log10, copysign
 
-#if defined(SWDEBUG)
-#include <string.h> // for strcmp
-#endif
-
 /* =================================================== */
 /*                  Local Variables                    */
 /* --------------------------------------------------- */
@@ -2480,7 +2476,7 @@ void soil_temperature_today(
 ) {
 #ifdef SWDEBUG
     int debug = 0;
-    if (strcmp(LogInfo->logDate, "1981-180") == 0) {
+    if (LogInfo->logYear == 1981 && LogInfo->logDOY == 180) {
         debug = 0;
     }
 #else
@@ -3133,7 +3129,7 @@ void soil_temperature(
 ) {
 #ifdef SWDEBUG
     int debug = 0;
-    if (strcmp(LogInfo->logDate, "1980-001") == 0) {
+    if (LogInfo->logYear == 1980 && LogInfo->logDOY == 1) {
         debug = 0;
     }
 #endif

--- a/src/SW_MPI.c
+++ b/src/SW_MPI.c
@@ -1549,7 +1549,7 @@ void SW_MPI_read_inputs(
     SW_NCIN_read_inputs(
         sw,
         SW_Domain,
-        NULL,
+        simSuids[eSW_InDomain],
         starts,
         counts,
         SW_Domain->SW_PathInputs.openInFileIDs,

--- a/src/SW_MPI.c
+++ b/src/SW_MPI.c
@@ -464,7 +464,8 @@ This function must result in a number of writes between
     as the next batch of input; can be domain or translated (index)
     SUIDs
 @param[in] numDomSuids Number of domain SUIDs that were given
-@param[in] sDom Specifies the program's domain is site-oriented
+@param[in] isInDomDiscrete Is input domain discrete (site-based)?
+    Otherwise, the input domain is gridded.
 @param[in] useSuccFlags A flag specifying if the function should take the
     success flags of simulation runs into account to make contiguous writes
     of the same value (pass or fail)
@@ -481,7 +482,7 @@ This function must result in a number of writes between
 static void get_contiguous_counts(
     size_t suids[][2],
     size_t numDomSuids,
-    Bool sDom,
+    Bool isInDomDiscrete,
     size_t nSuidsLeft,
     Bool useSuccFlags,
     const Bool *succFlags,
@@ -503,15 +504,16 @@ static void get_contiguous_counts(
     size_t suidIndex;
     int numContVals = 1;
     size_t *suid;
-    int xIndex = (sDom) ? 0 : 1;
+    int xIndex = (isInDomDiscrete) ? 0 : 1;
     Bool prevFlag = swTRUE;
     Bool currFlag = swTRUE;
 
     starts[0][0] = prevYX;
     starts[0][1] = prevX;
 
-    counts[0][0] = (sDom) ? numDomSuids : 1;
-    counts[0][1] = (sDom) ? 0 : N_SUID_ASSIGN; // NOLINT(bugprone-branch-clone)
+    counts[0][0] = (isInDomDiscrete) ? numDomSuids : 1;
+    // NOLINTNEXTLINE(bugprone-branch-clone)
+    counts[0][1] = (isInDomDiscrete) ? 0 : N_SUID_ASSIGN;
 
     if (useSuccFlags) {
         currFlag = succFlags[0];
@@ -530,8 +532,9 @@ static void get_contiguous_counts(
         // Check if x is not prevX + 1 or y is not prevYX + 1;
         // This means we found a place that is not contiguous
         // in the domain SUIDs
-        if (((sDom && suid[0] != prevYX + 1) ||
-             (!sDom && (suid[0] != prevYX || suid[1] != prevX + 1))) ||
+        if (((isInDomDiscrete && suid[0] != prevYX + 1) ||
+             (!isInDomDiscrete && (suid[0] != prevYX || suid[1] != prevX + 1))
+            ) ||
             (useSuccFlags && prevFlag != currFlag)) {
 
             // Set the count for X to number of SUIDs
@@ -545,17 +548,17 @@ static void get_contiguous_counts(
             numContVals = 0;
 
             prevYX = suids[suidIndex][0];
-            prevX = (sDom) ? 0 : suids[suidIndex][1];
+            prevX = (isInDomDiscrete) ? 0 : suids[suidIndex][1];
 
             starts[writeIndex][0] = prevYX;
             starts[writeIndex][1] = prevX;
-            counts[writeIndex][0] = (sDom) ? numDomSuids : 1;
+            counts[writeIndex][0] = (isInDomDiscrete) ? numDomSuids : 1;
             prevFlag = currFlag;
 
             nSuidsLeft--;
         }
         prevYX = suid[0];
-        prevX = (sDom) ? 0 : suid[1];
+        prevX = (isInDomDiscrete) ? 0 : suid[1];
 
         numContVals++;
     }
@@ -583,9 +586,8 @@ the number of sites/gridcells, this should save time when reading/writing
     as the next batch of input
 @param[in] distTSUIDs A list of domain translated SUIDs whose data will be
     distributed as the next batch of input
-@param[in] sDoms A list of flags that specify the domain type of every
-    netCDF input key (if used); specifies all other keys in `start` and
-    `count` including the program's domain
+@param[in] listIsInDomDiscrete Domain types of inputs:
+    Is an input domain discrete (site-based)? Otherwise, an input is gridded.
 @param[in] spatialVars1D Specifies if the input key "eSW_InSpatial" inputs
     are 1- or 2-dimensional; this will impact the order of "start" and "count"
     values
@@ -608,7 +610,7 @@ static void calculate_contiguous_allkeys(
     const Bool useIndexFile[],
     Bool *readInVars[],
     size_t distSUIDs[SW_NINKEYSNC][N_SUID_ASSIGN][2],
-    Bool sDoms[],
+    Bool listIsInDomDiscrete[],
     size_t numWrites[],
     size_t starts[SW_NINKEYSNC][N_SUID_ASSIGN][2],
     size_t counts[SW_NINKEYSNC][N_SUID_ASSIGN][2]
@@ -621,7 +623,8 @@ static void calculate_contiguous_allkeys(
 
     ForEachNCInKey(inKey) {
         useIndex = (inKey != eSW_InDomain) ? useIndexFile[inKey] : swFALSE;
-        sameDomType = (Bool) (sDoms[inKey] == sDoms[eSW_InDomain]);
+        sameDomType = (Bool) (listIsInDomDiscrete[inKey] ==
+                              listIsInDomDiscrete[eSW_InDomain]);
 
         if (inKey == eSW_InDomain || readInVars[inKey][0]) {
             if (inKey == eSW_InDomain || useIndex || !sameDomType) {
@@ -631,7 +634,7 @@ static void calculate_contiguous_allkeys(
                     (useTranslated) ? distSUIDs[inKey] :
                                       distSUIDs[eSW_InDomain],
                     nSuids,
-                    sDoms[inKey],
+                    listIsInDomDiscrete[inKey],
                     nSuidsLeft,
                     swFALSE,
                     NULL,
@@ -677,9 +680,6 @@ void find_active_sites(
     int suid = 0;
     signed char *prog = NULL;
     int progVarID = SW_Domain->netCDFInput.ncDomVarIDs[vNCprog];
-    Bool sDom = SW_Domain->netCDFInput.siteDoms[eSW_InDomain];
-    size_t numSites =
-        (sDom) ? SW_Domain->nDimS : SW_Domain->nDimY * SW_Domain->nDimX;
     size_t progIndex;
     int progFileID = SW_Domain->SW_PathInputs.ncDomFileIDs[vNCprog];
     size_t count[] = {0, 0};
@@ -689,11 +689,14 @@ void find_active_sites(
 
     if (rank == ROOT_PROC) {
         prog = (signed char *) Mem_Malloc(
-            sizeof(signed char) * numSites, "find_active_sites", LogInfo
+            sizeof(signed char) * SW_Domain->nSUIDs,
+            "find_active_sites",
+            LogInfo
         );
 
-        count[0] = (sDom) ? SW_Domain->nDimS : SW_Domain->nDimY;
-        count[1] = (sDom) ? 0 : SW_Domain->nDimX;
+        count[0] =
+            (SW_Domain->isSimDomDiscrete) ? SW_Domain->nDimS : SW_Domain->nDimY;
+        count[1] = (SW_Domain->isSimDomDiscrete) ? 0 : SW_Domain->nDimX;
     }
 
     if (SW_MPI_setup_fail(LogInfo->stopRun, MPI_COMM_WORLD)) {
@@ -721,7 +724,7 @@ void find_active_sites(
 
     /* Go through the entirety of the progress values and keep track of
        how many are ready to be run */
-    for (progIndex = 0; progIndex < numSites; progIndex++) {
+    for (progIndex = 0; progIndex < SW_Domain->nSUIDs; progIndex++) {
         // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
         *numActiveSites += (prog[progIndex] == PRGRSS_READY) ? 1 : 0;
     }
@@ -733,7 +736,7 @@ void find_active_sites(
 
     /* Go through the progress values again and calculate/store
        the active domain SUIDs */
-    for (progIndex = 0; progIndex < numSites; progIndex++) {
+    for (progIndex = 0; progIndex < SW_Domain->nSUIDs; progIndex++) {
         if (prog[progIndex] == PRGRSS_READY) {
             SW_DOM_calc_ncSuid(SW_Domain, progIndex, &(*activeSuids)[suid]);
 
@@ -766,9 +769,7 @@ static void get_activated_tsuids(
     size_t numActiveSites,
     LOG_INFO *LogInfo
 ) {
-    Bool inSDom;
-    Bool sProgDom = SW_Domain->netCDFInput.siteDoms[eSW_InDomain];
-    size_t nSites;
+    Bool isInDomDiscrete;
     unsigned int *sxIndexVals = NULL;
     unsigned int *yIndexVals = NULL;
     Bool **readInVars = SW_Domain->netCDFInput.readInVars;
@@ -798,20 +799,22 @@ static void get_activated_tsuids(
 
         fileID = SW_Domain->SW_PathInputs.openInFileIDs[inKey][indexFile][0];
 
-        inSDom = SW_Domain->netCDFInput.siteDoms[inKey];
-        nSites =
-            (sProgDom) ? SW_Domain->nDimS : SW_Domain->nDimX * SW_Domain->nDimY;
+        isInDomDiscrete = SW_Domain->netCDFInput.isInDomDiscrete[inKey];
 
         sxIndexVals = (unsigned int *) Mem_Malloc(
-            sizeof(unsigned int) * nSites, "get_activated_tsuids", LogInfo
+            sizeof(unsigned int) * SW_Domain->nSUIDs,
+            "get_activated_tsuids",
+            LogInfo
         );
         if (LogInfo->stopRun) {
             goto freeMem;
         }
 
-        if (!inSDom) {
+        if (!isInDomDiscrete) {
             yIndexVals = (unsigned int *) Mem_Malloc(
-                sizeof(unsigned int) * nSites, "get_activated_tsuids", LogInfo
+                sizeof(unsigned int) * SW_Domain->nSUIDs,
+                "get_activated_tsuids",
+                LogInfo
             );
             if (LogInfo->stopRun) {
                 goto freeMem;
@@ -822,7 +825,7 @@ static void get_activated_tsuids(
         SW_NC_get_vals(
             fileID,
             &varID,
-            (inSDom) ? "site_index" : "x_index",
+            (isInDomDiscrete) ? "site_index" : "x_index",
             sxIndexVals,
             LogInfo
         );
@@ -830,7 +833,7 @@ static void get_activated_tsuids(
             goto freeMem;
         }
 
-        if (!inSDom) {
+        if (!isInDomDiscrete) {
             varID = -1;
             SW_NC_get_vals(fileID, &varID, "y_index", yIndexVals, LogInfo);
             if (LogInfo->stopRun) {
@@ -853,11 +856,13 @@ static void get_activated_tsuids(
                 since we are using an index file
                 e.g., [0, 3] -> [1, 0]
              */
-            if (inSDom) {
+            if (isInDomDiscrete) {
                 indexCell[0] = sxIndexVals[yVal];
             } else {
                 xVal = activeSuids[siteIndex + 1];
-                offset = (sProgDom) ? yVal : (yVal * SW_Domain->nDimX) + xVal;
+                offset = (SW_Domain->isSimDomDiscrete) ?
+                             yVal :
+                             (yVal * SW_Domain->nDimX) + xVal;
 
                 indexCell[0] = yIndexVals[offset];
                 indexCell[1] = sxIndexVals[offset];
@@ -1525,7 +1530,7 @@ void SW_MPI_read_inputs(
         SW_Domain->netCDFInput.useIndexFile,
         SW_Domain->netCDFInput.readInVars,
         simSuids,
-        SW_Domain->netCDFInput.siteDoms,
+        SW_Domain->netCDFInput.isInDomDiscrete,
         numReads,
         starts,
         counts
@@ -1575,8 +1580,8 @@ void SW_MPI_read_inputs(
     as the next batch of input
 @param[in] numSuids Number of SUIDs that will be assigned, this should be
     maximum of N_SUID_ASSIGN
-@param[in] siteDom Specifies that the programs domain has sites, otherwise
-    it is gridded
+@param[in] isSimDomDiscrete Is simulation domain discrete (site-based)?
+    Otherwise, the simulation domain is gridded.
 @param[in] OutDom Struct of type SW_OUT_DOM that holds output
     information that do not change throughout simulation runs
 @param[in] succFlags Accumulator array of flags specifying how respective
@@ -1603,7 +1608,7 @@ void SW_MPI_write_outputs(
     double *temp_p_OUT[][SW_OUTNPERIODS],
     size_t distSUIDs[][2],
     size_t numSuids,
-    Bool siteDom,
+    Bool isSimDomDiscrete,
     SW_OUT_DOM *OutDom,
     Bool succFlags[],
     size_t starts[][2],
@@ -1626,7 +1631,7 @@ void SW_MPI_write_outputs(
         get_contiguous_counts(
             distSUIDs,
             numSuids,
-            siteDom,
+            isSimDomDiscrete,
             numSuids,
             considerSuccFlags,
             succFlags,
@@ -1673,7 +1678,7 @@ void SW_MPI_write_outputs(
         counts,
         SW_PathOutputs->openOutFileIDs,
         SW_PathOutputs->ncOutVarIDs,
-        siteDom,
+        isSimDomDiscrete,
         succFlags,
         SW_PathOutputs->outTimeSizes,
         LogInfo
@@ -1686,7 +1691,7 @@ void SW_MPI_write_outputs(
     // Update progress file statuses
     for (write = 0; write < maxNumWrites; write++) {
         // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
-        numSites = (siteDom) ? counts[write][0] : counts[write][1];
+        numSites = (isSimDomDiscrete) ? counts[write][0] : counts[write][1];
 
         for (mark = 0; mark < numSites; mark++) {
             // NOLINTBEGIN(clang-analyzer-core.NullDereference)

--- a/src/SW_Main_lib.c
+++ b/src/SW_Main_lib.c
@@ -414,9 +414,11 @@ void sw_init_logs(FILE *logInitPtr, LOG_INFO *LogInfo) {
     LogInfo->numDomainWarnings = 0;
     LogInfo->numDomainErrors = 0;
 
-    LogInfo->logSUID[0] = '\0';
     LogInfo->logStage[0] = '\0';
+    LogInfo->logSUID[0] = '\0';
+    LogInfo->hasLogSUID = swFALSE;
     LogInfo->logDate[0] = '\0';
+    LogInfo->hasLogDate = swFALSE;
 }
 
 /**

--- a/src/SW_Markov.c
+++ b/src/SW_Markov.c
@@ -117,9 +117,6 @@ void (*test_temp_correct_wetdry)(
            daily temperature; previously `vc10 = _vcov[1][0]`
     @param markov_rng Random number generator of the weather
                 generator
-    @param ncSuid Unique indentifier of the current suid being simulated to
-           insert into a produced message (MPI or NC mode only)
-    @param sDom Specifies the program's domain is site-oriented (MPI/NC only)
     @param LogInfo Holds information on warnings and errors
 
     @return Daily minimum (*tmin) and maximum (*tmax) temperature.

--- a/src/SW_Output.c
+++ b/src/SW_Output.c
@@ -3801,7 +3801,7 @@ void SW_OUT_create_files(
     SW_NCOUT_create_output_files(
         rank,
         SW_Domain->SW_PathInputs.ncInFiles[eSW_InDomain][vNCdom],
-        SW_Domain->DomainType,
+        SW_Domain->isSimDomDiscrete,
         SW_Domain->SW_PathInputs.outputPrefix,
         SW_Domain,
         SW_Domain->OutDom.timeSteps,

--- a/src/SW_Weather.c
+++ b/src/SW_Weather.c
@@ -801,12 +801,7 @@ void SW_WTH_setWeatherValues(
         for (doy = 0; doy < MAX_DAYS; doy++) {
             tempDoy = doy + doyOffset;
 
-            formatLogDate(
-                LogInfo->logDate,
-                sizeof LogInfo->logDate,
-                startYear + yearIndex,
-                doy + 1
-            );
+            updateLogDate(LogInfo, startYear + yearIndex, doy + 1);
 
             // Temperature [C]
             yearlyWeather[yearIndex].temp_max[doy] =
@@ -1095,7 +1090,7 @@ void SW_WTH_setWeatherValues(
         }
     }
 
-    LogInfo->logDate[0] = '\0';
+    LogInfo->hasLogDate = swFALSE;
 }
 
 /**
@@ -1676,9 +1671,7 @@ void generateMissingWeather(
 
         for (day = 0; day < numDaysYear; day++) {
 
-            formatLogDate(
-                LogInfo->logDate, sizeof LogInfo->logDate, year, day + 1
-            );
+            updateLogDate(LogInfo, year, day + 1);
 
             /* Determine variables with missing values */
             missing_Tmax = (Bool) missing(allHist[yearIndex].temp_max[day]);
@@ -1813,7 +1806,7 @@ void generateMissingWeather(
         }
     }
 
-    LogInfo->logDate[0] = '\0';
+    LogInfo->hasLogDate = swFALSE;
 }
 
 /**
@@ -1845,12 +1838,7 @@ void checkAllWeather(
 
         // Loop through `allHist` days
         for (doy = 0; doy < numDaysInYear; doy++) {
-            formatLogDate(
-                LogInfo->logDate,
-                sizeof LogInfo->logDate,
-                year + weather->startYear,
-                doy + 1
-            );
+            updateLogDate(LogInfo, year + weather->startYear, doy + 1);
 
             dailyMaxTemp = weathHist[year].temp_max[doy];
             dailyMinTemp = weathHist[year].temp_min[doy];
@@ -1991,7 +1979,7 @@ void checkAllWeather(
         }
     }
 
-    LogInfo->logDate[0] = '\0';
+    LogInfo->hasLogDate = swFALSE;
 }
 
 /**

--- a/src/SW_datastructs.c
+++ b/src/SW_datastructs.c
@@ -462,8 +462,8 @@ coordinate pairs, or in other words, size of the longitude/x dimension when
 reading the input file coordinate variables
 @param[in] depth Recursive depth/level the tree is adding to which also
 specifies the dimension of the coordinates we sort by/compare
-@param[in] inIsGridded Specifies if the input coordinates come from a gridded
-domain
+@param[in] isInDomDiscrete Is input domain discrete (site-based)?
+    Otherwise, the input domain is gridded.
 @param[in] inPrimCRSIsGeo Specifies if the input coordinates from from a domain
 that has a primary CRS of geographical
 @param[in] indices A list of all the indices where each coordinate comes from
@@ -483,7 +483,7 @@ static SW_KD_NODE *constructTree(
     size_t numY,
     size_t numX,
     int depth,
-    Bool inIsGridded,
+    Bool isInDomDiscrete,
     Bool inPrimCRSIsGeo,
     unsigned int **indices,
     LOG_INFO *LogInfo
@@ -504,7 +504,7 @@ static SW_KD_NODE *constructTree(
 
     quickSort(yxCoords, indices, left, right, compFunc);
 
-    if (inIsGridded) {
+    if (!isInDomDiscrete) {
         getCoordLocInGrid(
             indices[middle][0], indices[middle][1], numY, numX, &posLocation
         );
@@ -533,7 +533,7 @@ static SW_KD_NODE *constructTree(
         numY,
         numX,
         depth + 1,
-        inIsGridded,
+        isInDomDiscrete,
         inPrimCRSIsGeo,
         indices,
         LogInfo
@@ -548,7 +548,7 @@ static SW_KD_NODE *constructTree(
         numY,
         numX,
         depth + 1,
-        inIsGridded,
+        isInDomDiscrete,
         inPrimCRSIsGeo,
         indices,
         LogInfo
@@ -824,7 +824,8 @@ SW_KD_NODE *SW_DATA_addNode(
 @param[in] xCoords Longitude or x coordinates from input files
 @param[in] ySize Amount of latitude or y coordinates being provided
 @param[in] xSize Amount of longitude or x coordinates being provided
-@param[in] inIsGridded Specifies that the provided input file is gridded
+@param[in] isInDomDiscrete Is input domain discrete (site-based)?
+    Otherwise, the input domain is gridded.
 @param[in] has2DCoordVars Specifies if the coordinates that are being sent in
 originated from coordinate variables that we 2D, i.e., in matrix form
 @param[in] inPrimCRSIsGeo Specifies if the current CRS type is geographic
@@ -838,7 +839,7 @@ void SW_DATA_create_tree(
     double *xCoords,
     size_t ySize,
     size_t xSize,
-    Bool inIsGridded,
+    Bool isInDomDiscrete,
     Bool has2DCoordVars,
     Bool inPrimCRSIsGeo,
     sw_converter_t *yxConvs[],
@@ -903,7 +904,7 @@ void SW_DATA_create_tree(
         ySize,
         xSize,
         0,
-        inIsGridded,
+        isInDomDiscrete,
         inPrimCRSIsGeo,
         indices,
         LogInfo

--- a/src/SW_netCDF_General.c
+++ b/src/SW_netCDF_General.c
@@ -76,8 +76,8 @@ static void get_double_att_val(
 @brief Overwrite specific global attributes into a new file
 
 @param[in] ncFileID Identifier of the open netCDF file to write all information
-@param[in] domType Type of domain in which simulations are running
-    (gridcell/sites)
+@param[in] isSimDomDiscrete Is simulation domain discrete (site-based)?
+    Otherwise, the simulation domain is gridded.
 @param[in] freqAtt Value of a global attribute "frequency"
     * fixed (no time): "fx"
     * has time: "day", "week", "month", or "year"
@@ -86,7 +86,7 @@ static void get_double_att_val(
 */
 static void update_netCDF_global_atts(
     const int *ncFileID,
-    const char *domType,
+    Bool isSimDomDiscrete,
     const char *freqAtt,
     Bool isInputFile,
     LOG_INFO *LogInfo
@@ -98,15 +98,15 @@ static void update_netCDF_global_atts(
                               // YYYY-MM-DDTHH:MM:SSZ
 
     int attNum;
-    // Use "featureType" only if domainType is "s"
-    const int numGlobAtts = (strcmp(domType, "s") == 0) ? 5 : 4;
+    // Use "featureType" only if isSimDomDiscrete
+    const int numGlobAtts = isSimDomDiscrete ? 5 : 4;
     const char *attNames[] = {
         "source", "creation_date", "product", "frequency", "featureType"
     };
 
     const char *productStr = (isInputFile) ? "model-input" : "model-output";
     const char *featureTypeStr;
-    if (strcmp(domType, "s") == 0) {
+    if (isSimDomDiscrete) {
         featureTypeStr = (strcmp(freqAtt, "fx") == 0) ? "point" : "timeSeries";
     } else {
         featureTypeStr = "";
@@ -337,8 +337,7 @@ void SW_NC_check(
     const char *projCRS = crs_projsc->crs_name;
     Bool geoCRSExists = SW_NC_varExists(*ncFileID, geoCRS);
     Bool projCRSExists = SW_NC_varExists(*ncFileID, projCRS);
-    const char *impliedDomType =
-        (SW_NC_dimExists(siteName, *ncFileID)) ? "s" : "xy";
+    const Bool isInDomDiscrete = SW_NC_dimExists(siteName, *ncFileID);
     Bool dimMismatch = swFALSE;
     size_t latDimVal = 0;
     size_t lonDimVal = 0;
@@ -407,7 +406,7 @@ void SW_NC_check(
     /*
        Make sure the domain types are consistent
     */
-    if (strcmp(SW_Domain->DomainType, impliedDomType) != 0) {
+    if (SW_Domain->isSimDomDiscrete != isInDomDiscrete) {
         LogError(
             LogInfo,
             LOGERROR,
@@ -415,8 +414,8 @@ void SW_NC_check(
             "however, the current simulation uses a domain type '%s'. "
             "Please make sure these match.",
             fileName,
-            impliedDomType,
-            SW_Domain->DomainType
+            isInDomDiscrete ? "s" : "xy",
+            SW_Domain->isSimDomDiscrete ? "s" : "xy"
         );
         return; // Exit function prematurely due to error
     }
@@ -425,14 +424,14 @@ void SW_NC_check(
        Make sure the dimensions of the netCDF file is consistent with the
        domain input file
     */
-    if (strcmp(impliedDomType, "s") == 0) {
+    if (isInDomDiscrete) {
         SW_NC_get_dimlen_from_dimname(*ncFileID, siteName, &SDimVal, LogInfo);
         if (LogInfo->stopRun) {
             return; // Exit function prematurely due to error
         }
 
         dimMismatch = (Bool) (SDimVal != SW_Domain->nDimS);
-    } else if (strcmp(impliedDomType, "xy") == 0) {
+    } else {
         SW_NC_get_dimlen_from_dimname(
             *ncFileID, readinYName, &latDimVal, LogInfo
         );
@@ -1008,8 +1007,8 @@ void SW_NC_get_dimlen_from_dimname(
 and writing attributes
 
 @param[in] ncFileID Identifier of the netCDF file
-@param[in] domType Type of domain in which simulations are running
-    (gridcell/sites)
+@param[in] isSimDomDiscrete Is simulation domain discrete (site-based)?
+    Otherwise, the simulation domain is gridded.
 @param[in] newVarType Type of the variable to create
 @param[in] timeSize Size of "time" dimension
 @param[in] vertSize Size of "vertical" dimension
@@ -1043,7 +1042,7 @@ type and default value based on \p newVarType.
 */
 void SW_NC_create_full_var(
     int *ncFileID,
-    const char *domType,
+    Bool isSimDomDiscrete,
     int newVarType,
     size_t timeSize,
     size_t vertSize,
@@ -1072,9 +1071,8 @@ void SW_NC_create_full_var(
     int varID = 0;
     unsigned int index;
     int dimIDs[MAX_NUM_DIMS];
-    Bool domTypeIsSites = (Bool) (strcmp(domType, "s") == 0);
-    unsigned int numConstDims = (domTypeIsSites) ? 1 : 2;
-    const char *thirdDim = (domTypeIsSites) ? siteName : yName;
+    unsigned int numConstDims = (isSimDomDiscrete) ? 1 : 2;
+    const char *thirdDim = (isSimDomDiscrete) ? siteName : yName;
     const char *constDimNames[] = {thirdDim, xName};
     const char *timeVertVegNames[] = {"time", "vertical", "pft"};
     char *dimVarName;
@@ -1244,8 +1242,8 @@ reportFullBuffer:
 /**
 @brief Copy domain netCDF as a template
 
-@param[in] domType Type of domain in which simulations are running
-    (gridcell/sites)
+@param[in] isSimDomDiscrete Is simulation domain discrete (site-based)?
+    Otherwise, the simulation domain is gridded.
 @param[in] domFile Name of the domain netCDF
 @param[in] fileName Name of the netCDF file to create
 @param[in] newFileID Identifier of the netCDF file to create
@@ -1256,7 +1254,7 @@ access or not, if SWMPI is not enabled, this argument is not used
 @param[out] LogInfo  Holds information dealing with logfile output
 */
 void SW_NC_create_template(
-    const char *domType,
+    Bool isSimDomDiscrete,
     const char *domFile,
     const char *fileName,
     int *newFileID,
@@ -1289,7 +1287,9 @@ void SW_NC_create_template(
         return; /* Exit function prematurely due to error */
     }
 
-    update_netCDF_global_atts(newFileID, domType, freq, isInput, LogInfo);
+    update_netCDF_global_atts(
+        newFileID, isSimDomDiscrete, freq, isInput, LogInfo
+    );
 }
 
 /**

--- a/src/SW_netCDF_Input.c
+++ b/src/SW_netCDF_Input.c
@@ -8495,7 +8495,7 @@ be returned with any site-specific errors/warnings
 void SW_NCIN_read_inputs(
     SW_RUN *sw,
     SW_DOMAIN *SW_Domain,
-    size_t ncSUIDs[][2],
+    const size_t ncSUIDs[][2],
     size_t starts[][N_SUID_ASSIGN][2],
     size_t counts[][N_SUID_ASSIGN][2],
     int **openNCFileIDs[],

--- a/src/SW_netCDF_Input.c
+++ b/src/SW_netCDF_Input.c
@@ -5256,8 +5256,8 @@ temporal/spatial information for a set of simulation runs
 @param[in] numReads A list of size SW_NINKEYSNC holding how many
     contiguous reads it will take to read all the input for the specified
     input SUIDs
-@param[in] ncSUID Current simulation unit identifier for which is used
-to get data from netCDF
+@param[in] ncSUIDs An array of \ref N_SUID_ASSIGN with
+    simulation unit identifier(s) for which to read data from netCDFs
 @param[in] starts A list of size SW_NINKEYSNC storing calculated
     start indices for netCDFs to read contiguous data
 @param[in] counts A list of size SW_NINKEYSNC storing calculated
@@ -5276,7 +5276,7 @@ static void read_spatial_topo_climate_site_inputs(
     SW_DOMAIN *SW_Domain,
     size_t numInputs,
     const size_t numReads[],
-    const size_t ncSUID[],
+    const size_t ncSUIDs[][2],
     size_t starts[SW_NINKEYSNC][N_SUID_ASSIGN][2],
     size_t counts[SW_NINKEYSNC][N_SUID_ASSIGN][2],
     sw_converter_t ***convs,
@@ -5370,7 +5370,12 @@ static void read_spatial_topo_climate_site_inputs(
         /* Get the start indices based on if we need to use the respective
            index file */
         get_read_start(
-            useIndexFile, indexID, isInDomDiscrete, ncSUID, defSetStart, LogInfo
+            useIndexFile,
+            indexID,
+            isInDomDiscrete,
+            ncSUIDs[0],
+            defSetStart,
+            LogInfo
         );
         if (LogInfo->stopRun) {
             return;
@@ -5538,13 +5543,13 @@ static void read_spatial_topo_climate_site_inputs(
             (Bool) (GT(inputs[input].ModelRunIn.latitude, 0.0));
     }
 
-#if !defined(SWMPI)
+#if defined(SWMPI)
+    (void) ncSUIDs;
+    (void) useIndexFile;
+#else
     (void) starts;
     (void) counts;
     (void) openNCFileIDs;
-#else
-    (void) ncSUID;
-    (void) useIndexFile;
 #endif
 }
 
@@ -6341,8 +6346,8 @@ contiguous data; placement of these sizes match those of `starts`
 input key
 @param[in] numReads Number of reads it will take to read all vegetation
 inputs
-@param[in] ncSUID simulation unit identifier for which is used
-to get data from netCDF
+@param[in] ncSUIDs An array of \ref N_SUID_ASSIGN with
+    simulation unit identifier(s) for which to read data from netCDFs
 @param[in] vegConv A list of UDUNITS2 converters that were created
 to convert input data to units the program can understand within the
 "inVeg" input key
@@ -6358,7 +6363,7 @@ static void read_veg_inputs(
     size_t starts[][2],
     size_t counts[][2],
     size_t numReads,
-    const size_t ncSUID[],
+    const size_t ncSUIDs[][2],
     sw_converter_t **vegConv,
     int **vegFileIDs,
     double *tempVals,
@@ -6426,7 +6431,7 @@ static void read_veg_inputs(
     /* Get the start indices based on if we need to use the respective
         index file */
     get_read_start(
-        useIndexFile, indexID, isInDomDiscrete, ncSUID, defSetStart, LogInfo
+        useIndexFile, indexID, isInDomDiscrete, ncSUIDs[0], defSetStart, LogInfo
     );
     if (LogInfo->stopRun) {
         return;
@@ -6631,7 +6636,7 @@ static void read_veg_inputs(
     }
 
 #if defined(SWMPI)
-    (void) ncSUID;
+    (void) ncSUIDs;
 #else
     (void) starts;
     (void) counts;
@@ -6861,8 +6866,8 @@ consistency checks.
     used if \p hasConstSoilDepths
 @param[in] soilConv A UDUNITS2 converter used to convert user-provided
     units to units that SW2 understands
-@param[in] ncSUID Current simulation unit identifier for which is used
-    to get data from netCDF
+@param[in] ncSUIDs An array of \ref N_SUID_ASSIGN with
+    simulation unit identifier(s) for which to read data from netCDFs
 @param[in] numInputs Total number of inputs that will be read; varies
 with mode SWMPI, sticks to one in mode SWNC/SWNETCDF
 @param[in] numReads Number of reads it will take to read all soil
@@ -6889,7 +6894,7 @@ static void read_soil_inputs(
     Bool hasConstSoilDepths,
     const double depthsAllSoilLayers[],
     sw_converter_t **soilConv,
-    const size_t ncSUID[],
+    const size_t ncSUIDs[][2],
     size_t numInputs,
     size_t numReads,
     size_t starts[][2],
@@ -6966,12 +6971,18 @@ static void read_soil_inputs(
 
 #if !defined(SWMPI)
     get_read_start(
-        useIndexFile, indexID, isInDomDiscrete, ncSUID, defSetStart, mainLogInfo
+        useIndexFile,
+        indexID,
+        isInDomDiscrete,
+        ncSUIDs[0],
+        defSetStart,
+        mainLogInfo
     );
     if (mainLogInfo->stopRun) {
         return;
     }
 #endif
+
 
     /* Initialize soils */
     for (input = 0; input < numInputs; input++) {
@@ -7163,6 +7174,8 @@ static void read_soil_inputs(
     }
 
     for (input = 0; input < numInputs; input++) {
+        updateLogSUID(&siteLogs[input], ncSUIDs[input]);
+
         soils = (hasConstSoilDepths) ? &inputs[input].SoilRunIn :
                                        &newSoilBuff[input];
 
@@ -7187,9 +7200,7 @@ static void read_soil_inputs(
         }
     }
 
-#if defined(SWMPI)
-    (void) ncSUID;
-#else
+#if !defined(SWMPI)
     (void) starts;
     (void) counts;
 #endif
@@ -8082,8 +8093,7 @@ void SW_NCIN_create_domain_template(
 
 @param[in] progFileID Identifier of the progress netCDF file
 @param[in] progVarID Identifier of the progress variable
-@param[in] ncSUID Current simulation unit identifier for which is used
-    to get data from netCDF
+@param[in] ncSUID Simulation unit identifier for which to read data from netCDFs
 @param[in,out] LogInfo Holds information dealing with logfile output
 */
 Bool SW_NCIN_check_progress(
@@ -8108,8 +8118,8 @@ temporal/spatial information for a set of simulation runs
 @param[out] SW_WeatherIn Struct of type SW_WEATHER_INPUTS holding all relevant
 information pretaining to meteorological input data
 have been created for the input key 'inWeather'
-@param[in] ncSUID Current simulation unit identifier for which is used
-to get data from netCDF
+@param[in] ncSUIDs An array of \ref N_SUID_ASSIGN with
+    simulation unit identifier(s) for which to read data from netCDFs
 @param[in] weathConv A list of UDUNITS2 converters that were created
 to convert input data to units the program can understand within the
 "inWeather" input key
@@ -8134,7 +8144,7 @@ be returned with any site-specific errors/warnings
 static void read_weather_input(
     SW_DOMAIN *SW_Domain,
     SW_WEATHER_INPUTS *SW_WeatherIn,
-    const size_t ncSUID[],
+    const size_t ncSUIDs[][2],
     sw_converter_t **weathConv,
     size_t numInputs,
     size_t numReads,
@@ -8212,7 +8222,12 @@ static void read_weather_input(
 
 #if !defined(SWMPI)
     get_read_start(
-        useIndexFile, indexID, isInDomDiscrete, ncSUID, defSetStart, mainLogInfo
+        useIndexFile,
+        indexID,
+        isInDomDiscrete,
+        ncSUIDs[0],
+        defSetStart,
+        mainLogInfo
     );
     if (mainLogInfo->stopRun) {
         return;
@@ -8364,6 +8379,8 @@ static void read_weather_input(
     }
 
     for (input = 0; input < numInputs; input++) {
+        updateLogSUID(&siteLogs[input], ncSUIDs[input]);
+
         SW_WTH_setWeatherValues(
             SW_Domain->startyr,
             SW_WeatherIn->n_years,
@@ -8378,9 +8395,7 @@ static void read_weather_input(
     }
 
 freeMem:
-#if defined(SWMPI)
-    (void) ncSUID;
-#else
+#if !defined(SWMPI)
     (void) starts;
     (void) counts;
 #endif
@@ -8451,8 +8466,8 @@ to SW_Run
     all information in the simulation
 @param[in] SW_Domain Struct of type SW_DOMAIN holding constant
     temporal/spatial information for a set of simulation runs
-@param[in] ncSUID Current simulation unit identifier for which is used
-    to get data from netCDF
+@param[in] ncSUIDs An array of \ref N_SUID_ASSIGN with
+    simulation unit identifier(s) for which to read data from netCDFs
 @param[in] starts A list of size SW_NINKEYSNC specifying the start
     indices used when reading/writing using the netCDF library;
     default size is `nSuids` but as mentioned in `numWrites`, it would
@@ -8480,7 +8495,7 @@ be returned with any site-specific errors/warnings
 void SW_NCIN_read_inputs(
     SW_RUN *sw,
     SW_DOMAIN *SW_Domain,
-    const size_t ncSUID[],
+    const size_t ncSUIDs[][2],
     size_t starts[][N_SUID_ASSIGN][2],
     size_t counts[][N_SUID_ASSIGN][2],
     int **openNCFileIDs[],
@@ -8527,7 +8542,7 @@ void SW_NCIN_read_inputs(
             SW_Domain,
             numInputs,
             numReads,
-            ncSUID,
+            ncSUIDs,
             starts,
             counts,
             convs,
@@ -8568,7 +8583,7 @@ void SW_NCIN_read_inputs(
         read_weather_input(
             SW_Domain,
             &sw->WeatherIn,
-            ncSUID,
+            ncSUIDs,
             convs[eSW_InWeather],
             numInputs,
             numReads[eSW_InWeather],
@@ -8589,7 +8604,7 @@ void SW_NCIN_read_inputs(
             starts[eSW_InVeg],
             counts[eSW_InVeg],
             numReads[eSW_InVeg],
-            ncSUID,
+            ncSUIDs,
             convs[eSW_InVeg],
             vegFileIDs,
             tempVals,
@@ -8605,7 +8620,7 @@ void SW_NCIN_read_inputs(
             SW_Domain->hasConsistentSoilLayerDepths,
             SW_Domain->depthsAllSoilLayers,
             convs[eSW_InSoil],
-            ncSUID,
+            ncSUIDs,
             numInputs,
             numReads[eSW_InSoil],
             starts[eSW_InSoil],

--- a/src/SW_netCDF_Input.c
+++ b/src/SW_netCDF_Input.c
@@ -809,7 +809,7 @@ given configurations is an acceptable one
 @param[in] primCRSIsGeo Specifies if the current CRS type is geographic
 @param[in] inputInfo List of information pertaining to a specific input key
 @param[in] varName First active input variable name within an input key
-@param[in] domDomType Specifies the domain type that the program is
+@param[in] simulationDomainType Specifies the domain type that the program is
 making use of
 @param[out] LogInfo Holds information on warnings and errors
 */
@@ -817,11 +817,11 @@ static void check_correct_spatial_config(
     Bool primCRSIsGeo,
     char **inputInfo,
     char *varName,
-    char *domDomType,
+    char *simulationDomainType,
     LOG_INFO *LogInfo
 ) {
-    Bool siteDom = (Bool) (strcmp(domDomType, "s") == 0);
-    Bool inSiteDom = (Bool) (strcmp(inputInfo[INDOMTYPE], "s") == 0);
+    Bool isSimDomDiscrete = (Bool) (strcmp(simulationDomainType, "s") == 0);
+    Bool isInDomDiscrete = (Bool) (strcmp(inputInfo[INDOMTYPE], "s") == 0);
     Bool inGeoCRS =
         (Bool) (strcmp(inputInfo[INGRIDMAPPING], "latitude_longitude") == 0);
     Bool failedCaseOne = swFALSE;
@@ -836,10 +836,12 @@ static void check_correct_spatial_config(
         - Site, geo CRS domain with site, proj CRS input
         - Site, geo CRS domain with xy (gridded), proj CRS input
         - XY (gridded), geo CRS domain with xy (gridded), proj CRS input */
-    failedCaseOne = (Bool) (siteDom && primCRSIsGeo && inSiteDom && !inGeoCRS);
-    failedCaseTwo = (Bool) (siteDom && primCRSIsGeo && !inSiteDom && !inGeoCRS);
-    failedCaseThree =
-        (Bool) (!siteDom && primCRSIsGeo && !inSiteDom && !inGeoCRS);
+    failedCaseOne = (Bool) (isSimDomDiscrete && primCRSIsGeo &&
+                            isInDomDiscrete && !inGeoCRS);
+    failedCaseTwo = (Bool) (isSimDomDiscrete && primCRSIsGeo &&
+                            !isInDomDiscrete && !inGeoCRS);
+    failedCaseThree = (Bool) (!isSimDomDiscrete && primCRSIsGeo &&
+                              !isInDomDiscrete && !inGeoCRS);
 
     if (failedCaseOne || failedCaseTwo || failedCaseThree) {
         LogError(
@@ -857,11 +859,12 @@ static void check_correct_spatial_config(
         - XY (gridded), geo CRS domain with site, proj CRS input
         - XY (gridded), proj CRS domain with site, geo CRS input
         - XY (gridded), proj CRS domain with site, proj CRS input */
-    if (!siteDom) {
-        failedCaseFour = (Bool) (primCRSIsGeo && inSiteDom && inGeoCRS);
-        failedCaseFive = (Bool) (primCRSIsGeo && inSiteDom && !inGeoCRS);
-        failedCaseSix = (Bool) (!primCRSIsGeo && inSiteDom && inGeoCRS);
-        failedCaseSeven = (Bool) (!primCRSIsGeo && inSiteDom && !inGeoCRS);
+    if (!isSimDomDiscrete) {
+        failedCaseFour = (Bool) (primCRSIsGeo && isInDomDiscrete && inGeoCRS);
+        failedCaseFive = (Bool) (primCRSIsGeo && isInDomDiscrete && !inGeoCRS);
+        failedCaseSix = (Bool) (!primCRSIsGeo && isInDomDiscrete && inGeoCRS);
+        failedCaseSeven =
+            (Bool) (!primCRSIsGeo && isInDomDiscrete && !inGeoCRS);
 
         if (failedCaseFour || failedCaseFive || failedCaseSix ||
             failedCaseSeven) {
@@ -1547,7 +1550,6 @@ static void fill_domain_netCDF_vals(
     LOG_INFO *LogInfo
 ) {
 
-    Bool domTypeIsSite = (Bool) (strcmp(SW_Domain->DomainType, "s") == 0);
     unsigned int suidNum;
     unsigned int gridNum = 0;
     unsigned int *domVals = NULL;
@@ -1564,8 +1566,10 @@ static void fill_domain_netCDF_vals(
     size_t fillCountXBnds[] = {SW_Domain->nDimX, 2};
     double resY;
     double resX;
-    unsigned int numX = (domTypeIsSite) ? SW_Domain->nDimS : SW_Domain->nDimX;
-    unsigned int numY = (domTypeIsSite) ? SW_Domain->nDimS : SW_Domain->nDimY;
+    unsigned int numX =
+        (SW_Domain->isSimDomDiscrete) ? SW_Domain->nDimS : SW_Domain->nDimX;
+    unsigned int numY =
+        (SW_Domain->isSimDomDiscrete) ? SW_Domain->nDimS : SW_Domain->nDimY;
 
     int fillVarIDs[4] = {YVarID, XVarID};    // Fill other slots later if needed
     double **fillVals[4] = {&valsY, &valsX}; // Fill other slots later if needed
@@ -1576,7 +1580,7 @@ static void fill_domain_netCDF_vals(
     int varNum;
 
     alloc_netCDF_domain_vars(
-        domTypeIsSite,
+        SW_Domain->isSimDomDiscrete,
         SW_Domain->nSUIDs,
         numY,
         numX,
@@ -1598,7 +1602,7 @@ static void fill_domain_netCDF_vals(
     // --- Setup domain size, number of variables to fill, fill values,
     // fill variable IDs, and horizontal coordinate variables for the section
     // `Write out all values to file`
-    if (domTypeIsSite) {
+    if (SW_Domain->isSimDomDiscrete) {
         // Handle variables differently due to domain being 1D (sites)
         fillCountY[0] = SW_Domain->nDimS;
         fillCountX[0] = SW_Domain->nDimS;
@@ -1646,7 +1650,7 @@ static void fill_domain_netCDF_vals(
     for (gridNum = 0; gridNum < numX; gridNum++) {
         valsX[gridNum] = SW_Domain->min_x + (gridNum + .5) * resX;
 
-        if (!domTypeIsSite) {
+        if (!SW_Domain->isSimDomDiscrete) {
             bndsIndex = gridNum * 2;
             valsXBnds[bndsIndex] = SW_Domain->min_x + gridNum * resX;
             valsXBnds[bndsIndex + 1] = SW_Domain->min_x + (gridNum + 1) * resX;
@@ -1656,7 +1660,7 @@ static void fill_domain_netCDF_vals(
     for (gridNum = 0; gridNum < numY; gridNum++) {
         valsY[gridNum] = SW_Domain->min_y + (gridNum + .5) * resY;
 
-        if (!domTypeIsSite) {
+        if (!SW_Domain->isSimDomDiscrete) {
             bndsIndex = gridNum * 2;
             valsYBnds[bndsIndex] = SW_Domain->min_y + gridNum * resY;
             valsYBnds[bndsIndex + 1] = SW_Domain->min_y + (gridNum + 1) * resY;
@@ -2213,8 +2217,8 @@ static void fill_domain_netCDF_gridded(
 
 @param[in] SW_netCDFOut Constant netCDF output file information
 @param[in] ncFileID Identifier of the open netCDF file to write all information
-@param[in] domType Type of domain in which simulations are running
-    (gridcell/sites)
+@param[in] isSimDomDiscrete Is simulation domain discrete (site-based)?
+    Otherwise, the simulation domain is gridded.
 @param[in] freqAtt Value of a global attribute "frequency"
     * fixed (no time): "fx"
     * has time: "day", "week", "month", or "year"
@@ -2224,7 +2228,7 @@ static void fill_domain_netCDF_gridded(
 static void fill_netCDF_with_global_atts(
     SW_NETCDF_OUT *SW_netCDFOut,
     const int *ncFileID,
-    const char *domType,
+    Bool isSimDomDiscrete,
     const char *freqAtt,
     Bool isInputFile,
     LOG_INFO *LogInfo
@@ -2236,8 +2240,8 @@ static void fill_netCDF_with_global_atts(
                               // YYYY-MM-DDTHH:MM:SSZ
 
     int attNum;
-    // Use "featureType" only if domainType is "s"
-    const int numGlobAtts = (strcmp(domType, "s") == 0) ? 14 : 13;
+    // Use "featureType" only if isSimDomDiscrete
+    const int numGlobAtts = isSimDomDiscrete ? 14 : 13;
     const char *attNames[] = {
         "title",
         "author",
@@ -2257,7 +2261,7 @@ static void fill_netCDF_with_global_atts(
 
     const char *productStr = (isInputFile) ? "model-input" : "model-output";
     const char *featureTypeStr;
-    if (strcmp(domType, "s") == 0) {
+    if (isSimDomDiscrete) {
         featureTypeStr = (strcmp(freqAtt, "fx") == 0) ? "point" : "timeSeries";
     } else {
         featureTypeStr = "";
@@ -2460,15 +2464,15 @@ i.e., global attributes (including time created) and CRS information
 (including the creation of these variables)
 
 @param[in] SW_netCDFOut Constant netCDF output file information
-@param[in] domType Type of domain in which simulations are running
-    (gridcell/sites)
+@param[in] isSimDomDiscrete Is simulation domain discrete (site-based)?
+    Otherwise, the simulation domain is gridded.
 @param[in] ncFileID Identifier of the open netCDF file to write all information
 @param[in] isInputFile Specifies whether the file being written to is input
 @param[out] LogInfo Holds information on warnings and errors
 */
 static void fill_netCDF_with_invariants(
     SW_NETCDF_OUT *SW_netCDFOut,
-    char *domType,
+    Bool isSimDomDiscrete,
     int *ncFileID,
     Bool isInputFile,
     LOG_INFO *LogInfo
@@ -2519,7 +2523,7 @@ static void fill_netCDF_with_invariants(
 
     // Write global attributes
     fill_netCDF_with_global_atts(
-        SW_netCDFOut, ncFileID, domType, fx, isInputFile, LogInfo
+        SW_netCDFOut, ncFileID, isSimDomDiscrete, fx, isInputFile, LogInfo
     );
 }
 
@@ -2633,11 +2637,8 @@ static void fill_prog_netCDF_vals(SW_DOMAIN *SW_Domain, LOG_INFO *LogInfo) {
     size_t start2D[] = {0, 0};
     size_t count1D[] = {nSUIDs};
     size_t count2D[] = {nDimY, nDimX};
-    size_t *start =
-        (strcmp(SW_Domain->DomainType, "s") == 0) ? start1D : start2D;
-    size_t *count =
-        (strcmp(SW_Domain->DomainType, "s") == 0) ? count1D : count2D;
-    Bool siteDom = (Bool) (strcmp(SW_Domain->DomainType, "s") == 0);
+    size_t *start = SW_Domain->isSimDomDiscrete ? start1D : start2D;
+    size_t *count = SW_Domain->isSimDomDiscrete ? count1D : count2D;
     unsigned int subVal;
     size_t chunkSizes[2] = {1, 1};
     int storageType;
@@ -2645,7 +2646,7 @@ static void fill_prog_netCDF_vals(SW_DOMAIN *SW_Domain, LOG_INFO *LogInfo) {
     size_t countRead[2] = {0, 0};
     size_t numChunkReads = 0;
     size_t numChunkInYAxis;
-    size_t numChunkInXAxis;
+    size_t numChunkInXAxis = 1;
 
     long *readDomVals = NULL;
     signed char *vals = (signed char *) Mem_Malloc(
@@ -2693,9 +2694,10 @@ static void fill_prog_netCDF_vals(SW_DOMAIN *SW_Domain, LOG_INFO *LogInfo) {
     // Calculate how many chunks are held within the entirety of
     // the vertical (or site) axis for the program's domain
     countRead[0] = chunkSizes[0];
-    numChunkInYAxis = (siteDom) ? SW_Domain->nDimS : SW_Domain->nDimY;
+    numChunkInYAxis =
+        (SW_Domain->isSimDomDiscrete) ? SW_Domain->nDimS : SW_Domain->nDimY;
     numChunkInYAxis /= chunkSizes[0];
-    if (!siteDom) {
+    if (!SW_Domain->isSimDomDiscrete) {
         countRead[1] = chunkSizes[1];
         numChunkInXAxis = SW_Domain->nDimX / chunkSizes[1];
     }
@@ -2705,7 +2707,7 @@ static void fill_prog_netCDF_vals(SW_DOMAIN *SW_Domain, LOG_INFO *LogInfo) {
 
         // Set the new chunks start position(s) for the next read
         startRead[0] = (numChunkReads / numChunkInYAxis) * chunkSizes[0];
-        if (!siteDom) {
+        if (!SW_Domain->isSimDomDiscrete) {
             startRead[1] = (numChunkReads % numChunkInXAxis) * chunkSizes[1];
         }
 
@@ -3160,7 +3162,8 @@ static void alloc_dom_coord_info(
 coordinate variable/dimension names
 @param[in] siteName User-provided site dimension/variable "site" name
 @param[in] domFileID Domain file identifier
-@param[in] domType Type of domain - "s" or "xy"
+@param[in] isSimDomDiscrete Is simulation domain discrete (site-based)?
+    Otherwise, the simulation domain is gridded.
 @param[in] primCRSIsGeo Specifies if the current CRS type is geographic
 @param[out] LogInfo Holds information dealing with logfile output
 */
@@ -3169,7 +3172,7 @@ static void read_domain_coordinates(
     char *domCoordVarNames[],
     char *siteName,
     int domFileID,
-    char *domType,
+    Bool isSimDomDiscrete,
     Bool primCRSIsGeo,
     LOG_INFO *LogInfo
 ) {
@@ -3177,7 +3180,6 @@ static void read_domain_coordinates(
     int varID;
     const int numReadInDims = (primCRSIsGeo) ? 2 : 4;
     const int numDims = 2;
-    Bool siteDom = (Bool) (strcmp("s", domType) == 0);
     Bool allocArrays[] = {swFALSE, swFALSE, swFALSE, swFALSE};
     Bool validY;
     int numDimsInVar = 0;
@@ -3206,7 +3208,7 @@ static void read_domain_coordinates(
 
     /* Determine the dimension lengths from the currect dimension
        names matching site/xy and geographical/projected */
-    if (siteDom) {
+    if (isSimDomDiscrete) {
         domCoordNames[0] = siteName;
         domCoordNames[1] = siteName;
     } else {
@@ -4391,7 +4393,8 @@ created
 @param[in] nDims Number of dimensions for each coordinate variable
 @param[in] deflateLevel Level of deflation that will be used for the created
 variable
-@param[in] inDomIsSite Specifies if the input file has sites or is gridded
+@param[in] isInDomDiscrete Is input domain discrete (site-based)?
+    Otherwise, the input domain is gridded.
 @param[in] numAtts Number of attributes to give to each index variable(s)
 @param[in] key Current input key these variables/file is meant for
 @param[in] indexFileName Name of the newly created index file
@@ -4409,7 +4412,7 @@ static void create_index_vars(
     int templateID,
     int nDims,
     int deflateLevel,
-    Bool inDomIsSite,
+    Bool isInDomDiscrete,
     int numAtts,
     int key,
     char *indexFileName,
@@ -4468,7 +4471,7 @@ static void create_index_vars(
             return;
         }
 
-        if (inDomIsSite) {
+        if (isInDomDiscrete) {
             indexVarAttVals[0][0] = (char *) "site-position of %s";
         } else {
             indexVarAttVals[0][0] = (char *) "y-position of %s";
@@ -4535,9 +4538,10 @@ domain knows to the closest spatial point that the input file(s) provide
 @param[in] xDomSize Latitude/y domain dimension size
 @param[in] yCoords Latitude/y coordinates read-in from the user-provided file
 @param[in] xCoords Longitude/x coordinates read-in from the user-provided file
-@param[in] inIsGridded Specifies that the provided input file is gridded
-@param[in] siteDom Specifies that the programs domain has sites, otherwise
-it is gridded
+@param[in] isInDomDiscrete Is input domain discrete (site-based)?
+    Otherwise, the input domain is gridded.
+@param[in] isSimDomDiscrete Is simulation domain discrete (site-based)?
+    Otherwise, the simulation domain is gridded.
 @param[in] inPrimCRSIsGeo Specifies if the CRS in the provided input file is
 geographical or projected
 @param[in] indexVarIDs Identifiers of the created variable(s) in the new
@@ -4563,8 +4567,8 @@ static void write_indices(
     size_t xDomSize,
     double *yCoords,
     double *xCoords,
-    Bool inIsGridded,
-    Bool siteDom,
+    Bool isInDomDiscrete,
+    Bool isSimDomDiscrete,
     Bool inPrimCRSIsGeo,
     int indexVarIDs[],
     int templateID,
@@ -4594,7 +4598,7 @@ static void write_indices(
         xCoords,
         *(inFileDimSizes[0]),
         *(inFileDimSizes[1]),
-        inIsGridded,
+        isInDomDiscrete,
         has2DCoordVars,
         inPrimCRSIsGeo,
         yxConvs,
@@ -4604,7 +4608,7 @@ static void write_indices(
         goto freeTree;
     }
 
-    writeCount[1] = (inIsGridded) ? 1 : 0;
+    writeCount[1] = (isInDomDiscrete) ? 0 : 1;
 
     for (yIndex = 0UL; yIndex < yDomSize; yIndex++) {
         queryCoords[0] = domYCoords[yIndex];
@@ -4619,7 +4623,7 @@ static void write_indices(
             bestDist = DBL_MAX;
             nearNeighbor = NULL;
 
-            if (siteDom) {
+            if (isSimDomDiscrete) {
                 queryCoords[0] = domYCoords[xIndex];
                 xWritePos[0] = syWritePos[0] = xIndex;
             } else {
@@ -4650,7 +4654,7 @@ static void write_indices(
                     goto freeTree;
                 }
 
-                if (inIsGridded) {
+                if (!isInDomDiscrete) {
                     SW_NC_write_vals(
                         &indexVarIDs[1],
                         templateID,
@@ -4679,7 +4683,7 @@ static void write_indices(
                 goto freeTree;
             }
 
-            if (siteDom && !inIsGridded) {
+            if (isSimDomDiscrete && isInDomDiscrete) {
                 if (!EQ_w_tol(
                         nearNeighbor->coords[0], queryCoords[0], spatialTol
                     ) ||
@@ -4701,7 +4705,7 @@ static void write_indices(
             }
         }
 
-        if (siteDom) {
+        if (isSimDomDiscrete) {
             goto freeTree;
         }
     }
@@ -4719,7 +4723,8 @@ in the programs domain and the input file domain(s)
 @param[in] templateID Identifier of the newly created index file
 @param[in] domYName Name of the programs domain latitude/y axis/variable
 @param[in] domXName Name of the programs domain longitude/x axis/variable
-@param[in] inHasSite Specifies if the input file has sites or is gridded
+@param[in] isInDomDiscrete Is input domain discrete (site-based)?
+    Otherwise, the input domain is gridded.
 @param[out] nDims Number of dimensions for each coordinate variable
 @param[out] dimIDs Identifier of the coordinate dimensions
 @param[out] indexVarNames A list of all index variable names that are to be
@@ -4734,7 +4739,7 @@ static void get_index_vars_info(
     char *domYName,
     char *domXName,
     int dimIDs[][2],
-    Bool inHasSite,
+    Bool isInDomDiscrete,
     char *siteName,
     char *indexVarNames[],
     char *domName,
@@ -4745,7 +4750,7 @@ static void get_index_vars_info(
     char *varNames[] = {domYName, domXName};
     char *varName;
 
-    if (inHasSite && !SW_NC_dimExists(siteName, inFileID)) {
+    if (isInDomDiscrete && !SW_NC_dimExists(siteName, inFileID)) {
         LogError(
             LogInfo,
             LOGERROR,
@@ -4755,12 +4760,13 @@ static void get_index_vars_info(
         );
     }
 
-    indexVarNames[0] = (inHasSite) ? (char *) "site_index" : (char *) "y_index";
-    indexVarNames[1] = (inHasSite) ? (char *) "" : (char *) "x_index";
-    *numVars = (inHasSite) ? 1 : 2;
+    indexVarNames[0] =
+        (isInDomDiscrete) ? (char *) "site_index" : (char *) "y_index";
+    indexVarNames[1] = (isInDomDiscrete) ? (char *) "" : (char *) "x_index";
+    *numVars = (isInDomDiscrete) ? 1 : 2;
 
     for (varNum = 0; varNum < *numVars; varNum++) {
-        varName = (inHasSite) ? varNames[varNum] : domName;
+        varName = (isInDomDiscrete) ? varNames[varNum] : domName;
 
         SW_NC_get_vardimids(
             templateID, -1, varName, dimIDs[varNum], nDims, LogInfo
@@ -5000,17 +5006,16 @@ when dealing with an index file
 @param[in] useIndexFile Flag specifying if the current input key
 must use the respective index file
 @param[in] indexFileID Identifier of the index file
-@param[in] inSiteDom Flag specifying if the input variable has a domain
-of sites or is gridded
-@param[in] ncSUID Current simulation unit identifier for which is used
-to get data from netCDF
+@param[in] isInDomDiscrete Is input domain discrete (site-based)?
+    Otherwise, the input domain is gridded.
+@param[in] ncSUID Simulation unit identifier for which to read data from netCDFs
 @param[out] start Start indices to figure out and write to
 @param[out] LogInfo Holds information on warnings and errors
 */
 static void get_read_start(
     Bool useIndexFile,
     const int indexFileID,
-    Bool inSiteDom,
+    Bool isInDomDiscrete,
     const size_t ncSUID[],
     size_t start[],
     LOG_INFO *LogInfo
@@ -5018,13 +5023,13 @@ static void get_read_start(
     char *indexVarNames[] = {NULL, NULL};
     int varNum;
     int indexVarID;
-    int numIndexVars = (inSiteDom) ? 1 : 2;
+    int numIndexVars = (isInDomDiscrete) ? 1 : 2;
 
     /* Get the closest site from the index file if needed */
     if (useIndexFile) {
         indexVarNames[0] =
-            (inSiteDom) ? (char *) "site_index" : (char *) "y_index";
-        indexVarNames[1] = (inSiteDom) ? (char *) "" : (char *) "x_index";
+            (isInDomDiscrete) ? (char *) "site_index" : (char *) "y_index";
+        indexVarNames[1] = (isInDomDiscrete) ? (char *) "" : (char *) "x_index";
 
         for (varNum = 0; varNum < numIndexVars; varNum++) {
             indexVarID = -1;
@@ -5033,7 +5038,7 @@ static void get_read_start(
                 indexFileID,
                 &indexVarID,
                 indexVarNames[varNum],
-                (inSiteDom) ? &ncSUID[0] : ncSUID,
+                (isInDomDiscrete) ? &ncSUID[0] : ncSUID,
                 &start[varNum],
                 LogInfo
             );
@@ -5283,7 +5288,7 @@ static void read_spatial_topo_climate_site_inputs(
     char ***inVarInfo;
     Bool *readInput;
     Bool useIndexFile;
-    Bool sDom;
+    Bool isInDomDiscrete;
 
     size_t count[] = {0, 0, 0};
     size_t start[] = {0, 0, 0};
@@ -5311,7 +5316,6 @@ static void read_spatial_topo_climate_site_inputs(
     int timeIndex;
     size_t defSetStart[2] = {0};
     size_t defSetCount[2] = {1, 1};
-    Bool *sDoms = SW_Domain->netCDFInput.siteDoms;
 #if !defined(SWMPI)
     const int indexFile = 0;
     const int firstFile = 0;
@@ -5357,7 +5361,7 @@ static void read_spatial_topo_climate_site_inputs(
         start[0] = start[1] = start[2] = 0;
         count[0] = count[1] = count[2] = 0;
 
-        sDom = sDoms[currKey];
+        isInDomDiscrete = SW_Domain->netCDFInput.isInDomDiscrete[currKey];
 #if !defined(SWMPI)
         useIndexFile = SW_Domain->netCDFInput.useIndexFile[currKey];
         indexID =
@@ -5366,7 +5370,7 @@ static void read_spatial_topo_climate_site_inputs(
         /* Get the start indices based on if we need to use the respective
            index file */
         get_read_start(
-            useIndexFile, indexID, sDom, ncSUID, defSetStart, LogInfo
+            useIndexFile, indexID, isInDomDiscrete, ncSUID, defSetStart, LogInfo
         );
         if (LogInfo->stopRun) {
             return;
@@ -5513,7 +5517,8 @@ static void read_spatial_topo_climate_site_inputs(
                         values[keyNum][varNum - 1]
                     );
 
-                    if (varNum == eiv_longitude && !twoDLat && !sDom) {
+                    if (varNum == eiv_longitude && !twoDLat &&
+                        !isInDomDiscrete) {
                         *(values[0][eiv_latitude - 1]) =
                             inputs[inputOrigin].ModelRunIn.latitude;
                     }
@@ -5540,7 +5545,6 @@ static void read_spatial_topo_climate_site_inputs(
 #else
     (void) ncSUID;
     (void) useIndexFile;
-    (void) sDom;
 #endif
 }
 
@@ -6089,7 +6093,7 @@ static void get_invar_information(
             if (inKey == eSW_InDomain) {
                 inVarInfo = SW_netCDFIn->inVarInfo[eSW_InDomain];
 
-                SW_netCDFIn->siteDoms[eSW_InDomain] =
+                SW_netCDFIn->isInDomDiscrete[eSW_InDomain] =
                     (Bool) (strcmp(inVarInfo[0][INDOMTYPE], "s") == 0);
             }
             continue;
@@ -6110,7 +6114,7 @@ static void get_invar_information(
 
         // Store flags if each input key has a site domain so this
         // information is not calculated repeatedly
-        SW_netCDFIn->siteDoms[inKey] =
+        SW_netCDFIn->isInDomDiscrete[inKey] =
             (Bool) (strcmp(inVarInfo[startVar][INDOMTYPE], "s") == 0);
 
         SW_NCIN_alloc_sim_var_information(
@@ -6404,7 +6408,7 @@ static void read_veg_inputs(
     size_t input = 0;
     size_t inputOrigin = 0;
     size_t stride = 1;
-    Bool sDom = SW_Domain->netCDFInput.siteDoms[eSW_InVeg];
+    Bool isInDomDiscrete = SW_Domain->netCDFInput.isInDomDiscrete[eSW_InVeg];
     const int firstFile = 0;
 
 #if !defined(SWMPI)
@@ -6421,7 +6425,9 @@ static void read_veg_inputs(
 #if !defined(SWMPI)
     /* Get the start indices based on if we need to use the respective
         index file */
-    get_read_start(useIndexFile, indexID, sDom, ncSUID, defSetStart, LogInfo);
+    get_read_start(
+        useIndexFile, indexID, isInDomDiscrete, ncSUID, defSetStart, LogInfo
+    );
     if (LogInfo->stopRun) {
         return;
     }
@@ -6495,7 +6501,7 @@ static void read_veg_inputs(
                 count[lonIndex] = defSetCount[1];
             }
 
-            numSites = (sDom) ? count[latIndex] : count[lonIndex];
+            numSites = (isInDomDiscrete) ? count[latIndex] : count[lonIndex];
 
             /* vegetation variables have time axis except cover */
             varHasNotTime =
@@ -6916,7 +6922,7 @@ static void read_soil_inputs(
     size_t start[4] = {0}; /* Maximum of four dimensions */
     size_t count[4] = {0}; /* Maximum of four dimensions */
     Bool hasPFT;
-    Bool inSiteDom = SW_Domain->netCDFInput.siteDoms[eSW_InSoil];
+    Bool isInDomDiscrete = SW_Domain->netCDFInput.isInDomDiscrete[eSW_InSoil];
     Bool isSwrcpVar;
     int numVarsInSoilKey = numVarsInKey[eSW_InSoil];
     char *varName;
@@ -6960,7 +6966,7 @@ static void read_soil_inputs(
 
 #if !defined(SWMPI)
     get_read_start(
-        useIndexFile, indexID, inSiteDom, ncSUID, defSetStart, mainLogInfo
+        useIndexFile, indexID, isInDomDiscrete, ncSUID, defSetStart, mainLogInfo
     );
     if (mainLogInfo->stopRun) {
         return;
@@ -6985,7 +6991,7 @@ static void read_soil_inputs(
         defSetCount[0] = counts[read][0];
         defSetCount[1] = counts[read][1];
 
-        numSites = (inSiteDom) ? defSetCount[0] : defSetCount[1];
+        numSites = (isInDomDiscrete) ? defSetCount[0] : defSetCount[1];
 #endif
 
         for (varNum = fIndex; varNum < numVarsInSoilKey; varNum++) {
@@ -7707,7 +7713,7 @@ void SW_NCIN_create_progress(SW_DOMAIN *SW_Domain, LOG_INFO *LogInfo) {
             }
 
             SW_NC_create_template(
-                SW_Domain->DomainType,
+                SW_Domain->isSimDomDiscrete,
                 domFileName,
                 progFileName,
                 progFileID,
@@ -7722,7 +7728,7 @@ void SW_NCIN_create_progress(SW_DOMAIN *SW_Domain, LOG_INFO *LogInfo) {
         }
         SW_NC_create_full_var(
             progFileID,
-            SW_Domain->DomainType,
+            SW_Domain->isSimDomDiscrete,
             NC_BYTE,
             0,
             0,
@@ -7975,7 +7981,7 @@ void SW_NCIN_create_domain_template(
         return; // Exit prematurely due to error
     }
 
-    if (strcmp(SW_Domain->DomainType, "s") == 0) {
+    if (SW_Domain->isSimDomDiscrete) {
         nDomainDims = 1;
 
         // Create s dimension/domain variables
@@ -8044,7 +8050,7 @@ void SW_NCIN_create_domain_template(
 
     fill_netCDF_with_invariants(
         &SW_Domain->OutDom.netCDFOutput,
-        SW_Domain->DomainType,
+        SW_Domain->isSimDomDiscrete,
         domFileID,
         swTRUE,
         LogInfo
@@ -8151,7 +8157,8 @@ static void read_weather_input(
     TimeInt numDays;
     TimeInt yearIndex;
     TimeInt year;
-    Bool inSiteDom = SW_Domain->netCDFInput.siteDoms[eSW_InWeather];
+    Bool isInDomDiscrete =
+        SW_Domain->netCDFInput.isInDomDiscrete[eSW_InWeather];
     int fIndex = 1;
     int varID = -1;
     int ncFileID = -1;
@@ -8205,7 +8212,7 @@ static void read_weather_input(
 
 #if !defined(SWMPI)
     get_read_start(
-        useIndexFile, indexID, inSiteDom, ncSUID, defSetStart, mainLogInfo
+        useIndexFile, indexID, isInDomDiscrete, ncSUID, defSetStart, mainLogInfo
     );
     if (mainLogInfo->stopRun) {
         return;
@@ -8278,7 +8285,8 @@ static void read_weather_input(
                 }
 
                 ncFileID = weathFileIDs[varNum][weathFileIndex];
-                numSites = (inSiteDom) ? count[latIndex] : count[lonIndex];
+                numSites =
+                    (isInDomDiscrete) ? count[latIndex] : count[lonIndex];
 
                 if (read >= numReads) {
                     if (read == numReads) {
@@ -8927,7 +8935,7 @@ void SW_NCIN_init_ptrs(SW_NETCDF_IN *SW_netCDFIn) {
             SW_netCDFIn->projCoordConvs[k][coordNum] = NULL;
         }
 
-        SW_netCDFIn->siteDoms[k] = swFALSE;
+        SW_netCDFIn->isInDomDiscrete[k] = swFALSE;
     }
 
     SW_netCDFIn->weathCalOverride = NULL;
@@ -9920,7 +9928,7 @@ void SW_NCIN_precalc_lookups(
             domCoordVarNamesNonSite,
             SW_Domain->OutDom.netCDFOutput.siteName,
             domFileID,
-            SW_Domain->DomainType,
+            SW_Domain->isSimDomDiscrete,
             primCRSIsGeo,
             LogInfo
         );
@@ -10011,8 +10019,7 @@ void SW_NCIN_create_indices(SW_DOMAIN *SW_Domain, LOG_INFO *LogInfo) {
     char *indexName = NULL;
     char *fileName;
     int dimIDs[2][2] = {{0}}; /* Up to two dims for two variables */
-    Bool inHasSite = swFALSE;
-    Bool siteDom = (Bool) (strcmp(SW_Domain->DomainType, "s") == 0);
+    Bool isInDomDiscrete = swFALSE;
     char *domYName = SW_Domain->OutDom.netCDFOutput.geo_YAxisName;
     char *domXName = SW_Domain->OutDom.netCDFOutput.geo_XAxisName;
     char *indexVarNames[2] = {NULL, NULL};
@@ -10117,7 +10124,7 @@ void SW_NCIN_create_indices(SW_DOMAIN *SW_Domain, LOG_INFO *LogInfo) {
                 }
 
                 SW_NC_create_template(
-                    SW_Domain->DomainType,
+                    SW_Domain->isSimDomDiscrete,
                     domFile,
                     indexName,
                     &templateID,
@@ -10130,7 +10137,7 @@ void SW_NCIN_create_indices(SW_DOMAIN *SW_Domain, LOG_INFO *LogInfo) {
                     return; /* Exit function prematurely due to error */
                 }
 
-                inHasSite =
+                isInDomDiscrete =
                     (Bool) (strcmp(varInfo[fIndex][INDOMTYPE], "s") == 0);
 
                 get_index_vars_info(
@@ -10140,7 +10147,7 @@ void SW_NCIN_create_indices(SW_DOMAIN *SW_Domain, LOG_INFO *LogInfo) {
                     domYName,
                     domXName,
                     dimIDs,
-                    inHasSite,
+                    isInDomDiscrete,
                     varInfo[fIndex][INSITENAME],
                     indexVarNames,
                     domVarName,
@@ -10159,7 +10166,7 @@ void SW_NCIN_create_indices(SW_DOMAIN *SW_Domain, LOG_INFO *LogInfo) {
                     templateID,
                     indexVarNDims,
                     SW_Domain->OutDom.netCDFOutput.deflateLevel,
-                    inHasSite,
+                    isInDomDiscrete,
                     numAtts,
                     k,
                     indexName,
@@ -10204,8 +10211,8 @@ void SW_NCIN_create_indices(SW_DOMAIN *SW_Domain, LOG_INFO *LogInfo) {
                     domXSize,
                     inputYVals,
                     inputXVals,
-                    (Bool) !inHasSite,
-                    siteDom,
+                    isInDomDiscrete,
+                    SW_Domain->isSimDomDiscrete,
                     inPrimCRSIsGeo,
                     varIDs,
                     templateID,

--- a/src/SW_netCDF_Input.c
+++ b/src/SW_netCDF_Input.c
@@ -8495,7 +8495,7 @@ be returned with any site-specific errors/warnings
 void SW_NCIN_read_inputs(
     SW_RUN *sw,
     SW_DOMAIN *SW_Domain,
-    const size_t ncSUIDs[][2],
+    size_t ncSUIDs[][2],
     size_t starts[][N_SUID_ASSIGN][2],
     size_t counts[][N_SUID_ASSIGN][2],
     int **openNCFileIDs[],

--- a/src/SW_netCDF_Output.c
+++ b/src/SW_netCDF_Output.c
@@ -2677,7 +2677,7 @@ void SW_NCOUT_write_output(
     double *p_OUT[][SW_OUTNPERIODS],
     unsigned int numFilesPerKey,
     char **ncOutFileNames[][SW_OUTNPERIODS],
-    const size_t ncSUIDs[][2],
+    size_t ncSUIDs[][2],
     size_t numWritesGroup,
     size_t numWritesProc,
     size_t starts[][2],

--- a/src/SW_netCDF_Output.c
+++ b/src/SW_netCDF_Output.c
@@ -889,7 +889,8 @@ static void store_time_sizes(
 /**
 @brief Collect the write dimensions/sizes for the current output slice
 
-@param[in] sDom Specifies the program's domain is site-oriented
+@param[in] isSimDomDiscrete Is simulation domain discrete (site-based)?
+    Otherwise, the simulation domain is gridded.
 @param[in] timeSize Number of time steps in current output slice
 @param[in] nsl Number of soil layers
 @param[in] npft Number of plant functional types
@@ -897,7 +898,7 @@ static void store_time_sizes(
 @param[out] countTotal Total size (count) of output values
  */
 static void get_vardim_write_counts(
-    Bool sDom,
+    Bool isSimDomDiscrete,
     size_t timeSize,
     IntUS nsl,
     IntUS npft,
@@ -907,7 +908,7 @@ static void get_vardim_write_counts(
 ) {
     int dimIndex;
     int ndimsp;
-    int nSpaceDims = (sDom) ? 1 : 2;
+    int nSpaceDims = (isSimDomDiscrete) ? 1 : 2;
 
     /* Fill 1s into space dimensions (we write one site/xy-gridcell per run) */
     /* We assume here that the first dimension(s) are space */
@@ -1145,8 +1146,8 @@ is represented by
 @param[in] OutDom Struct of type SW_OUT_DOM that holds output
     information that do not change throughout simulation runs
 @param[in] domFile Domain netCDF file name
-@param[in] domType Type of domain in which simulations are running
-    (gridcell/sites)
+@param[in] isSimDomDiscrete Is simulation domain discrete (site-based)?
+    Otherwise, the simulation domain is gridded.
 @param[in] newFileName Name of the new file that will be created
 @param[in] key Specifies what output key is currently being allocated
     (i.e., temperature, precipitation, etc.)
@@ -1178,7 +1179,7 @@ variable
 static void create_output_file(
     SW_OUT_DOM *OutDom,
     const char *domFile,
-    const char *domType,
+    Bool isSimDomDiscrete,
     const char *newFileName,
     OutKey key,
     OutPeriod pd,
@@ -1231,7 +1232,7 @@ static void create_output_file(
     // Create a new output file - if this function is called,
     // it means it did not already exist
     SW_NC_create_template(
-        domType,
+        isSimDomDiscrete,
         domFile,
         newFileName,
         newFileID,
@@ -1260,7 +1261,7 @@ static void create_output_file(
 
             SW_NC_create_full_var(
                 newFileID,
-                domType,
+                isSimDomDiscrete,
                 NC_DOUBLE,
                 originTimeSize,
                 nsl[index],
@@ -2219,8 +2220,8 @@ is represented by
 
 @param[in] rank Process number known to MPI for the current process (aka rank)
 @param[in] domFile Name of the domain netCDF
-@param[in] domType Type of domain in which simulations are running
-    (gridcell/sites)
+@param[in] isSimDomDiscrete Is simulation domain discrete (site-based)?
+    Otherwise, the simulation domain is gridded.
 @param[in] outputPrefix Directory path of output files.
 @param[in] SW_Domain Struct of type SW_DOMAIN holding constant
     temporal/spatial information for a set of simulation runs
@@ -2247,7 +2248,7 @@ holds basic information about output files and values
 void SW_NCOUT_create_output_files(
     int rank,
     const char *domFile,
-    const char *domType,
+    Bool isSimDomDiscrete,
     const char *outputPrefix,
     SW_DOMAIN *SW_Domain,
     OutPeriod timeSteps[][SW_OUTNPERIODS],
@@ -2446,7 +2447,7 @@ void SW_NCOUT_create_output_files(
                                 create_output_file(
                                     &SW_Domain->OutDom,
                                     domFile,
-                                    domType,
+                                    isSimDomDiscrete,
                                     fileNameBuf,
                                     (OutKey) key,
                                     pd,
@@ -2661,7 +2662,8 @@ output netCDF files
     only used if SWMPI is enabled, otherwise is NULL
 @param[in] outVarIDs A list of size SW_OUTNKEYS holding lists of
     output variable IDs
-@param[in] siteDom Specifies if the domain is site-oriented
+@param[in] isSimDomDiscrete Is simulation domain discrete (site-based)?
+    Otherwise, the simulation domain is gridded.
 @param[in] succFlags A list of success flags for a single or multiple
     site's (swTRUE = success, swFALSE = failure); only used with
     SWMPI enabled
@@ -2681,7 +2683,7 @@ void SW_NCOUT_write_output(
     size_t counts[][2],
     int *openOutFileIDs[][SW_OUTNPERIODS],
     int *outVarIDs[],
-    Bool siteDom,
+    Bool isSimDomDiscrete,
     const Bool succFlags[],
     size_t *timeSizes[],
     LOG_INFO *LogInfo
@@ -2778,15 +2780,15 @@ void SW_NCOUT_write_output(
                         start[1] = ncSuid[1];
 #endif
 
-                        numSites =
-                            (siteDom) ? counts[write][0] : counts[write][1];
+                        numSites = (isSimDomDiscrete) ? counts[write][0] :
+                                                        counts[write][1];
                         ptrOffset = oneSiteOffset * numSiteSum;
 
                         // Locate correct slice in netCDF to write to
                         varID = outVarIDs[key][varNum];
 
                         get_vardim_write_counts(
-                            siteDom,
+                            isSimDomDiscrete,
                             timeSize,
                             OutDom->nsl_OUT[key][varNum],
                             OutDom->npft_OUT[key][varNum],

--- a/src/SW_netCDF_Output.c
+++ b/src/SW_netCDF_Output.c
@@ -2642,7 +2642,8 @@ output netCDF files
 @param[in] numFilesPerKey Number of output netCDFs each output key will
     have (same amount for each key)
 @param[in] ncOutFileNames A list of the generated output netCDF file names
-@param[in] ncSuid Unique indentifier of the current suid being simulated
+@param[in] ncSUIDs An array of \ref N_SUID_ASSIGN with
+    simulation unit identifier(s)
 @param[in] numWritesGroup The number of writes across all processes
     that must be performed by the calling function to output all simulated
     information for the sites (MPI only)
@@ -2676,7 +2677,7 @@ void SW_NCOUT_write_output(
     double *p_OUT[][SW_OUTNPERIODS],
     unsigned int numFilesPerKey,
     char **ncOutFileNames[][SW_OUTNPERIODS],
-    const size_t ncSuid[],
+    const size_t ncSUIDs[][2],
     size_t numWritesGroup,
     size_t numWritesProc,
     size_t starts[][2],
@@ -2776,8 +2777,8 @@ void SW_NCOUT_write_output(
                         start[0] = starts[write][0];
                         start[1] = starts[write][1];
 #else
-                        start[0] = ncSuid[0];
-                        start[1] = ncSuid[1];
+                        start[0] = ncSUIDs[0][0];
+                        start[1] = ncSUIDs[0][1];
 #endif
 
                         numSites = (isSimDomDiscrete) ? counts[write][0] :
@@ -2946,7 +2947,7 @@ void SW_NCOUT_write_output(
     }
 
 #if defined(SWMPI)
-    (void) ncSuid;
+    (void) ncSUIDs;
     (void) ncOutFileNames;
 #else
     (void) starts;

--- a/src/SW_netCDF_Output.c
+++ b/src/SW_netCDF_Output.c
@@ -2677,7 +2677,7 @@ void SW_NCOUT_write_output(
     double *p_OUT[][SW_OUTNPERIODS],
     unsigned int numFilesPerKey,
     char **ncOutFileNames[][SW_OUTNPERIODS],
-    size_t ncSUIDs[][2],
+    const size_t ncSUIDs[][2],
     size_t numWritesGroup,
     size_t numWritesProc,
     size_t starts[][2],

--- a/src/filefuncs.c
+++ b/src/filefuncs.c
@@ -367,10 +367,11 @@ The suid is formatted to `suid [X]` for site-based domains and
 @param[out] buffer Prefix for log message
 @param[in] sizeBuffer Size of \p buffer
 @param[in] ncSuid Unique indentifier of the current simulation unit
-@param[in] sDom Is simulation domain site based?
+@param[in] isSimDomDiscrete Is simulation domain discrete (site-based)?
+    Otherwise, the simulation domain is gridded.
 */
 void formatLogSUID(
-    char *buffer, size_t sizeBuffer, size_t ncSuid[], Bool sDom
+    char *buffer, size_t sizeBuffer, size_t ncSuid[], Bool isSimDomDiscrete
 ) {
     int expectedWriteSize;
 
@@ -378,7 +379,7 @@ void formatLogSUID(
         buffer[0] = '\0';
 
     } else {
-        if (sDom) {
+        if (isSimDomDiscrete) {
             expectedWriteSize =
                 snprintf(buffer, sizeBuffer, "suid [%zu]", ncSuid[0] + 1);
         } else {

--- a/src/filefuncs.c
+++ b/src/filefuncs.c
@@ -180,6 +180,81 @@ closeDir: { closedir(dir); }
 
 // NOLINTEND(misc-no-recursion)
 
+
+/**
+@brief Format simulation unit identifier as prefix for log messages
+
+The suid is formatted to `suid [X]` for site-based domains and
+`suid [X, Y]` for gridded domains (with base1 X, Y).
+
+@param[in,out] LogInfo Holds information on warnings and errors
+*/
+static void formatLogSUID(LOG_INFO *LogInfo) {
+    int expectedWriteSize;
+    size_t sizeBuffer = sizeof LogInfo->logSUID;
+
+    if (LogInfo->isSimDomDiscrete) {
+        expectedWriteSize = snprintf(
+            LogInfo->logSUID, sizeBuffer, "suid [%zu]", LogInfo->ncSUID[0] + 1
+        );
+    } else {
+        expectedWriteSize = snprintf(
+            LogInfo->logSUID,
+            sizeBuffer,
+            "suid [%zu, %zu]",
+            LogInfo->ncSUID[1] + 1,
+            LogInfo->ncSUID[0] + 1
+        );
+    }
+
+#ifdef SWDEBUG
+    if (expectedWriteSize < 0 || (size_t) expectedWriteSize >= sizeBuffer) {
+#if defined(RSOILWAT)
+        Rf_error("Programmer: message prefix for suid failed.");
+#else
+        (void) fprintf(stderr, "Programmer: message prefix for suid failed.");
+#endif
+        exit(EXIT_FAILURE);
+    }
+#else
+    (void) expectedWriteSize;
+#endif
+}
+
+/**
+@brief Format simulation date as prefix for log messages
+
+The date is formatted as `YYYY-DDD` where
+`YYYY` is the calendar year and `DDD` is day of year (1-366).
+
+@param[in,out] LogInfo Holds information on warnings and errors
+*/
+static void formatLogDate(LOG_INFO *LogInfo) {
+    int expectedWriteSize;
+    size_t sizeBuffer = sizeof LogInfo->logDate;
+
+    expectedWriteSize = snprintf(
+        LogInfo->logDate,
+        sizeBuffer,
+        "%4d-%03d",
+        LogInfo->logYear,
+        LogInfo->logDOY
+    );
+
+#ifdef SWDEBUG
+    if (expectedWriteSize < 0 || (size_t) expectedWriteSize >= sizeBuffer) {
+#if defined(RSOILWAT)
+        Rf_error("Programmer: message prefix for date failed.");
+#else
+        (void) fprintf(stderr, "Programmer: message prefix for date failed.");
+#endif
+        exit(EXIT_FAILURE);
+    }
+#else
+    (void) expectedWriteSize;
+#endif
+}
+
 /**
 @brief Compose, store and count warning and error messages
 
@@ -229,7 +304,8 @@ static void LogErrorHelper(
         countFullBuffer += fullBuffer ? 1 : 0;
     }
 
-    if (strlen(LogInfo->logSUID) > 0) {
+    if (LogInfo->hasLogSUID) {
+        formatLogSUID(LogInfo);
         expectedWriteSize = snprintf(buf, sizeof buf, "; %s", LogInfo->logSUID);
         fullBuffer = sw_memccpy_inc(
             (void **) &writePtr, writeEndPtr, (void *) buf, '\0', &writeSize
@@ -238,7 +314,8 @@ static void LogErrorHelper(
             (fullBuffer || expectedWriteSize >= MAX_LOG_SIZE) ? 1 : 0;
     }
 
-    if (strlen(LogInfo->logDate) > 0) {
+    if (LogInfo->hasLogDate) {
+        formatLogDate(LogInfo);
         expectedWriteSize = snprintf(buf, sizeof buf, "; %s", LogInfo->logDate);
         fullBuffer = sw_memccpy_inc(
             (void **) &writePtr, writeEndPtr, (void *) buf, '\0', &writeSize
@@ -358,85 +435,27 @@ void LogError(LOG_INFO *LogInfo, const int mode, const char *fmt, ...) {
     va_end(args);
 }
 
-/**
-@brief Format simulation unit identifier as prefix for log messages
+/** Set simulation unit identifier for log messages
 
-The suid is formatted to `suid [X]` for site-based domains and
-`suid [X, Y]` for gridded domains (with base1 X, Y).
-
-@param[out] buffer Prefix for log message
-@param[in] sizeBuffer Size of \p buffer
-@param[in] ncSuid Unique indentifier of the current simulation unit
-@param[in] isSimDomDiscrete Is simulation domain discrete (site-based)?
-    Otherwise, the simulation domain is gridded.
+@param[out] LogInfo Holds information on warnings and errors
+@param[in] ncSUID Unique indentifier of the current simulation unit
 */
-void formatLogSUID(
-    char *buffer, size_t sizeBuffer, size_t ncSuid[], Bool isSimDomDiscrete
-) {
-    int expectedWriteSize;
-
-    if (isnull(ncSuid)) {
-        buffer[0] = '\0';
-
-    } else {
-        if (isSimDomDiscrete) {
-            expectedWriteSize =
-                snprintf(buffer, sizeBuffer, "suid [%zu]", ncSuid[0] + 1);
-        } else {
-            expectedWriteSize = snprintf(
-                buffer,
-                sizeBuffer,
-                "suid [%zu, %zu]",
-                ncSuid[1] + 1,
-                ncSuid[0] + 1
-            );
-        }
-
-#ifdef SWDEBUG
-        if (expectedWriteSize < 0 || (size_t) expectedWriteSize >= sizeBuffer) {
-#if defined(RSOILWAT)
-            Rf_error("Programmer: message prefix for suid failed.");
-#else
-            (void
-            ) fprintf(stderr, "Programmer: message prefix for suid failed.");
-#endif
-            exit(EXIT_FAILURE);
-        }
-#else
-        (void) expectedWriteSize;
-#endif
-    }
+void updateLogSUID(LOG_INFO *LogInfo, const size_t ncSUID[]) {
+    LogInfo->ncSUID[0] = ncSUID[0];
+    LogInfo->ncSUID[1] = ncSUID[1];
+    LogInfo->hasLogSUID = swTRUE;
 }
 
-/**
-@brief Format simulation date as prefix for log messages
+/** Set date for log messages
 
-The date is formatted as `YYYY-DDD` where
-`YYYY` is the calendar year and `DDD` is day of year (1-366).
-
-@param[out] buffer Prefix for log message
-@param[in] sizeBuffer Size of \p buffer
+@param[out] LogInfo Holds information on warnings and errors
 @param[in] year Calendar year
 @param[in] doy Day of year (base1)
 */
-void formatLogDate(
-    char *buffer, size_t sizeBuffer, unsigned int year, unsigned int doy
-) {
-    int expectedWriteSize;
-    expectedWriteSize = snprintf(buffer, sizeBuffer, "%4d-%03d", year, doy);
-
-#ifdef SWDEBUG
-    if (expectedWriteSize < 0 || (size_t) expectedWriteSize >= sizeBuffer) {
-#if defined(RSOILWAT)
-        Rf_error("Programmer: message prefix for date failed.");
-#else
-        (void) fprintf(stderr, "Programmer: message prefix for date failed.");
-#endif
-        exit(EXIT_FAILURE);
-    }
-#else
-    (void) expectedWriteSize;
-#endif
+void updateLogDate(LOG_INFO *LogInfo, unsigned int year, unsigned int doy) {
+    LogInfo->logYear = year;
+    LogInfo->logDOY = doy;
+    LogInfo->hasLogDate = swTRUE;
 }
 
 /**


### PR DESCRIPTION
Fix informative messages for all modes

- Addressing issue #509 "Consistent identifying information for all warning and error messages"

- The first attempt at issue #509 (commit 15ae9d7e3e5d08b6a26055349d428ee476c96c19, PR #510) failed to provide messages with SUID information during inputs in SWMPI mode
- Inputs in all modes now provide full information to messages

Additional updates
- Informative message prefixes are no longer constructed for each new SUID and each new day -- instead, LOG_INFO now stores relevant information and formats message prefixes only when a message is created
- Harmonize identification of discrete and gridded domain types: replace char "domainType" with logical "isSimDomDiscrete" and "isInDomDiscrete"
