### PR TITLE
Feature CF compliance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -61,6 +61,8 @@
     * correctly reading latitude of all grid cells -- including when
       mean monthly windspeed is read from nc-inputs (#516).
 
+* Improve compliance of `"netCDF"` output with `CF` 1.10 (#520; @dschlaep).
+
 ## Changes to inputs
 * New input via `"siteparam.in"` to select the input option for potential
   evaporation coefficients: either provided as inputs by `"soils.in"` or
@@ -81,6 +83,10 @@
   years, i.e., time periods that are not affected by a delayed simulation start
   (after January 1 of the first year) or an early simulation end
   (before December 31 of the last year).
+* New variable `"pft_labels"` for `"netCDF"` output now provides vegetation
+  type names along the `"pft"` dimension; this replaces the
+  variable `"pft"` which previously provided vegetation type names via
+  attributes `"flag_meaning"` and `"flag_values"`.
 
 
 # SOILWAT2 v8.3.0

--- a/src/SW_netCDF_General.c
+++ b/src/SW_netCDF_General.c
@@ -1200,11 +1200,13 @@ void SW_NC_create_full_var(
     }
 
     for (index = 0; index < numAtts; index++) {
-        SW_NC_write_string_att(
-            attNames[index], attVals[index], varID, *ncFileID, LogInfo
-        );
-        if (LogInfo->stopRun) {
-            return; // Exit function prematurely due to error
+        if (attVals[index] != NULL && strlen(attVals[index]) > 0) {
+            SW_NC_write_string_att(
+                attNames[index], attVals[index], varID, *ncFileID, LogInfo
+            );
+            if (LogInfo->stopRun) {
+                return; // Exit function prematurely due to error
+            }
         }
     }
 

--- a/src/SW_netCDF_General.c
+++ b/src/SW_netCDF_General.c
@@ -1079,8 +1079,9 @@ void SW_NC_create_full_var(
     unsigned int numConstDims = (isSimDomDiscrete) ? 1 : 2;
     const char *thirdDim = (isSimDomDiscrete) ? siteName : yName;
     const char *constDimNames[] = {thirdDim, xName};
-    const char *timeVertVegNames[] = {"time", "vertical", "pft"};
-    char *dimVarName;
+    const char *timeVertVegDimNames[] = {"time", "vertical", "pft"};
+    const char *timeVertVegVarNames[] = {"time", "vertical", "pft_label"};
+    char *dimName;
     size_t timeVertVegVals[] = {timeSize, vertSize, pftSize};
     unsigned int numTimeVertVegVals = 3;
     size_t varVal = 0;
@@ -1107,12 +1108,12 @@ void SW_NC_create_full_var(
     }
 
     for (index = 0; index < numTimeVertVegVals; index++) {
-        dimVarName = (char *) timeVertVegNames[index];
+        dimName = (char *) timeVertVegDimNames[index];
         varVal = timeVertVegVals[index];
         if (varVal > 0) {
-            if (!SW_NC_dimExists(dimVarName, *ncFileID)) {
+            if (!SW_NC_dimExists(dimName, *ncFileID)) {
                 SW_NCOUT_create_output_dimVar(
-                    dimVarName,
+                    dimName,
                     varVal,
                     *ncFileID,
                     &dimIDs[dimArrSize],
@@ -1129,13 +1130,14 @@ void SW_NC_create_full_var(
                 );
             } else {
                 SW_NC_get_dim_identifier(
-                    *ncFileID, dimVarName, &dimIDs[dimArrSize], LogInfo
+                    *ncFileID, dimName, &dimIDs[dimArrSize], LogInfo
                 );
             }
             if (LogInfo->stopRun) {
                 return; // Exit function prematurely due to error
             }
 
+            /* Update coordinates attribute */
             fullBuffer = sw_memccpy_inc(
                 (void **) &writePtr, endWritePtr, (void *) " ", '\0', &writeSize
             );
@@ -1146,7 +1148,7 @@ void SW_NC_create_full_var(
             fullBuffer = sw_memccpy_inc(
                 (void **) &writePtr,
                 endWritePtr,
-                (void *) timeVertVegNames[index],
+                (void *) timeVertVegVarNames[index],
                 '\0',
                 &writeSize
             );

--- a/src/SW_netCDF_Output.c
+++ b/src/SW_netCDF_Output.c
@@ -42,6 +42,9 @@
 
 #define MAX_ATTVAL_SIZE 256
 
+/** Maximum number of characters in a PFT name */
+#define MAX_PFT_NAME_LENGTH 8
+
 // Indices to second dimension of `outputVarInfo[varIndex][attIndex]`
 #define DIM_INDEX 0 // unused
 #define VARNAME_INDEX 1
@@ -362,21 +365,41 @@ static unsigned int calc_timeSize(
 }
 
 /**
-@brief Write values to the pft variable
+@brief Write pft labels (SOILWAT2 vegetation types)
 
 @param[in] ncFileID Identifier of the open netCDF file to write the attribute
 @param[in] varID Variable identifier within the given netCDF
 @param[out] LogInfo Holds information on warnings and errors
 */
-static void write_pft_vals(int ncFileID, int varID, LOG_INFO *LogInfo) {
-    unsigned char vals[NVEGTYPES] = {0};
-    for (int k = 0; k < NVEGTYPES; k++) {
-        vals[k] = (unsigned char) (k + 1);
+static void write_pft_labels(int ncFileID, int varID, LOG_INFO *LogInfo) {
+    size_t start[] = {0, 0};
+    size_t count[] = {NVEGTYPES, MAX_PFT_NAME_LENGTH};
+
+    char *pftLabels = (char *) Mem_Calloc(
+        (size_t) (NVEGTYPES * MAX_PFT_NAME_LENGTH),
+        sizeof(char),
+        "write_pft_labels",
+        LogInfo
+    );
+    if (LogInfo->stopRun) {
+        return; // Exit function prematurely due to error
     }
 
-    if (nc_put_var_ubyte(ncFileID, varID, &vals[0]) != NC_NOERR) {
-        LogError(LogInfo, LOGERROR, "Could not write pft values.");
+    for (int k = 0; k < NVEGTYPES; k++) {
+        (void) snprintf(
+            &pftLabels[(size_t) (k * MAX_PFT_NAME_LENGTH)],
+            MAX_PFT_NAME_LENGTH,
+            "%s",
+            key2veg[k]
+        );
     }
+
+    if (nc_put_vara_text(ncFileID, varID, start, count, pftLabels) !=
+        NC_NOERR) {
+        LogError(LogInfo, LOGERROR, "Could not write pft labels.");
+    }
+
+    free(pftLabels);
 }
 
 /**
@@ -746,7 +769,7 @@ static void fill_dimVar(
     const int numBnds = 2;
 
     if (dimNum == pftInd) {
-        write_pft_vals(ncFileID, varID, LogInfo);
+        write_pft_labels(ncFileID, varID, LogInfo);
     } else {
         if (!SW_NC_dimExists("bnds", ncFileID)) {
             SW_NC_create_netCDF_dim(
@@ -1384,15 +1407,15 @@ static void create_output_file(
 /* --------------------------------------------------- */
 
 /**
-@brief Create a "time", "vertical", or "pft" dimension variable and the
-respective "*_bnds" variables (plus "bnds" dimension)
-and fill the variable with the respective information
+@brief Create a "time", "vertical", or "pft" dimension,
+associated variable and the respective "*_bnds" variables
+(plus "bnds" dimension) and fill the variable with the respective information
 
 @param[in] name Name of the new dimension
 @param[in] size Size of the new dimension
 @param[in] ncFileID Identifier of the netCDF in which the information
     will be written
-@param[in,out] dimID New dimenion identifier within the given netCDF
+@param[in,out] dimID New dimension identifier within the given netCDF
 @param[in] hasConsistentSoilLayerDepths Flag indicating if all simulation
     run within domain have identical soil layer depths
     (though potentially variable number of soil layers)
@@ -1427,7 +1450,9 @@ void SW_NCOUT_create_output_dimVar(
 ) {
 
     char *dimNames[3] = {(char *) "vertical", (char *) "time", (char *) "pft"};
-    signed char pftFlagVals[NVEGTYPES] = {0};
+    char *dimVarNames[3] = {
+        (char *) "vertical", (char *) "time", (char *) "pft_label"
+    };
     const int vertIndex = 0;
     const int timeIndex = 1;
     const int pftIndex = 2;
@@ -1439,35 +1464,31 @@ void SW_NCOUT_create_output_dimVar(
     int varType;
     double tempVal = 1.0;
     double *startFillTime;
-    const int numDims = 1;
+    int numDims = 1;
 
     const char *outAttNames[][6] = {
         {"long_name", "standard_name", "units", "positive", "axis", "bounds"},
         {"long_name", "standard_name", "units", "axis", "calendar", "bounds"},
-        {"standard_name", "flag_meanings"}
+        {"standard_name"}
     };
 
     char outAttVals[][6][MAX_FILENAMESIZE] = {
         {"soil depth", "depth", "centimeter", "down", "Z", "vertical_bnds"},
         {"time", "time", "", "T", "standard", "time_bnds"},
-        {"biological_taxon_name"}
+        {"SOILWAT2 vegetation type"}
     };
-    outAttVals[pftIndex][1][0] = '\0';
+
     char *soilWritePtr = outAttVals[vertIndex][0];
     char *centiWritePtr = outAttVals[vertIndex][2];
-    char *pftWritePtr = outAttVals[pftIndex][1];
     char *endSoilDepthPtr =
         outAttVals[vertIndex][0] + sizeof outAttVals[vertIndex][0] - 1;
     char *endCentiPtr =
         outAttVals[vertIndex][2] + sizeof outAttVals[vertIndex][2] - 1;
-    char *pftEndPtr =
-        outAttVals[pftIndex][1] + sizeof outAttVals[pftIndex][1] - 1;
     size_t soilDepthSize = MAX_FILENAMESIZE - strlen(outAttVals[vertIndex][0]);
     size_t centiSize = MAX_FILENAMESIZE - strlen(outAttVals[vertIndex][2]);
-    size_t pftWriteSize = MAX_FILENAMESIZE - strlen(outAttVals[pftIndex][1]);
     Bool fullBuffer = swFALSE;
 
-    const int numVarAtts[] = {6, 6, 2};
+    const int numVarAtts[] = {6, 6, 1};
 
     for (dimNum = 0; dimNum < 3; dimNum++) {
         if (Str_CompareI(dimNames[dimNum], name) == 0) {
@@ -1485,21 +1506,39 @@ void SW_NCOUT_create_output_dimVar(
         return; // Exit function prematurely due to error
     }
 
-    varType = (dimNum == pftIndex) ? NC_BYTE : NC_DOUBLE;
+    varType = (dimNum == pftIndex) ? NC_CHAR : NC_DOUBLE;
 
     startFillTime = (dimNum == timeIndex) ? startTime : &tempVal;
 
-    SW_NC_create_netCDF_dim(name, size, &ncFileID, dimID, LogInfo);
+    /* Create the dimension and get its identifier */
+    SW_NC_create_netCDF_dim(
+        dimNames[dimNum], size, &ncFileID, &dimIDs[0], LogInfo
+    );
+    *dimID = dimIDs[0];
     if (LogInfo->stopRun) {
         return; // Exit function prematurely due to error
     }
 
-    if (!SW_NC_varExists(ncFileID, name)) {
-        dimIDs[0] = *dimID;
+    if (dimNum == pftIndex) {
+        /* Create extra dimension for character length of PFT labels */
+        numDims = 2;
+        SW_NC_create_netCDF_dim(
+            "pft_label_nchar",
+            MAX_PFT_NAME_LENGTH,
+            &ncFileID,
+            &dimIDs[1],
+            LogInfo
+        );
+        if (LogInfo->stopRun) {
+            return; // Exit function prematurely due to error
+        }
+    }
 
+    /* Create the dimension variable and fill it with values */
+    if (!SW_NC_varExists(ncFileID, dimVarNames[dimNum])) {
         SW_NC_create_netCDF_var(
             &varID,
-            name,
+            dimVarNames[dimNum],
             dimIDs,
             &ncFileID,
             varType,
@@ -1564,49 +1603,6 @@ void SW_NCOUT_create_output_dimVar(
             );
             if (fullBuffer) {
                 goto reportFullBuffer;
-            }
-        } else if (dimNum == pftIndex) {
-            for (index = 0; index < NVEGTYPES; index++) {
-                pftFlagVals[index] = (signed char) (index + 1);
-            }
-
-            SW_NC_write_att(
-                "flag_values",
-                (void *) pftFlagVals,
-                varID,
-                ncFileID,
-                NVEGTYPES,
-                NC_BYTE,
-                LogInfo
-            );
-            if (LogInfo->stopRun) {
-                return;
-            }
-
-            // Create string for flag_meanings of PFTs
-            for (index = 0; index < NVEGTYPES; index++) {
-                fullBuffer = sw_memccpy_inc(
-                    (void **) &pftWritePtr,
-                    pftEndPtr,
-                    (void *) key2veg[index],
-                    '\0',
-                    &pftWriteSize
-                );
-                if (fullBuffer) {
-                    goto reportFullBuffer;
-                }
-                if (index < NVEGTYPES - 1) {
-                    fullBuffer = sw_memccpy_inc(
-                        (void **) &pftWritePtr,
-                        pftEndPtr,
-                        (void *) " ",
-                        '\0',
-                        &pftWriteSize
-                    );
-                    if (fullBuffer) {
-                        goto reportFullBuffer;
-                    }
-                }
             }
         }
 

--- a/tools/complianceChecker.sh
+++ b/tools/complianceChecker.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+#------ . ------
+usage="
+Check netCDF files for CF compliance using the IOOS compliance checker
+
+Usage: tools/complianceChecker.sh [OPTIONS]
+
+Options:
+    -c, --cf              Version of the CF convention (default is '1.10').
+    --cf=<...>
+
+    -d, --directory       Path to directory with netCDF file(s) to check
+    --directory=<...>     (default is 'tests/example/Output').
+
+    -i, --input           Full file path and name to a netCDF file to check;
+    --input=<...>         overwrites the --directory option (no default).
+
+    -r, --report          Name of the report output (or '-' for stdout)
+    --report=<...>        (default is '-').
+
+    -f, --format          Output format of the report (default is 'text'),
+    --format=<...>        possible values {text,html,json,json_new}.
+
+    --skipChecks          Skip a check (default ''), e.g.,
+    --skipChecks=<...>    check_dimension_order.
+
+    -h, --help            Display this help page.
+
+Examples:
+    tools/complianceChecker.sh
+    tools/complianceChecker.sh -f text
+    tools/complianceChecker.sh -r complianceCheckerReport
+    tools/complianceChecker.sh -d tests/example/Output
+    tools/complianceChecker.sh -i tests/example/Output/AET_1980-1999_day.nc
+    tools/complianceChecker.sh --skipChecks check_dimension_order
+
+Note: See the help page of the compliance-checker for additional information \
+including implemented CF versions and report formats.
+
+Note: This script expects that the compliance-checker \
+(https://github.com/ioos/compliance-checker) is available on PATH or \
+that it is installed in a conda environment named 'ioos'.
+"
+#------ . ------
+
+
+#------ Default values ------
+ncFileInput=""
+pathNCOutputs="tests/example/Output"
+reportName="-"
+reportFormat="text"
+cf="1.10"
+skipChecks=""
+
+
+#------ Command line arguments ------
+while [ $# -gt 0 ]; do
+    case $1 in
+        --cf=*) cf="${1#*=}" ;;
+        -c|--cf) cf="$2"; shift ;;
+
+        --directory=*) pathNCOutputs="${1#*=}" ;;
+        -d|--directory) pathNCOutputs="$2"; shift ;;
+
+        --input=*) ncFileInput="${1#*=}" ;;
+        -i|--input) ncFileInput="$2"; shift ;;
+
+        --report=*) reportName="${1#*=}" ;;
+        -r|--report) reportName="$2"; shift ;;
+
+        --format=*) reportFormat="${1#*=}" ;;
+        -f|--format) reportFormat="$2"; shift ;;
+
+        --skipChecks=*) skipChecks="${1#*=}" ;;
+        --skipChecks) skipChecks="$2"; shift ;;
+
+        -h|--help) echo "$usage"; exit 0 ;;
+
+        *) echo "Option \"$1\" is not implemented."; exit 1 ;;
+    esac
+    shift
+done
+
+
+case "${reportFormat}" in
+    text) outputFormat="txt" ;;
+    html) outputFormat="html" ;;
+    json|json_new) outputFormat="json" ;;
+    *) outputFormat="${reportFormat}"
+esac
+
+if [ "${reportName}" = "-" ]; then
+    outputReport="-"    # stdout
+    reportFormat="text"
+else
+    outputReport="${reportName}.${outputFormat}"
+fi
+
+
+#------ Locate netCDF file(s) ------
+
+if [ -n "${ncFileInput}" ]; then
+    if [ ! -f "${ncFileInput}" ]; then
+        echo "'${ncFileInput}' does not exist."
+        exit 1
+    fi
+    ncFileNames=("${ncFileInput}")
+else
+    ncFileNames=("${pathNCOutputs}/"*".nc")   # Array with full paths
+fi
+
+
+if [ "${#ncFileNames[@]}" -eq 0 ]; then
+    echo "No netCDF files found at '${pathNCOutputs}'"
+    exit 1
+fi
+
+
+#------ Run the checker ------
+loadCONDA=false
+
+if ! command -v compliance-checker > /dev/null 2>&1 ; then
+    loadCONDA=true
+    source activate
+    conda activate ioos
+fi
+
+compliance-checker \
+    --test=cf:"${cf}" \
+    --criteria strict \
+    --skip-checks "${skipChecks}" \
+    --format "${reportFormat}" \
+    --output "${outputReport}" \
+    "${ncFileNames[@]}"
+
+
+
+if [ "${loadCONDA}" = "true" ]; then
+    conda deactivate
+fi
+
+unset ncFileNames
+#------ . ------
+


### PR DESCRIPTION
Improve compliance of nc-output with CF 1.10 

- close #520

- New variable pft_labels for nc-output now provides vegetation type names along the pft dimension; this replaces the variable pft which previously provided vegetation type names via attributes flag_meaning and flag_values
- Variable attributes are only created if not empty
- New tools script to run the IOOS compliance-checker for CF on netCDF output files